### PR TITLE
feat(leaderboard): add heat ranking

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 allowBuilds:
-  '@parcel/watcher': set this to true or false
-  '@swc/core': set this to true or false
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false
+  '@parcel/watcher': true
+  '@swc/core': true
+  sharp: true
+  unrs-resolver: true
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { Leaderboard } from "@/components/Leaderboard";
+import type { LeaderboardView } from "@/components/LeaderboardClient";
+
+export const dynamic = "force-dynamic";
 
 const REMOVAL_ISSUE_URL =
   "https://github.com/hikariming/github-roast/issues/new?title=%E7%94%B3%E8%AF%B7%E4%B8%8B%E6%A6%9C&body=%E8%AF%B7%E5%A1%AB%E5%86%99%E4%BD%A0%E7%9A%84%20GitHub%20%E7%94%A8%E6%88%B7%E5%90%8D%EF%BC%9A";
@@ -21,27 +25,52 @@ export async function generateMetadata({
 
 export default async function LeaderboardPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ view?: string }>;
 }) {
   const { locale } = await params;
+  const query = await searchParams;
+  const view: LeaderboardView = query?.view === "heat" ? "heat" : "score";
+  await connection();
   setRequestLocale(locale);
   const t = await getTranslations("leaderboard");
 
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-5 py-14 sm:py-20">
-      <header className="mb-8 text-center">
-        <h1 className="text-3xl font-black tracking-tight sm:text-4xl">{t("heading")}</h1>
+      <header className="mb-8">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-4 sm:gap-6">
+            <Link
+              href="/leaderboard"
+              className={`shrink-0 text-3xl font-black tracking-tight sm:text-4xl ${
+                view === "score" ? "text-zinc-100" : "text-zinc-500 hover:text-zinc-200"
+              }`}
+            >
+              {t("heading")}
+            </Link>
+            <span className="h-14 w-1 shrink-0 rotate-12 rounded-full bg-[rgb(255,105,0)] sm:h-20" />
+            <Link
+              href="/leaderboard?view=heat"
+              className={`shrink-0 text-xl font-black sm:text-2xl ${
+                view === "heat" ? "text-zinc-100" : "text-zinc-500 hover:text-red-300"
+              }`}
+            >
+              {t("heatView")}
+            </Link>
+          </div>
+          <Link
+            href="/"
+            className="shrink-0 rounded-full bg-orange-600 px-4 py-2 text-xs font-medium text-white hover:bg-orange-500 sm:px-5 sm:text-sm"
+          >
+            {t("judgeCta")}
+          </Link>
+        </div>
         <p className="mt-2 text-zinc-400">{t("subtitle")}</p>
-        <Link
-          href="/"
-          className="mt-4 inline-block rounded-full bg-orange-600 px-5 py-2 text-sm font-medium text-white hover:bg-orange-500"
-        >
-          {t("judgeCta")}
-        </Link>
       </header>
 
-      <Leaderboard pageSize={20} />
+      <Leaderboard pageSize={20} initialView={view} />
 
       <footer className="mt-12 text-center text-xs leading-relaxed text-zinc-600">
         {t.rich("footerNote", {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,9 +1,12 @@
+import { connection } from "next/server";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { DeveloperCount } from "@/components/DeveloperCount";
-import { Leaderboard } from "@/components/Leaderboard";
+import { HomeLeaderboard } from "@/components/HomeLeaderboard";
 import { Roaster } from "@/components/Roaster";
 import type { TierKey } from "@/lib/tier";
+
+export const dynamic = "force-dynamic";
 
 // Tier pills: emoji + color are language-neutral; the label comes from i18n.
 const TIER_PILLS: { key: TierKey; emoji: string; cls: string }[] = [
@@ -16,6 +19,7 @@ const TIER_PILLS: { key: TierKey; emoji: string; cls: string }[] = [
 
 export default async function Home({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
+  await connection();
   setRequestLocale(locale);
   const t = await getTranslations("home");
   const tt = await getTranslations("tiers");
@@ -88,19 +92,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
 
       <Roaster />
 
-      {/* Embedded leaderboard (paginated) so the board is visible without leaving */}
-      <section className="mt-16 w-full max-w-2xl">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xl font-black">{t("boardHeading")}</h2>
-          <Link
-            href="/leaderboard"
-            className="text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
-          >
-            {t("openBoard")}
-          </Link>
-        </div>
-        <Leaderboard pageSize={10} />
-      </section>
+      <HomeLeaderboard pageSize={10} />
 
       <footer className="mt-20 max-w-xl text-center text-xs leading-relaxed text-zinc-600">
         <p>{t.rich("disclaimer1", { b: (c) => <strong>{c}</strong> })}</p>

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,6 +1,10 @@
-import { NextResponse } from "next/server";
-import { getLeaderboard, type LeaderboardEntry } from "@/lib/db";
-import { getCachedLeaderboard, setCachedLeaderboard } from "@/lib/redis";
+import { NextRequest, NextResponse } from "next/server";
+import { getHeatLeaderboard, getLeaderboard, type LeaderboardEntry } from "@/lib/db";
+import {
+  getCachedLeaderboard,
+  setCachedLeaderboard,
+  type LeaderboardCacheView,
+} from "@/lib/redis";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,19 +16,25 @@ const LIMIT = 500;
 // stale-while-revalidate keeps it instant while one background request refreshes.
 const CDN_CACHE = "public, s-maxage=120, stale-while-revalidate=600";
 
-export async function GET() {
-  const cached = await getCachedLeaderboard();
+function leaderboardView(req: NextRequest): LeaderboardCacheView {
+  return req.nextUrl.searchParams.get("view") === "heat" ? "heat" : "score";
+}
+
+export async function GET(req: NextRequest) {
+  const view = leaderboardView(req);
+  const cached = await getCachedLeaderboard(view);
   if (cached) {
     return NextResponse.json(
-      { entries: cached, cached: true },
+      { entries: cached, cached: true, view },
       { headers: { "Cache-Control": CDN_CACHE } },
     );
   }
 
-  const entries: LeaderboardEntry[] = await getLeaderboard(LIMIT);
-  await setCachedLeaderboard(entries);
+  const entries: LeaderboardEntry[] =
+    view === "heat" ? await getHeatLeaderboard(LIMIT) : await getLeaderboard(LIMIT);
+  await setCachedLeaderboard(entries, view);
   return NextResponse.json(
-    { entries, cached: false },
+    { entries, cached: false, view },
     { headers: { "Cache-Control": CDN_CACHE } },
   );
 }

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { recordAccountLookup } from "@/lib/db";
 import { AccountNotFoundError, GitHubRateLimitError, collect } from "@/lib/github";
-import { checkRateLimit, coalesceScan, getCachedScan } from "@/lib/redis";
+import {
+  checkRateLimit,
+  clearCachedLeaderboards,
+  coalesceScan,
+  getCachedScan,
+} from "@/lib/redis";
 import { score } from "@/lib/score";
 import { verifyTurnstile } from "@/lib/turnstile";
 import type { ScanResult } from "@/lib/types";
@@ -22,6 +28,11 @@ function normalizeUsername(input: string): string | null {
 function clientIp(req: NextRequest): string {
   const fwd = req.headers.get("x-forwarded-for");
   return fwd?.split(",")[0]?.trim() || "0.0.0.0";
+}
+
+async function recordSuccessfulLookup(username: string): Promise<void> {
+  await recordAccountLookup(username);
+  await clearCachedLeaderboards();
 }
 
 export async function POST(req: NextRequest) {
@@ -49,6 +60,7 @@ export async function POST(req: NextRequest) {
   // score), so the scan response stays purely the deterministic result.
   const cached = await getCachedScan(username);
   if (cached) {
+    await recordSuccessfulLookup(cached.metrics.username);
     return NextResponse.json({ ...cached, cached: true });
   }
 
@@ -63,6 +75,7 @@ export async function POST(req: NextRequest) {
       const scoring = score(metrics);
       return { metrics, top_repos, recent_prs, flood_pr_titles, scoring };
     });
+    await recordSuccessfulLookup(result.metrics.username);
     return NextResponse.json({ ...result, cached: false });
   } catch (e) {
     if (e instanceof AccountNotFoundError) {

--- a/src/components/HomeLeaderboard.tsx
+++ b/src/components/HomeLeaderboard.tsx
@@ -1,0 +1,39 @@
+import { getTranslations } from "next-intl/server";
+import { getHeatLeaderboard, getLeaderboard } from "@/lib/db";
+import { HomeLeaderboardClient, type HomeLeaderboardLabels } from "./HomeLeaderboardClient";
+import type { LeaderboardLabels } from "./LeaderboardClient";
+
+export async function HomeLeaderboard({ pageSize = 10 }: { pageSize?: number }) {
+  const tHome = await getTranslations("home");
+  const tBoard = await getTranslations("leaderboard");
+  const leaderboardLabels: LeaderboardLabels = {
+    empty: tBoard("empty"),
+    prev: tBoard("prev"),
+    next: tBoard("next"),
+    collapse: tBoard("collapse"),
+    viewDetail: tBoard("viewDetail", { username: "{username}" }),
+    heatLabel: tBoard("heatLabel"),
+    heatTitle: tBoard("heatTitle"),
+  };
+  const labels: HomeLeaderboardLabels = {
+    heading: tHome("boardHeading"),
+    openBoard: tHome("openBoard"),
+    scoreView: tBoard("scoreView"),
+    heatView: tBoard("heatView"),
+  };
+
+  const [scoreEntries, heatEntries] = await Promise.all([
+    getLeaderboard(500),
+    getHeatLeaderboard(500),
+  ]);
+
+  return (
+    <HomeLeaderboardClient
+      labels={labels}
+      leaderboardLabels={leaderboardLabels}
+      pageSize={pageSize}
+      scoreEntries={scoreEntries}
+      heatEntries={heatEntries}
+    />
+  );
+}

--- a/src/components/HomeLeaderboardClient.tsx
+++ b/src/components/HomeLeaderboardClient.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { Link } from "@/i18n/navigation";
+import {
+  LeaderboardClient,
+  type LeaderboardClientEntry,
+  type LeaderboardLabels,
+  type LeaderboardView,
+} from "./LeaderboardClient";
+
+export interface HomeLeaderboardLabels {
+  heading: string;
+  openBoard: string;
+  scoreView: string;
+  heatView: string;
+}
+
+export function HomeLeaderboardClient({
+  heatEntries,
+  labels,
+  leaderboardLabels,
+  pageSize,
+  scoreEntries,
+}: {
+  heatEntries: LeaderboardClientEntry[];
+  labels: HomeLeaderboardLabels;
+  leaderboardLabels: LeaderboardLabels;
+  pageSize: number;
+  scoreEntries: LeaderboardClientEntry[];
+}) {
+  const [view, setView] = useState<LeaderboardView>("score");
+  const fullBoardHref = view === "heat" ? "/leaderboard?view=heat" : "/leaderboard";
+
+  return (
+    <section className="mt-16 w-full max-w-2xl">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex min-w-0 items-center gap-4 sm:gap-6">
+          <button
+            type="button"
+            onClick={() => setView("score")}
+            className={`shrink-0 text-xl font-black ${
+              view === "score" ? "text-zinc-100" : "text-zinc-500 hover:text-zinc-200"
+            }`}
+            aria-pressed={view === "score"}
+          >
+            {labels.heading}
+          </button>
+          <span className="h-10 w-1 shrink-0 rotate-12 rounded-full bg-[rgb(255,105,0)] sm:h-12" />
+          <button
+            type="button"
+            onClick={() => setView("heat")}
+            className={`shrink-0 text-lg font-black sm:text-xl ${
+              view === "heat" ? "text-zinc-100" : "text-zinc-500 hover:text-red-300"
+            }`}
+            aria-pressed={view === "heat"}
+          >
+            {labels.heatView}
+          </button>
+        </div>
+        <Link
+          href={fullBoardHref}
+          className="ml-4 shrink-0 text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
+        >
+          {labels.openBoard}
+        </Link>
+      </div>
+      <LeaderboardClient
+        key={view}
+        initialView={view}
+        labels={leaderboardLabels}
+        pageSize={pageSize}
+        scoreEntries={scoreEntries}
+        heatEntries={heatEntries}
+      />
+    </section>
+  );
+}

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,184 +1,42 @@
-"use client";
+import { getTranslations } from "next-intl/server";
+import { getHeatLeaderboard, getLeaderboard } from "@/lib/db";
+import {
+  LeaderboardClient,
+  type LeaderboardLabels,
+  type LeaderboardView,
+} from "./LeaderboardClient";
 
-import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
-import { Link } from "@/i18n/navigation";
-import { tierStyle } from "@/lib/tier";
-import type { Tier } from "@/lib/types";
+export async function Leaderboard({
+  initialView = "score",
+  pageSize,
+}: {
+  initialView?: LeaderboardView;
+  pageSize?: number;
+}) {
+  const t = await getTranslations("leaderboard");
+  const labels: LeaderboardLabels = {
+    empty: t("empty"),
+    prev: t("prev"),
+    next: t("next"),
+    collapse: t("collapse"),
+    viewDetail: t("viewDetail", { username: "{username}" }),
+    heatLabel: t("heatLabel"),
+    heatTitle: t("heatTitle"),
+  };
 
-interface Entry {
-  username: string;
-  display_name: string | null;
-  avatar_url: string | null;
-  profile_url: string | null;
-  final_score: number;
-  tier: Tier;
-  tags?: { zh: string[]; en: string[] };
-}
-
-const RANK_BADGE = ["🥇", "🥈", "🥉"];
-
-/** Second-line tags: 3 zh + 3 en by default, expandable to show all. */
-function TagRow({ tags }: { tags?: { zh: string[]; en: string[] } }) {
-  const t = useTranslations("leaderboard");
-  const [expanded, setExpanded] = useState(false);
-  const zh = tags?.zh ?? [];
-  const en = tags?.en ?? [];
-  if (zh.length + en.length === 0) return null;
-
-  const zhShown = expanded ? zh : zh.slice(0, 3);
-  const enShown = expanded ? en : en.slice(0, 3);
-  const hidden = zh.length - zhShown.length + (en.length - enShown.length);
-
-  return (
-    <div className="mt-1 flex flex-wrap items-center gap-1">
-      {zhShown.map((t, i) => (
-        <span
-          key={`zh-${t}-${i}`}
-          className="rounded-full bg-orange-500/10 px-1.5 py-px text-[10px] text-orange-200/90"
-        >
-          #{t}
-        </span>
-      ))}
-      {enShown.map((t, i) => (
-        <span
-          key={`en-${t}-${i}`}
-          className="rounded-full bg-sky-500/10 px-1.5 py-px text-[10px] text-sky-200/90"
-        >
-          #{t}
-        </span>
-      ))}
-      {hidden > 0 && (
-        <button
-          onClick={() => setExpanded(true)}
-          className="rounded-full border border-white/10 px-1.5 py-px text-[10px] text-zinc-400 hover:bg-white/10"
-        >
-          +{hidden}
-        </button>
-      )}
-      {expanded && (
-        <button
-          onClick={() => setExpanded(false)}
-          className="rounded-full border border-white/10 px-1.5 py-px text-[10px] text-zinc-400 hover:bg-white/10"
-        >
-          {t("collapse")}
-        </button>
-      )}
-    </div>
-  );
-}
-
-export function Leaderboard({ pageSize }: { pageSize?: number }) {
-  const t = useTranslations("leaderboard");
-  const [entries, setEntries] = useState<Entry[] | null>(null);
-  const [error, setError] = useState(false);
-  const [page, setPage] = useState(0);
-
-  useEffect(() => {
-    let alive = true;
-    fetch("/api/leaderboard")
-      .then((r) => r.json())
-      .then((d) => {
-        if (alive) setEntries((d.entries as Entry[]) ?? []);
-      })
-      .catch(() => alive && setError(true));
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  if (error) {
-    return <p className="text-center text-zinc-500">{t("loadError")}</p>;
-  }
-  if (entries === null) {
-    return <p className="text-center text-zinc-500 animate-pulse">{t("loading")}</p>;
-  }
-  if (entries.length === 0) {
-    return <p className="text-center text-zinc-500">{t("empty")}</p>;
-  }
-
-  const totalPages = pageSize ? Math.max(1, Math.ceil(entries.length / pageSize)) : 1;
-  const current = Math.min(page, totalPages - 1);
-  const visible = pageSize ? entries.slice(current * pageSize, (current + 1) * pageSize) : entries;
-  const offset = pageSize ? current * pageSize : 0;
+  const [scoreEntries, heatEntries] = await Promise.all([
+    initialView === "score" ? getLeaderboard(500) : Promise.resolve([]),
+    initialView === "heat" ? getHeatLeaderboard(500) : Promise.resolve([]),
+  ]);
 
   return (
-    <>
-      <ol className="flex flex-col gap-2">
-        {visible.map((e, i) => {
-          const rank = offset + i;
-          const style = tierStyle(e.tier);
-          return (
-            <li
-              key={e.username}
-              className="group relative flex items-center gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 transition-colors hover:bg-white/[0.06]"
-            >
-              {/* Stretched link: whole row navigates to the detail page. Kept as a
-                  real <a> so cmd/ctrl-click opens a new tab. Tag expand buttons sit
-                  above it (z-10) so they still toggle instead of navigating. */}
-              <Link
-                href={`/u/${e.username}`}
-                prefetch={false}
-                aria-label={t("viewDetail", { username: e.username })}
-                className="absolute inset-0 z-0 rounded-xl"
-              />
-              <span className="w-8 shrink-0 text-center text-sm font-bold tabular-nums text-zinc-400">
-                {RANK_BADGE[rank] ?? rank + 1}
-              </span>
-            {e.avatar_url ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={e.avatar_url}
-                alt={e.username}
-                className="h-9 w-9 shrink-0 rounded-full"
-              />
-            ) : (
-              <div className="h-9 w-9 shrink-0 rounded-full bg-white/10" />
-            )}
-            <div className="min-w-0 flex-1">
-              <div className="truncate">
-                <span className="font-medium group-hover:underline">@{e.username}</span>
-                {e.display_name && (
-                  <span className="ml-1.5 text-sm text-zinc-500">{e.display_name}</span>
-                )}
-              </div>
-              {/* Above the stretched link so the +N / 收起 buttons toggle, not navigate. */}
-              <div className="relative z-10 w-fit">
-                <TagRow tags={e.tags} />
-              </div>
-            </div>
-            <span className={`shrink-0 text-xs font-medium ${style.text}`}>
-              {style.emoji} {e.tier}
-            </span>
-            <span className={`w-16 shrink-0 text-right text-lg font-black tabular-nums ${style.text}`}>
-              {e.final_score.toFixed(2)}
-            </span>
-          </li>
-          );
-        })}
-      </ol>
-
-      {pageSize && totalPages > 1 && (
-        <div className="mt-4 flex items-center justify-center gap-4 text-sm">
-          <button
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
-            disabled={current === 0}
-            className="rounded-lg border border-white/10 px-3 py-1.5 text-zinc-300 hover:bg-white/10 disabled:opacity-40"
-          >
-            {t("prev")}
-          </button>
-          <span className="tabular-nums text-zinc-500">
-            {current + 1} / {totalPages}
-          </span>
-          <button
-            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-            disabled={current >= totalPages - 1}
-            className="rounded-lg border border-white/10 px-3 py-1.5 text-zinc-300 hover:bg-white/10 disabled:opacity-40"
-          >
-            {t("next")}
-          </button>
-        </div>
-      )}
-    </>
+    <LeaderboardClient
+      key={initialView}
+      initialView={initialView}
+      labels={labels}
+      pageSize={pageSize}
+      scoreEntries={scoreEntries}
+      heatEntries={heatEntries}
+    />
   );
 }

--- a/src/components/LeaderboardClient.tsx
+++ b/src/components/LeaderboardClient.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState } from "react";
+import { Link } from "@/i18n/navigation";
+import { tierStyle } from "@/lib/tier";
+import type { Tier } from "@/lib/types";
+
+export interface LeaderboardClientEntry {
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  profile_url: string | null;
+  final_score: number;
+  tier: Tier;
+  tags?: { zh: string[]; en: string[] };
+  lookup_count: number;
+}
+
+export interface LeaderboardLabels {
+  empty: string;
+  prev: string;
+  next: string;
+  collapse: string;
+  viewDetail: string;
+  heatLabel: string;
+  heatTitle: string;
+}
+
+export type LeaderboardView = "score" | "heat";
+
+const RANK_BADGE = ["🥇", "🥈", "🥉"];
+
+/** Second-line tags: 3 zh + 3 en by default, expandable to show all. */
+function TagRow({
+  labels,
+  tags,
+}: {
+  labels: LeaderboardLabels;
+  tags?: { zh: string[]; en: string[] };
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const zh = tags?.zh ?? [];
+  const en = tags?.en ?? [];
+  if (zh.length + en.length === 0) return null;
+
+  const zhShown = expanded ? zh : zh.slice(0, 3);
+  const enShown = expanded ? en : en.slice(0, 3);
+  const hidden = zh.length - zhShown.length + (en.length - enShown.length);
+
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-1">
+      {zhShown.map((t, i) => (
+        <span
+          key={`zh-${t}-${i}`}
+          className="rounded-full bg-orange-500/10 px-1.5 py-px text-[10px] text-orange-200/90"
+        >
+          #{t}
+        </span>
+      ))}
+      {enShown.map((t, i) => (
+        <span
+          key={`en-${t}-${i}`}
+          className="rounded-full bg-sky-500/10 px-1.5 py-px text-[10px] text-sky-200/90"
+        >
+          #{t}
+        </span>
+      ))}
+      {hidden > 0 && (
+        <button
+          onClick={() => setExpanded(true)}
+          className="rounded-full border border-white/10 px-1.5 py-px text-[10px] text-zinc-400 hover:bg-white/10"
+        >
+          +{hidden}
+        </button>
+      )}
+      {expanded && (
+        <button
+          onClick={() => setExpanded(false)}
+          className="rounded-full border border-white/10 px-1.5 py-px text-[10px] text-zinc-400 hover:bg-white/10"
+        >
+          {labels.collapse}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function LeaderboardClient({
+  initialView,
+  labels,
+  pageSize,
+  scoreEntries,
+  heatEntries,
+}: {
+  initialView: LeaderboardView;
+  labels: LeaderboardLabels;
+  pageSize?: number;
+  scoreEntries: LeaderboardClientEntry[];
+  heatEntries: LeaderboardClientEntry[];
+}) {
+  const [page, setPage] = useState(0);
+  const entries = initialView === "heat" ? heatEntries : scoreEntries;
+
+  if (entries.length === 0) {
+    return <p className="text-center text-zinc-500">{labels.empty}</p>;
+  }
+
+  const totalPages = pageSize ? Math.max(1, Math.ceil(entries.length / pageSize)) : 1;
+  const current = Math.min(page, totalPages - 1);
+  const visible = pageSize ? entries.slice(current * pageSize, (current + 1) * pageSize) : entries;
+  const offset = pageSize ? current * pageSize : 0;
+
+  return (
+    <>
+      <ol className="flex flex-col gap-2">
+        {visible.map((e, i) => {
+          const rank = offset + i;
+          const style = tierStyle(e.tier);
+          const detailLabel = labels.viewDetail.replace("{username}", e.username);
+          const heatSelected = initialView === "heat";
+          return (
+            <li
+              key={e.username}
+              className="group relative flex items-center gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-3 transition-colors hover:bg-white/[0.06] sm:px-4"
+            >
+              {/* Stretched link: whole row navigates to the detail page. Kept as a
+                  real <a> so cmd/ctrl-click opens a new tab. Tag expand buttons sit
+                  above it (z-10) so they still toggle instead of navigating. */}
+              <Link
+                href={`/u/${e.username}`}
+                prefetch={false}
+                aria-label={detailLabel}
+                className="absolute inset-0 z-0 rounded-xl"
+              />
+              <span className="w-8 shrink-0 text-center text-sm font-bold tabular-nums text-zinc-400">
+                {RANK_BADGE[rank] ?? rank + 1}
+              </span>
+              {e.avatar_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={e.avatar_url}
+                  alt={e.username}
+                  className="h-9 w-9 shrink-0 rounded-full"
+                />
+              ) : (
+                <div className="h-9 w-9 shrink-0 rounded-full bg-white/10" />
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="truncate">
+                  <span className="font-medium group-hover:underline">@{e.username}</span>
+                  {e.display_name && (
+                    <span className="ml-1.5 text-sm text-zinc-500">{e.display_name}</span>
+                  )}
+                </div>
+                {/* Above the stretched link so the +N / collapse buttons toggle, not navigate. */}
+                <div className="relative z-10 w-fit">
+                  <TagRow labels={labels} tags={e.tags} />
+                </div>
+              </div>
+              {heatSelected ? (
+                <div className="grid w-28 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-3 gap-y-0.5 text-right sm:w-36">
+                  <div
+                    className="truncate text-left text-xs font-medium text-amber-300 sm:text-sm"
+                    title={labels.heatTitle}
+                  >
+                    🔥 {labels.heatLabel}
+                  </div>
+                  <div
+                    className="text-lg font-black tabular-nums text-amber-300"
+                    title={labels.heatTitle}
+                    aria-label={`${labels.heatLabel} ${e.lookup_count}`}
+                  >
+                    {e.lookup_count}
+                  </div>
+                  <div className={`truncate text-left text-[11px] font-medium ${style.text}`}>
+                    {style.emoji} {e.tier}
+                  </div>
+                  <div className={`text-sm font-black tabular-nums ${style.text}`}>
+                    {e.final_score.toFixed(2)}
+                  </div>
+                </div>
+              ) : (
+                <div className="grid w-28 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-3 gap-y-0.5 text-right sm:w-36">
+                  <div className={`truncate text-left text-xs font-medium sm:text-sm ${style.text}`}>
+                    {style.emoji} {e.tier}
+                  </div>
+                  <div className={`text-lg font-black tabular-nums ${style.text}`}>
+                    {e.final_score.toFixed(2)}
+                  </div>
+                  <div
+                    className="truncate text-left text-[11px] font-semibold text-amber-300"
+                    title={labels.heatTitle}
+                  >
+                    🔥 {labels.heatLabel}
+                  </div>
+                  <div
+                    className="text-sm font-black tabular-nums text-amber-300"
+                    title={labels.heatTitle}
+                    aria-label={`${labels.heatLabel} ${e.lookup_count}`}
+                  >
+                    {e.lookup_count}
+                  </div>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {pageSize && totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-center gap-4 text-sm">
+          <button
+            onClick={() => setPage(Math.max(0, current - 1))}
+            disabled={current === 0}
+            className="rounded-lg border border-white/10 px-3 py-1.5 text-zinc-300 hover:bg-white/10 disabled:opacity-40"
+          >
+            {labels.prev}
+          </button>
+          <span className="tabular-nums text-zinc-500">
+            {current + 1} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage(Math.min(totalPages - 1, current + 1))}
+            disabled={current >= totalPages - 1}
+            className="rounded-lg border border-white/10 px-3 py-1.5 text-zinc-300 hover:bg-white/10 disabled:opacity-40"
+          >
+            {labels.next}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/LeaderboardClient.tsx
+++ b/src/components/LeaderboardClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { Link } from "@/i18n/navigation";
-import { tierStyle } from "@/lib/tier";
+import { TIER_KEY, tierStyle } from "@/lib/tier";
 import type { Tier } from "@/lib/types";
 
 export interface LeaderboardClientEntry {
@@ -29,38 +30,44 @@ export interface LeaderboardLabels {
 export type LeaderboardView = "score" | "heat";
 
 const RANK_BADGE = ["🥇", "🥈", "🥉"];
+const TAG_TONE: Record<TagLocale, string> = {
+  zh: "bg-orange-500/10 text-orange-200/90",
+  en: "bg-sky-500/10 text-sky-200/90",
+};
 
-/** Second-line tags: 3 zh + 3 en by default, expandable to show all. */
+type TagLocale = "zh" | "en";
+
+function tagLocaleFor(locale: string): TagLocale {
+  return locale === "en" ? "en" : "zh";
+}
+
+/** Second-line tags: current locale first, with the other locale as fallback. */
 function TagRow({
   labels,
+  locale,
   tags,
 }: {
   labels: LeaderboardLabels;
+  locale: TagLocale;
   tags?: { zh: string[]; en: string[] };
 }) {
   const [expanded, setExpanded] = useState(false);
-  const zh = tags?.zh ?? [];
-  const en = tags?.en ?? [];
-  if (zh.length + en.length === 0) return null;
+  const fallbackLocale: TagLocale = locale === "en" ? "zh" : "en";
+  const primary = tags?.[locale] ?? [];
+  const fallback = tags?.[fallbackLocale] ?? [];
+  const visibleTags = primary.length > 0 ? primary : fallback;
+  const visibleLocale = primary.length > 0 ? locale : fallbackLocale;
+  if (visibleTags.length === 0) return null;
 
-  const zhShown = expanded ? zh : zh.slice(0, 3);
-  const enShown = expanded ? en : en.slice(0, 3);
-  const hidden = zh.length - zhShown.length + (en.length - enShown.length);
+  const shown = expanded ? visibleTags : visibleTags.slice(0, 3);
+  const hidden = visibleTags.length - shown.length;
 
   return (
     <div className="mt-1 flex flex-wrap items-center gap-1">
-      {zhShown.map((t, i) => (
+      {shown.map((t, i) => (
         <span
-          key={`zh-${t}-${i}`}
-          className="rounded-full bg-orange-500/10 px-1.5 py-px text-[10px] text-orange-200/90"
-        >
-          #{t}
-        </span>
-      ))}
-      {enShown.map((t, i) => (
-        <span
-          key={`en-${t}-${i}`}
-          className="rounded-full bg-sky-500/10 px-1.5 py-px text-[10px] text-sky-200/90"
+          key={`${visibleLocale}-${t}-${i}`}
+          className={`rounded-full px-1.5 py-px text-[10px] ${TAG_TONE[visibleLocale]}`}
         >
           #{t}
         </span>
@@ -98,8 +105,11 @@ export function LeaderboardClient({
   scoreEntries: LeaderboardClientEntry[];
   heatEntries: LeaderboardClientEntry[];
 }) {
+  const locale = useLocale();
+  const tTier = useTranslations("tiers");
   const [page, setPage] = useState(0);
   const entries = initialView === "heat" ? heatEntries : scoreEntries;
+  const tagLocale = tagLocaleFor(locale);
 
   if (entries.length === 0) {
     return <p className="text-center text-zinc-500">{labels.empty}</p>;
@@ -116,6 +126,7 @@ export function LeaderboardClient({
         {visible.map((e, i) => {
           const rank = offset + i;
           const style = tierStyle(e.tier);
+          const tierName = tTier(`${TIER_KEY[e.tier]}.name`);
           const detailLabel = labels.viewDetail.replace("{username}", e.username);
           const heatSelected = initialView === "heat";
           return (
@@ -154,7 +165,7 @@ export function LeaderboardClient({
                 </div>
                 {/* Above the stretched link so the +N / collapse buttons toggle, not navigate. */}
                 <div className="relative z-10 w-fit">
-                  <TagRow labels={labels} tags={e.tags} />
+                  <TagRow labels={labels} locale={tagLocale} tags={e.tags} />
                 </div>
               </div>
               {heatSelected ? (
@@ -173,7 +184,7 @@ export function LeaderboardClient({
                     {e.lookup_count}
                   </div>
                   <div className={`truncate text-left text-[11px] font-medium ${style.text}`}>
-                    {style.emoji} {e.tier}
+                    {style.emoji} {tierName}
                   </div>
                   <div className={`text-sm font-black tabular-nums ${style.text}`}>
                     {e.final_score.toFixed(2)}
@@ -182,7 +193,7 @@ export function LeaderboardClient({
               ) : (
                 <div className="grid w-28 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-baseline gap-x-3 gap-y-0.5 text-right sm:w-36">
                   <div className={`truncate text-left text-xs font-medium sm:text-sm ${style.text}`}>
-                    {style.emoji} {e.tier}
+                    {style.emoji} {tierName}
                   </div>
                   <div className={`text-lg font-black tabular-nums ${style.text}`}>
                     {e.final_score.toFixed(2)}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -86,6 +86,14 @@ function ensureSchema(db: Client): Promise<void> {
              scanned_at   INTEGER NOT NULL
            )`,
           `CREATE INDEX IF NOT EXISTS idx_scores_score ON scores(final_score DESC)`,
+          `CREATE TABLE IF NOT EXISTS account_stats (
+             username        TEXT PRIMARY KEY,
+             lookup_count    INTEGER NOT NULL DEFAULT 0,
+             first_lookup_at INTEGER NOT NULL,
+             last_lookup_at  INTEGER NOT NULL
+           )`,
+          `CREATE INDEX IF NOT EXISTS idx_account_stats_heat
+             ON account_stats(lookup_count DESC)`,
           // Logged-in users (GitHub OAuth). Identity only for now; the lowercased
           // `login` lets us later link a user to their own `scores` row + comments.
           `CREATE TABLE IF NOT EXISTS users (
@@ -146,6 +154,175 @@ export interface LeaderboardEntry {
   final_score: number;
   tier: Tier;
   tags: Tags;
+  lookup_count: number;
+}
+
+const PREVIEW_SUB_SCORES: SubScores = {
+  account_maturity: 10,
+  original_project_quality: 18,
+  contribution_quality: 26,
+  ecosystem_impact: 20,
+  community_influence: 8,
+  activity_authenticity: 17,
+};
+
+const PREVIEW_SCANNED_AT = 1_800_000_000_000;
+
+const PREVIEW_ACCOUNTS: AccountDetail[] = [
+  {
+    username: "demo-hot-legend",
+    display_name: "Preview Legend",
+    avatar_url: null,
+    profile_url: null,
+    final_score: 100,
+    tier: "夯",
+    tags: {
+      zh: ["开源狠人", "热度爆表", "满分选手"],
+      en: ["oss beast", "hot profile", "perfect score"],
+    },
+    sub_scores: PREVIEW_SUB_SCORES,
+    roast:
+      "## 本地预览数据\n\n这个账号是开发环境假数据，用来检查榜单热度布局。生产环境不会显示这些示例账号。",
+    roast_en:
+      "## Local preview data\n\nThis is development-only sample data for checking the leaderboard heat layout.",
+    scanned_at: PREVIEW_SCANNED_AT,
+  },
+  {
+    username: "demo-heat-runner",
+    display_name: "Preview Runner",
+    avatar_url: null,
+    profile_url: null,
+    final_score: 96.42,
+    tier: "夯",
+    tags: {
+      zh: ["高频被查", "框架老炮", "PR 稳定"],
+      en: ["frequent lookup", "framework veteran", "steady prs"],
+    },
+    sub_scores: {
+      ...PREVIEW_SUB_SCORES,
+      contribution_quality: 25,
+      activity_authenticity: 16,
+    },
+    roast:
+      "## 本地预览数据\n\n这个账号用于验证热度榜第二名和详情页跳转，不代表真实 GitHub 用户。",
+    roast_en:
+      "## Local preview data\n\nThis sample account validates the second heat rank and detail-page flow.",
+    scanned_at: PREVIEW_SCANNED_AT - 1,
+  },
+  {
+    username: "demo-score-smith",
+    display_name: "Preview Smith",
+    avatar_url: null,
+    profile_url: null,
+    final_score: 94.18,
+    tier: "顶级",
+    tags: {
+      zh: ["稳定输出", "工具匠人", "社区常客"],
+      en: ["steady output", "tool builder", "community regular"],
+    },
+    sub_scores: {
+      ...PREVIEW_SUB_SCORES,
+      ecosystem_impact: 18,
+      community_influence: 7,
+    },
+    roast:
+      "## 本地预览数据\n\n这个账号用于验证热度数字和评分数字在同一个右侧块里上下并列。",
+    roast_en:
+      "## Local preview data\n\nThis sample account validates the stacked score and heat block.",
+    scanned_at: PREVIEW_SCANNED_AT - 2,
+  },
+  {
+    username: "demo-fresh-star",
+    display_name: "Preview Fresh Star",
+    avatar_url: null,
+    profile_url: null,
+    final_score: 88.73,
+    tier: "人上人",
+    tags: {
+      zh: ["新晋热门", "项目很亮", "增长快"],
+      en: ["rising", "bright projects", "fast growth"],
+    },
+    sub_scores: {
+      ...PREVIEW_SUB_SCORES,
+      account_maturity: 7,
+      contribution_quality: 22,
+      ecosystem_impact: 15,
+    },
+    roast:
+      "## 本地预览数据\n\n这个账号用于拉开热度榜分页和排序差异。",
+    roast_en:
+      "## Local preview data\n\nThis sample account creates more variety in the heat ranking.",
+    scanned_at: PREVIEW_SCANNED_AT - 3,
+  },
+];
+
+const PREVIEW_HEAT: Record<string, number> = {
+  "demo-hot-legend": 58,
+  "demo-heat-runner": 612,
+  "demo-score-smith": 241,
+  "demo-fresh-star": 404,
+};
+
+function previewEnabled(): boolean {
+  return process.env.NODE_ENV !== "production" && process.env.GHROAST_PREVIEW_DATA !== "0";
+}
+
+function toLeaderboardEntry(account: AccountDetail): LeaderboardEntry {
+  return {
+    username: account.username,
+    display_name: account.display_name,
+    avatar_url: account.avatar_url,
+    profile_url: account.profile_url,
+    final_score: account.final_score,
+    tier: account.tier,
+    tags: account.tags,
+    lookup_count: PREVIEW_HEAT[account.username] ?? 0,
+  };
+}
+
+function previewLeaderboard(limit: number, minScore: number): LeaderboardEntry[] {
+  if (!previewEnabled()) return [];
+  return PREVIEW_ACCOUNTS.filter((account) => account.final_score >= minScore)
+    .map(toLeaderboardEntry)
+    .sort((a, b) => b.final_score - a.final_score || b.lookup_count - a.lookup_count)
+    .slice(0, limit);
+}
+
+function previewHeatLeaderboard(limit: number, minScore: number): LeaderboardEntry[] {
+  if (!previewEnabled()) return [];
+  return PREVIEW_ACCOUNTS.filter((account) => account.final_score >= minScore)
+    .map(toLeaderboardEntry)
+    .sort((a, b) => b.lookup_count - a.lookup_count || b.final_score - a.final_score)
+    .slice(0, limit);
+}
+
+function previewAccountDetail(username: string): AccountDetail | null {
+  if (!previewEnabled()) return null;
+  return (
+    PREVIEW_ACCOUNTS.find(
+      (account) => account.username.toLowerCase() === username.toLowerCase(),
+    ) ?? null
+  );
+}
+
+/** Count one successful public lookup for a GitHub account. */
+export async function recordAccountLookup(username: string): Promise<void> {
+  const db = getClient();
+  if (!db) return;
+  try {
+    await ensureSchema(db);
+    const now = Date.now();
+    await db.execute({
+      sql: `INSERT INTO account_stats (username, lookup_count, first_lookup_at, last_lookup_at)
+            VALUES (?, 1, ?, ?)
+            ON CONFLICT(username) DO UPDATE SET
+              lookup_count   = account_stats.lookup_count + 1,
+              last_lookup_at = excluded.last_lookup_at`,
+      args: [username.toLowerCase(), now, now],
+    });
+  } catch (e) {
+    console.error("recordAccountLookup failed:", e);
+  }
 }
 
 /** Upsert an account's latest score. Best-effort; never throws to the caller. */
@@ -213,7 +390,14 @@ export async function getPercentile(
   score: number,
 ): Promise<{ below: number; total: number } | null> {
   const db = getClient();
-  if (!db) return null;
+  if (!db) {
+    const preview = previewLeaderboard(Number.MAX_SAFE_INTEGER, 0);
+    if (preview.length === 0) return null;
+    return {
+      below: preview.filter((entry) => entry.final_score < score).length,
+      total: preview.length,
+    };
+  }
   try {
     await ensureSchema(db);
     const res = await db.execute({
@@ -223,8 +407,24 @@ export async function getPercentile(
       args: [score],
     });
     const row = res.rows[0];
-    if (!row) return null;
-    return { below: Number(row.below), total: Number(row.total) };
+    if (!row) {
+      const preview = previewLeaderboard(Number.MAX_SAFE_INTEGER, 0);
+      return preview.length
+        ? {
+            below: preview.filter((entry) => entry.final_score < score).length,
+            total: preview.length,
+          }
+        : null;
+    }
+    const counts = { below: Number(row.below), total: Number(row.total) };
+    if (counts.total > 0) return counts;
+    const preview = previewLeaderboard(Number.MAX_SAFE_INTEGER, 0);
+    return preview.length
+      ? {
+          below: preview.filter((entry) => entry.final_score < score).length,
+          total: preview.length,
+        }
+      : counts;
   } catch (e) {
     console.error("getPercentile failed:", e);
     return null;
@@ -234,11 +434,17 @@ export async function getPercentile(
 /** Total number of accounts ever evaluated (for the "N developers" counter). */
 export async function getScoreCount(): Promise<number | null> {
   const db = getClient();
-  if (!db) return null;
+  if (!db) {
+    const preview = previewLeaderboard(Number.MAX_SAFE_INTEGER, 0);
+    return preview.length ? preview.length : null;
+  }
   try {
     await ensureSchema(db);
     const res = await db.execute("SELECT COUNT(*) AS n FROM scores");
-    return Number(res.rows[0]?.n ?? 0);
+    const count = Number(res.rows[0]?.n ?? 0);
+    if (count > 0) return count;
+    const preview = previewLeaderboard(Number.MAX_SAFE_INTEGER, 0);
+    return preview.length ? preview.length : count;
   } catch (e) {
     console.error("getScoreCount failed:", e);
     return null;
@@ -251,18 +457,21 @@ export async function getLeaderboard(
   minScore = 60,
 ): Promise<LeaderboardEntry[]> {
   const db = getClient();
-  if (!db) return [];
+  if (!db) return previewLeaderboard(limit, minScore);
   try {
     await ensureSchema(db);
     const res = await db.execute({
-      sql: `SELECT username, display_name, avatar_url, profile_url, final_score, tier, tags
-            FROM scores
-            WHERE hidden = 0 AND final_score >= ?
-            ORDER BY final_score DESC, scanned_at DESC
+      sql: `SELECT s.username, s.display_name, s.avatar_url, s.profile_url,
+                   s.final_score, s.tier, s.tags,
+                   COALESCE(stats.lookup_count, 0) AS lookup_count
+            FROM scores AS s
+            LEFT JOIN account_stats AS stats ON stats.username = s.username
+            WHERE s.hidden = 0 AND s.final_score >= ?
+            ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
       args: [minScore, limit],
     });
-    return res.rows.map((r) => ({
+    const entries = res.rows.map((r) => ({
       username: String(r.username),
       display_name: r.display_name as string | null,
       avatar_url: r.avatar_url as string | null,
@@ -270,10 +479,49 @@ export async function getLeaderboard(
       final_score: Number(r.final_score),
       tier: String(r.tier) as Tier,
       tags: parseTags(r.tags),
+      lookup_count: Number(r.lookup_count) || 0,
     }));
+    return entries.length > 0 ? entries : previewLeaderboard(limit, minScore);
   } catch (e) {
     console.error("getLeaderboard failed:", e);
-    return [];
+    return previewLeaderboard(limit, minScore);
+  }
+}
+
+/** Public board sorted by successful lookup count, highest heat first. */
+export async function getHeatLeaderboard(
+  limit = 100,
+  minScore = 60,
+): Promise<LeaderboardEntry[]> {
+  const db = getClient();
+  if (!db) return previewHeatLeaderboard(limit, minScore);
+  try {
+    await ensureSchema(db);
+    const res = await db.execute({
+      sql: `SELECT s.username, s.display_name, s.avatar_url, s.profile_url,
+                   s.final_score, s.tier, s.tags,
+                   COALESCE(stats.lookup_count, 0) AS lookup_count
+            FROM scores AS s
+            LEFT JOIN account_stats AS stats ON stats.username = s.username
+            WHERE s.hidden = 0 AND s.final_score >= ?
+            ORDER BY lookup_count DESC, s.final_score DESC, s.scanned_at DESC
+            LIMIT ?`,
+      args: [minScore, limit],
+    });
+    const entries = res.rows.map((r) => ({
+      username: String(r.username),
+      display_name: r.display_name as string | null,
+      avatar_url: r.avatar_url as string | null,
+      profile_url: r.profile_url as string | null,
+      final_score: Number(r.final_score),
+      tier: String(r.tier) as Tier,
+      tags: parseTags(r.tags),
+      lookup_count: Number(r.lookup_count) || 0,
+    }));
+    return entries.length > 0 ? entries : previewHeatLeaderboard(limit, minScore);
+  } catch (e) {
+    console.error("getHeatLeaderboard failed:", e);
+    return previewHeatLeaderboard(limit, minScore);
   }
 }
 
@@ -303,7 +551,17 @@ export interface ScoreBrief {
 /** Minimal score lookup for the SVG badge — avoids fetching the heavy roast text. */
 export async function getScoreBrief(username: string): Promise<ScoreBrief | null> {
   const db = getClient();
-  if (!db) return null;
+  if (!db) {
+    const preview = previewAccountDetail(username);
+    return preview
+      ? {
+          username: preview.username,
+          display_name: preview.display_name,
+          final_score: preview.final_score,
+          tier: preview.tier,
+        }
+      : null;
+  }
   try {
     await ensureSchema(db);
     const res = await db.execute({
@@ -314,7 +572,17 @@ export async function getScoreBrief(username: string): Promise<ScoreBrief | null
       args: [username.toLowerCase()],
     });
     const r = res.rows[0];
-    if (!r) return null;
+    if (!r) {
+      const preview = previewAccountDetail(username);
+      return preview
+        ? {
+            username: preview.username,
+            display_name: preview.display_name,
+            final_score: preview.final_score,
+            tier: preview.tier,
+          }
+        : null;
+    }
     return {
       username: String(r.username),
       display_name: r.display_name as string | null,
@@ -330,7 +598,7 @@ export async function getScoreBrief(username: string): Promise<ScoreBrief | null
 /** Full persisted record for one account's detail page (null if absent/hidden). */
 export async function getAccountDetail(username: string): Promise<AccountDetail | null> {
   const db = getClient();
-  if (!db) return null;
+  if (!db) return previewAccountDetail(username);
   try {
     await ensureSchema(db);
     const res = await db.execute({
@@ -342,7 +610,7 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
       args: [username.toLowerCase()],
     });
     const r = res.rows[0];
-    if (!r) return null;
+    if (!r) return previewAccountDetail(username);
     return {
       username: String(r.username),
       display_name: r.display_name as string | null,
@@ -358,7 +626,7 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
     };
   } catch (e) {
     console.error("getAccountDetail failed:", e);
-    return null;
+    return previewAccountDetail(username);
   }
 }
 
@@ -381,16 +649,23 @@ export async function getSimilarAccounts(
   limit = 6,
 ): Promise<LeaderboardEntry[]> {
   const db = getClient();
-  if (!db) return [];
+  if (!db) {
+    return previewLeaderboard(Number.MAX_SAFE_INTEGER, 0)
+      .filter((entry) => entry.username.toLowerCase() !== username.toLowerCase())
+      .slice(0, limit);
+  }
   try {
     await ensureSchema(db);
     const res = await db.execute({
-      sql: `SELECT username, display_name, avatar_url, profile_url, final_score, tier, tags, sub_scores
-            FROM scores
-            WHERE hidden = 0
-              AND username != ?
-              AND final_score BETWEEN ? AND ?
-            ORDER BY final_score DESC
+      sql: `SELECT s.username, s.display_name, s.avatar_url, s.profile_url,
+                   s.final_score, s.tier, s.tags, s.sub_scores,
+                   COALESCE(stats.lookup_count, 0) AS lookup_count
+            FROM scores AS s
+            LEFT JOIN account_stats AS stats ON stats.username = s.username
+            WHERE s.hidden = 0
+              AND s.username != ?
+              AND s.final_score BETWEEN ? AND ?
+            ORDER BY s.final_score DESC
             LIMIT ?`,
       args: [
         username.toLowerCase(),
@@ -408,12 +683,27 @@ export async function getSimilarAccounts(
       tier: String(r.tier) as Tier,
       tags: parseTags(r.tags),
       sub_scores: parseSubScores(r.sub_scores),
+      lookup_count: Number(r.lookup_count) || 0,
     }));
-    // Rank by profile distance, then drop sub_scores to match LeaderboardEntry.
-    return rankSimilar(subScores, candidates, limit).map(({ sub_scores: _omit, ...e }) => e);
+    const ranked = rankSimilar(subScores, candidates, limit).map((e) => ({
+      username: e.username,
+      display_name: e.display_name,
+      avatar_url: e.avatar_url,
+      profile_url: e.profile_url,
+      final_score: e.final_score,
+      tier: e.tier,
+      tags: e.tags,
+      lookup_count: e.lookup_count,
+    }));
+    if (ranked.length > 0) return ranked;
+    return previewLeaderboard(Number.MAX_SAFE_INTEGER, 0)
+      .filter((entry) => entry.username.toLowerCase() !== username.toLowerCase())
+      .slice(0, limit);
   } catch (e) {
     console.error("getSimilarAccounts failed:", e);
-    return [];
+    return previewLeaderboard(Number.MAX_SAFE_INTEGER, 0)
+      .filter((entry) => entry.username.toLowerCase() !== username.toLowerCase())
+      .slice(0, limit);
   }
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -196,7 +196,7 @@ const PREVIEW_ACCOUNTS: AccountDetail[] = [
     tier: "夯",
     tags: {
       zh: ["高频被查", "框架老炮", "PR 稳定"],
-      en: ["frequent lookup", "framework veteran", "steady prs"],
+      en: ["frequently roasted", "framework veteran", "steady prs"],
     },
     sub_scores: {
       ...PREVIEW_SUB_SCORES,

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -217,24 +217,41 @@ export async function setCachedStats(total: number): Promise<void> {
   }
 }
 
-const LEADERBOARD_KEY = "leaderboard:top";
+export type LeaderboardCacheView = "score" | "heat";
+
+const leaderboardKey = (view: LeaderboardCacheView) => `leaderboard:${view}`;
 const LEADERBOARD_TTL_SECONDS = 300; // 5 min — board moves slowly; fewer DB reads
 
-export async function getCachedLeaderboard(): Promise<LeaderboardEntry[] | null> {
+export async function getCachedLeaderboard(
+  view: LeaderboardCacheView = "score",
+): Promise<LeaderboardEntry[] | null> {
   const r = getRedis();
   if (!r) return null;
   try {
-    return (await r.get<LeaderboardEntry[]>(LEADERBOARD_KEY)) ?? null;
+    return (await r.get<LeaderboardEntry[]>(leaderboardKey(view))) ?? null;
   } catch {
     return null;
   }
 }
 
-export async function setCachedLeaderboard(entries: LeaderboardEntry[]): Promise<void> {
+export async function setCachedLeaderboard(
+  entries: LeaderboardEntry[],
+  view: LeaderboardCacheView = "score",
+): Promise<void> {
   const r = getRedis();
   if (!r) return;
   try {
-    await r.set(LEADERBOARD_KEY, entries, { ex: LEADERBOARD_TTL_SECONDS });
+    await r.set(leaderboardKey(view), entries, { ex: LEADERBOARD_TTL_SECONDS });
+  } catch {
+    // best-effort
+  }
+}
+
+export async function clearCachedLeaderboards(): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+  try {
+    await r.del(leaderboardKey("score"), leaderboardKey("heat"));
   } catch {
     // best-effort
   }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -43,6 +43,10 @@
     "prev": "← Prev",
     "next": "Next →",
     "collapse": "Collapse",
+    "scoreView": "Top Scores",
+    "heatView": "🔥 Most Viewed",
+    "heatLabel": "Heat",
+    "heatTitle": "Successful lookup count",
     "viewDetail": "View @{username}'s score detail"
   },
   "detail": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -44,9 +44,9 @@
     "next": "Next →",
     "collapse": "Collapse",
     "scoreView": "Top Scores",
-    "heatView": "🔥 Most Viewed",
+    "heatView": "🔥 Most Roasted",
     "heatLabel": "Heat",
-    "heatTitle": "Successful lookup count",
+    "heatTitle": "Successful roast count",
     "viewDetail": "View @{username}'s score detail"
   },
   "detail": {

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -43,6 +43,10 @@
     "prev": "← 上一页",
     "next": "下一页 →",
     "collapse": "收起",
+    "scoreView": "评分榜",
+    "heatView": "🔥 热度榜",
+    "heatLabel": "热度",
+    "heatTitle": "被成功查询的次数",
     "viewDetail": "查看 @{username} 的评分详情"
   },
   "detail": {


### PR DESCRIPTION
## Summary

- Add a successful-lookup heat counter for scanned accounts and expose it on leaderboard responses.
- Add score and heat leaderboard views, with homepage in-place switching and full leaderboard URL support via `?view=heat`.
- Show heat next to each ranked account, prioritizing heat as the primary metric in the heat view.
- Add development-only preview data so the empty local database still demonstrates score-vs-heat ordering.

## Notes

- No generated files included.
- No GraphQL codegen updates included.
- No DB baseline updates included; schema is handled by the existing best-effort libSQL setup path.
- `pnpm-workspace.yaml` records the local pnpm build-script approvals needed for install/build reproducibility.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`