### PR TITLE
fix(leaderboard): align heat tab hover color

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -62,7 +62,7 @@ export default async function LeaderboardPage({
                 className={`rounded-full px-3 py-1.5 transition-colors ${
                   view === "heat"
                     ? "bg-white/10 text-zinc-100"
-                    : "text-zinc-500 hover:text-red-300"
+                    : "text-zinc-500 hover:text-zinc-200"
                 }`}
               >
                 {t("heatView")}

--- a/src/components/HomeLeaderboardClient.tsx
+++ b/src/components/HomeLeaderboardClient.tsx
@@ -51,7 +51,7 @@ export function HomeLeaderboardClient({
             type="button"
             onClick={() => setView("heat")}
             className={`shrink-0 text-lg font-black leading-tight sm:text-xl ${
-              view === "heat" ? "text-zinc-100" : "text-zinc-500 hover:text-red-300"
+              view === "heat" ? "text-zinc-100" : "text-zinc-500 hover:text-zinc-200"
             }`}
             aria-pressed={view === "heat"}
           >


### PR DESCRIPTION
## Summary

- Use the same inactive hover color for the heat tab as the score/Hall of Fame tab.
- Apply the fix to both the full leaderboard header and the homepage leaderboard switcher.

## Notes

- No generated files included.
- No GraphQL codegen updates included.
- No DB baseline updates included.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`