### PR TITLE
fix(ui): 修复窄屏下开始审判按钮被挤压竖排折行

### DIFF
--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -267,7 +267,7 @@ export function Roaster() {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             placeholder={t("inputPlaceholder")}
-            className="flex-1 bg-transparent px-1 py-2 text-base outline-none placeholder:text-zinc-600"
+            className="min-w-0 flex-1 bg-transparent px-1 py-2 text-base outline-none placeholder:text-zinc-600"
             autoCapitalize="off"
             autoCorrect="off"
             spellCheck={false}
@@ -275,7 +275,7 @@ export function Roaster() {
           <button
             type="submit"
             disabled={scanning || roasting || !username.trim()}
-            className="rounded-lg bg-orange-600 px-5 py-2 font-medium text-white transition hover:bg-orange-500 disabled:opacity-40"
+            className="shrink-0 whitespace-nowrap rounded-lg bg-orange-600 px-5 py-2 font-medium text-white transition hover:bg-orange-500 disabled:opacity-40"
           >
             {scanning ? t("judging") : t("judge")}
           </button>


### PR DESCRIPTION
## 问题
移动端/窄屏下,「开始审判」按钮被输入框挤压成极窄竖条,四个字竖排折行(见反馈截图)。

## 根因
输入框用 \`flex-1\` 但缺少 \`min-w-0\`。flex item 默认 \`min-width: auto\`,不允许收缩到内容宽度以下,于是输入框抢占全部宽度,把按钮挤窄,导致按钮文字被迫竖排。

## 修复
\`src/components/Roaster.tsx\`:
- input 加 \`min-w-0\` — 允许输入框在空间不足时收缩,让出空间给按钮
- button 加 \`shrink-0 whitespace-nowrap\` — 按钮不被压缩、文字不换行,始终横排完整显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)