### PR TITLE
fix(leaderboard): open usernames on GitHub

### DIFF
--- a/src/components/LeaderboardClient.tsx
+++ b/src/components/LeaderboardClient.tsx
@@ -129,6 +129,7 @@ export function LeaderboardClient({
           const tierName = tTier(`${TIER_KEY[e.tier]}.name`);
           const detailLabel = labels.viewDetail.replace("{username}", e.username);
           const heatSelected = initialView === "heat";
+          const profileUrl = e.profile_url ?? `https://github.com/${encodeURIComponent(e.username)}`;
           return (
             <li
               key={e.username}
@@ -158,7 +159,14 @@ export function LeaderboardClient({
               )}
               <div className="min-w-0 flex-1">
                 <div className="truncate">
-                  <span className="font-medium group-hover:underline">@{e.username}</span>
+                  <a
+                    href={profileUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="relative z-10 font-medium underline-offset-2 hover:underline"
+                  >
+                    @{e.username}
+                  </a>
                   {e.display_name && (
                     <span className="ml-1.5 text-sm text-zinc-500">{e.display_name}</span>
                   )}


### PR DESCRIPTION
## Summary

- Make leaderboard usernames link directly to their GitHub profiles in a new tab.
- Preserve the existing pill-row click behavior for the empty area, which still opens the local score detail page.

## Why

The username text was rendered inside the stretched row link, so clicking it followed the row-level detail navigation instead of opening the GitHub profile.

## Validation

- `pnpm lint`
- `pnpm typecheck`

## Generated files / codegen / DB

None. No generated files, GraphQL codegen, or DB baseline updates.