### PR TITLE
fix(leaderboard): prevent header controls overlap

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -40,11 +40,11 @@ export default async function LeaderboardPage({
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-5 py-14 sm:py-20">
       <header className="mb-8">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-4 sm:gap-6">
+        <div className="flex flex-col items-start gap-5 xl:flex-row xl:items-start xl:justify-between">
+          <div className="flex min-w-0 max-w-full flex-1 flex-wrap items-center gap-x-4 gap-y-3 sm:gap-x-6">
             <Link
               href="/leaderboard"
-              className={`shrink-0 text-3xl font-black tracking-tight sm:text-4xl ${
+              className={`shrink-0 text-3xl font-black leading-tight tracking-tight sm:text-4xl ${
                 view === "score" ? "text-zinc-100" : "text-zinc-500 hover:text-zinc-200"
               }`}
             >
@@ -53,7 +53,7 @@ export default async function LeaderboardPage({
             <span className="h-14 w-1 shrink-0 rotate-12 rounded-full bg-[rgb(255,105,0)] sm:h-20" />
             <Link
               href="/leaderboard?view=heat"
-              className={`shrink-0 text-xl font-black sm:text-2xl ${
+              className={`shrink-0 text-xl font-black leading-tight sm:text-2xl ${
                 view === "heat" ? "text-zinc-100" : "text-zinc-500 hover:text-red-300"
               }`}
             >

--- a/src/components/HomeLeaderboardClient.tsx
+++ b/src/components/HomeLeaderboardClient.tsx
@@ -34,12 +34,12 @@ export function HomeLeaderboardClient({
 
   return (
     <section className="mt-16 w-full max-w-2xl">
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex min-w-0 items-center gap-4 sm:gap-6">
+      <div className="mb-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 max-w-full flex-wrap items-center gap-x-4 gap-y-2 sm:gap-x-6">
           <button
             type="button"
             onClick={() => setView("score")}
-            className={`shrink-0 text-xl font-black ${
+            className={`shrink-0 text-xl font-black leading-tight ${
               view === "score" ? "text-zinc-100" : "text-zinc-500 hover:text-zinc-200"
             }`}
             aria-pressed={view === "score"}
@@ -50,7 +50,7 @@ export function HomeLeaderboardClient({
           <button
             type="button"
             onClick={() => setView("heat")}
-            className={`shrink-0 text-lg font-black sm:text-xl ${
+            className={`shrink-0 text-lg font-black leading-tight sm:text-xl ${
               view === "heat" ? "text-zinc-100" : "text-zinc-500 hover:text-red-300"
             }`}
             aria-pressed={view === "heat"}
@@ -60,7 +60,7 @@ export function HomeLeaderboardClient({
         </div>
         <Link
           href={fullBoardHref}
-          className="ml-4 shrink-0 text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
+          className="shrink-0 self-end text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline sm:ml-4 sm:self-auto"
         >
           {labels.openBoard}
         </Link>


### PR DESCRIPTION
## Summary

- Allow the full leaderboard header controls to wrap instead of overlapping the CTA in English.
- Apply the same wrapping behavior to the homepage leaderboard header to avoid the same issue at narrower widths.

## Notes

- No generated files included.
- No GraphQL codegen updates included.
- No DB baseline updates included.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`