### PR TITLE
feat(leaderboard): add direct page jump

### DIFF
--- a/src/components/HomeLeaderboard.tsx
+++ b/src/components/HomeLeaderboard.tsx
@@ -10,6 +10,7 @@ export async function HomeLeaderboard({ pageSize = 10 }: { pageSize?: number }) 
     empty: tBoard("empty"),
     prev: tBoard("prev"),
     next: tBoard("next"),
+    pageJumpLabel: tBoard("pageJumpLabel"),
     collapse: tBoard("collapse"),
     viewDetail: tBoard("viewDetail", { username: "{username}" }),
     heatLabel: tBoard("heatLabel"),

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -18,6 +18,7 @@ export async function Leaderboard({
     empty: t("empty"),
     prev: t("prev"),
     next: t("next"),
+    pageJumpLabel: t("pageJumpLabel"),
     collapse: t("collapse"),
     viewDetail: t("viewDetail", { username: "{username}" }),
     heatLabel: t("heatLabel"),

--- a/src/components/LeaderboardClient.tsx
+++ b/src/components/LeaderboardClient.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useLocale, useTranslations } from "next-intl";
-import { useState } from "react";
+import { type FormEvent, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import { TIER_KEY, tierStyle } from "@/lib/tier";
 import type { Tier } from "@/lib/types";
+import { resolveLeaderboardPageInput } from "./leaderboardPagination";
 
 export interface LeaderboardClientEntry {
   username: string;
@@ -23,6 +24,7 @@ export interface LeaderboardLabels {
   empty: string;
   prev: string;
   next: string;
+  pageJumpLabel: string;
   collapse: string;
   viewDetail: string;
   heatLabel: string;
@@ -115,6 +117,7 @@ export function LeaderboardClient({
   const locale = useLocale();
   const tTier = useTranslations("tiers");
   const [page, setPage] = useState(0);
+  const [pageInput, setPageInput] = useState({ page: 0, value: "1" });
   const entries =
     initialView === "heat"
       ? heatEntries
@@ -122,16 +125,33 @@ export function LeaderboardClient({
         ? progressEntries
         : scoreEntries;
   const tagLocale = tagLocaleFor(locale);
+  const totalPages = pageSize ? Math.max(1, Math.ceil(entries.length / pageSize)) : 1;
+  const current = Math.min(page, totalPages - 1);
+  const currentPageInput = pageInput.page === current ? pageInput.value : String(current + 1);
+  const visible = pageSize ? entries.slice(current * pageSize, (current + 1) * pageSize) : entries;
+  const offset = pageSize ? current * pageSize : 0;
+
+  function goToPage(nextPage: number) {
+    const target = resolveLeaderboardPageInput(String(nextPage + 1), current, totalPages);
+    setPage(target);
+    setPageInput({ page: target, value: String(target + 1) });
+  }
+
+  function commitPageInput() {
+    const target = resolveLeaderboardPageInput(currentPageInput, current, totalPages);
+    setPage(target);
+    setPageInput({ page: target, value: String(target + 1) });
+  }
+
+  function handlePageSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    commitPageInput();
+  }
 
   if (entries.length === 0) {
     const emptyMsg = initialView === "progress" ? labels.progressEmpty : labels.empty;
     return <p className="text-center text-zinc-500">{emptyMsg}</p>;
   }
-
-  const totalPages = pageSize ? Math.max(1, Math.ceil(entries.length / pageSize)) : 1;
-  const current = Math.min(page, totalPages - 1);
-  const visible = pageSize ? entries.slice(current * pageSize, (current + 1) * pageSize) : entries;
-  const offset = pageSize ? current * pageSize : 0;
 
   return (
     <>
@@ -266,17 +286,30 @@ export function LeaderboardClient({
       {pageSize && totalPages > 1 && (
         <div className="mt-4 flex items-center justify-center gap-4 text-sm">
           <button
-            onClick={() => setPage(Math.max(0, current - 1))}
+            onClick={() => goToPage(current - 1)}
             disabled={current === 0}
             className="rounded-lg border border-white/10 px-3 py-1.5 text-zinc-300 hover:bg-white/10 disabled:opacity-40"
           >
             {labels.prev}
           </button>
-          <span className="tabular-nums text-zinc-500">
-            {current + 1} / {totalPages}
-          </span>
+          <form
+            onSubmit={handlePageSubmit}
+            className="flex items-center gap-1 tabular-nums text-zinc-500"
+          >
+            <input
+              aria-label={labels.pageJumpLabel}
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={currentPageInput}
+              onBlur={commitPageInput}
+              onChange={(event) => setPageInput({ page: current, value: event.target.value })}
+              className="w-14 rounded-lg border border-white/10 bg-transparent px-2 py-1 text-center text-zinc-300 outline-none hover:bg-white/10 focus:border-orange-500/60 focus:bg-white/[0.03]"
+            />
+            <span>/ {totalPages}</span>
+          </form>
           <button
-            onClick={() => setPage(Math.min(totalPages - 1, current + 1))}
+            onClick={() => goToPage(current + 1)}
             disabled={current >= totalPages - 1}
             className="rounded-lg border border-white/10 px-3 py-1.5 text-zinc-300 hover:bg-white/10 disabled:opacity-40"
           >

--- a/src/components/leaderboardPagination.ts
+++ b/src/components/leaderboardPagination.ts
@@ -1,0 +1,18 @@
+function clampPageIndex(page: number, totalPages: number): number {
+  return Math.min(Math.max(0, page), Math.max(0, totalPages - 1));
+}
+
+export function resolveLeaderboardPageInput(
+  raw: string,
+  currentPage: number,
+  totalPages: number,
+): number {
+  const pageCount = Math.max(1, Math.floor(totalPages));
+  const current = clampPageIndex(Math.floor(currentPage), pageCount);
+  if (!raw.trim()) return current;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return current;
+
+  return clampPageIndex(Math.trunc(value) - 1, pageCount);
+}

--- a/src/lib/__tests__/leaderboardPagination.test.ts
+++ b/src/lib/__tests__/leaderboardPagination.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { resolveLeaderboardPageInput } from "../../components/leaderboardPagination";
+
+describe("resolveLeaderboardPageInput", () => {
+  it("converts a 1-based page input to a clamped 0-based page index", () => {
+    expect(resolveLeaderboardPageInput("3", 0, 5)).toBe(2);
+    expect(resolveLeaderboardPageInput("999", 1, 5)).toBe(4);
+    expect(resolveLeaderboardPageInput("0", 1, 5)).toBe(0);
+  });
+
+  it("keeps the current page for blank or invalid input", () => {
+    expect(resolveLeaderboardPageInput("", 2, 5)).toBe(2);
+    expect(resolveLeaderboardPageInput("abc", 2, 5)).toBe(2);
+  });
+});

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -42,6 +42,7 @@
     "empty": "🧮 Crunching the numbers — check back soon…",
     "prev": "← Prev",
     "next": "Next →",
+    "pageJumpLabel": "Go to page",
     "collapse": "Collapse",
     "scoreView": "Top Scores",
     "heatView": "🔥 Most Roasted",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -42,6 +42,7 @@
     "empty": "🧮 正在计算中，稍后再来看看…",
     "prev": "← 上一页",
     "next": "下一页 →",
+    "pageJumpLabel": "跳转到页码",
     "collapse": "收起",
     "scoreView": "评分榜",
     "heatView": "🔥 热度榜",


### PR DESCRIPTION
## Summary

- Replace the leaderboard pagination counter with a compact page input.
- Let users jump directly to a page from both the home leaderboard and the full leaderboard page.
- Keep previous/next buttons and direct input on shared clamped page handling.

## Notes

- The input uses `type="text"` with numeric input hints, so browsers do not show native number steppers.
- Page input stays local to the component and does not change the URL.
- No local seed script or generated database files included.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`