### PR TITLE
feat：改进缓存命中和缓存&db版本逻辑

### DIFF
--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClient } from "@libsql/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ROAST_CACHE_VERSION } from "../cache-version";
 import type { ScoreEntry } from "../db";
 
 let db: typeof import("../db");
@@ -57,6 +58,34 @@ describe("getArchivedRoast", () => {
     await expect(db.getArchivedRoast("RockChinQ", "en")).resolves.toMatchObject({
       report: "## English report",
     });
+  });
+
+  it("does not replay archived reports from a stale roast version", async () => {
+    await db.recordScore({ ...entry, username: "stale-roast" });
+    await db.updateRoast("stale-roast", "## stale report", "zh");
+
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: `UPDATE scores SET roast_version = ? WHERE username = ?`,
+      args: [`${ROAST_CACHE_VERSION}-old`, "stale-roast"],
+    });
+
+    await expect(db.getArchivedRoast("stale-roast", "zh")).resolves.toBeNull();
+  });
+
+  it("does not replay archived reports from rows without cache versions", async () => {
+    await db.recordScore({ ...entry, username: "legacy-roast" });
+    await db.updateRoast("legacy-roast", "## legacy report", "zh");
+
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: `UPDATE scores
+            SET score_version = NULL, roast_version = NULL
+            WHERE username = ?`,
+      args: ["legacy-roast"],
+    });
+
+    await expect(db.getArchivedRoast("legacy-roast", "zh")).resolves.toBeNull();
   });
 });
 

--- a/src/lib/__tests__/lang.test.ts
+++ b/src/lib/__tests__/lang.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  bypassGeneratedCaches,
+  ROAST_CACHE_VERSION,
+  SCORE_CACHE_VERSION,
+} from "../cache-version";
 import { normLang } from "../lang";
-import { roastKey } from "../redis";
+import { roastKey, scanKey } from "../redis";
 
 describe("normLang", () => {
   it("returns en only for the exact 'en' value", () => {
@@ -15,12 +20,41 @@ describe("normLang", () => {
 });
 
 describe("roastKey", () => {
+  it("namespaces scan keys by score cache version", () => {
+    expect(scanKey("SampleUser")).toBe(
+      `scan:${SCORE_CACHE_VERSION}:sampleuser`,
+    );
+  });
+
   it("namespaces the cache key by language and lowercases the username", () => {
-    expect(roastKey("SampleUser", "en")).toBe("roast:v2:en:sampleuser");
-    expect(roastKey("SampleUser", "zh")).toBe("roast:v2:zh:sampleuser");
+    expect(roastKey("SampleUser", "en")).toBe(
+      `roast:${ROAST_CACHE_VERSION}:en:sampleuser`,
+    );
+    expect(roastKey("SampleUser", "zh")).toBe(
+      `roast:${ROAST_CACHE_VERSION}:zh:sampleuser`,
+    );
   });
 
   it("keeps en and zh keys distinct", () => {
     expect(roastKey("sample-user", "en")).not.toBe(roastKey("sample-user", "zh"));
+  });
+});
+
+describe("bypassGeneratedCaches", () => {
+  it("bypasses generated caches in development unless explicitly enabled", () => {
+    try {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("ENABLE_DEV_GENERATED_CACHE", undefined);
+      expect(bypassGeneratedCaches()).toBe(true);
+
+      vi.stubEnv("ENABLE_DEV_GENERATED_CACHE", "1");
+      expect(bypassGeneratedCaches()).toBe(false);
+
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ENABLE_DEV_GENERATED_CACHE", undefined);
+      expect(bypassGeneratedCaches()).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/src/lib/cache-version.ts
+++ b/src/lib/cache-version.ts
@@ -1,0 +1,17 @@
+/**
+ * Cache/archive versions for generated GitHub roast artifacts.
+ *
+ * Bump SCORE_CACHE_VERSION when deterministic scan metrics or scoring formulas
+ * change. Bump ROAST_CACHE_VERSION when prompt/report generation semantics
+ * change. Development bypasses these caches entirely so local prompt/scoring
+ * edits are visible on the next request.
+ */
+export const SCORE_CACHE_VERSION = "v4";
+export const ROAST_CACHE_VERSION = "v3";
+
+export function bypassGeneratedCaches(): boolean {
+  return (
+    process.env.NODE_ENV === "development" &&
+    process.env.ENABLE_DEV_GENERATED_CACHE !== "1"
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,6 +10,11 @@
 
 import { Client, createClient } from "@libsql/client";
 import { createHash } from "node:crypto";
+import {
+  bypassGeneratedCaches,
+  ROAST_CACHE_VERSION,
+  SCORE_CACHE_VERSION,
+} from "./cache-version";
 import { computeTrendingScore, rankTrending } from "./hotness";
 import type { Lang } from "./lang";
 import type { PaperDims, PaperMode, PaperTierKey } from "./paper-types";
@@ -199,6 +204,9 @@ function ensureSchema(db: Client): Promise<void> {
         // Bilingual one-liner {zh,en} JSON — generated in one LLM call so the
         // roast shows in the visitor's language regardless of report language.
         "roast_line TEXT",
+        "score_version TEXT",
+        "roast_version TEXT",
+        "roast_en_version TEXT",
         // Previous scan's score + timestamp, kept for the 进步榜 (progress board).
         // Populated by recordScore on a genuinely later re-scan; NULL until then.
         "prev_score REAL",
@@ -315,8 +323,8 @@ export async function recordScore(entry: ScoreEntry): Promise<void> {
     const username = entry.username.toLowerCase();
     await db.execute({
       sql: `INSERT INTO scores
-              (username, display_name, avatar_url, profile_url, final_score, tier, tags, roast_line, bot_score, sub_scores, scanned_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              (username, display_name, avatar_url, profile_url, final_score, tier, tags, roast_line, score_version, bot_score, sub_scores, scanned_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(username) DO UPDATE SET
               prev_score      = CASE WHEN excluded.scanned_at - scores.scanned_at >= ?
                                      THEN scores.final_score ELSE scores.prev_score END,
@@ -329,6 +337,7 @@ export async function recordScore(entry: ScoreEntry): Promise<void> {
               tier         = excluded.tier,
               tags         = excluded.tags,
               roast_line   = excluded.roast_line,
+              score_version = excluded.score_version,
               bot_score    = excluded.bot_score,
               sub_scores   = excluded.sub_scores,
               scanned_at   = excluded.scanned_at`,
@@ -341,6 +350,7 @@ export async function recordScore(entry: ScoreEntry): Promise<void> {
         entry.tier,
         JSON.stringify(entry.tags ?? EMPTY_TAGS),
         JSON.stringify(entry.roast_line ?? EMPTY_ROAST_LINE),
+        SCORE_CACHE_VERSION,
         entry.bot_score,
         JSON.stringify(entry.sub_scores),
         entry.scanned_at,
@@ -371,11 +381,12 @@ export async function updateRoast(username: string, roast: string, lang: Lang): 
   if (!db) return;
   // Column name comes from a fixed allowlist (never from user input).
   const col = lang === "en" ? "roast_en" : "roast";
+  const versionCol = lang === "en" ? "roast_en_version" : "roast_version";
   try {
     await ensureSchema(db);
     await db.execute({
-      sql: `UPDATE scores SET ${col} = ? WHERE username = ?`,
-      args: [roast, username.toLowerCase()],
+      sql: `UPDATE scores SET ${col} = ?, ${versionCol} = ? WHERE username = ?`,
+      args: [roast, ROAST_CACHE_VERSION, username.toLowerCase()],
     });
   } catch (e) {
     console.error("updateRoast failed:", e);
@@ -755,9 +766,11 @@ export async function getArchivedRoast(
   username: string,
   lang: Lang,
 ): Promise<ArchivedRoast | null> {
+  if (bypassGeneratedCaches()) return null;
   const db = getClient();
   if (!db) return null;
   const col = lang === "en" ? "roast_en" : "roast";
+  const versionCol = lang === "en" ? "roast_en_version" : "roast_version";
   try {
     await ensureSchema(db);
     const res = await db.execute({
@@ -765,10 +778,12 @@ export async function getArchivedRoast(
             FROM scores
             WHERE username = ?
               AND hidden = 0
+              AND score_version = ?
+              AND ${versionCol} = ?
               AND ${col} IS NOT NULL
               AND ${col} != ''
             LIMIT 1`,
-      args: [username.toLowerCase()],
+      args: [username.toLowerCase(), SCORE_CACHE_VERSION, ROAST_CACHE_VERSION],
     });
     const r = res.rows[0];
     if (!r) return null;

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -10,6 +10,11 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
+import {
+  bypassGeneratedCaches,
+  ROAST_CACHE_VERSION,
+  SCORE_CACHE_VERSION,
+} from "./cache-version";
 import type { LeaderboardEntry } from "./db";
 import type { Lang } from "./lang";
 import type { ScanResult } from "./types";
@@ -29,14 +34,14 @@ function getRedis(): Redis | null {
 }
 
 const SCAN_TTL_SECONDS = 60 * 60 * 24; // 24h
-// v3: scoring formula includes social-only dormant profile handling. Bumping the
-// prefix invalidates cached scans whose embedded scoring used older rules.
-const scanKey = (username: string) => `scan:v3:${username.toLowerCase()}`;
+export const scanKey = (username: string) =>
+  `scan:${SCORE_CACHE_VERSION}:${username.toLowerCase()}`;
 const lockKey = (username: string) => `lock:scan:${username.toLowerCase()}`;
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export async function getCachedScan(username: string): Promise<ScanResult | null> {
+  if (bypassGeneratedCaches()) return null;
   const r = getRedis();
   if (!r) return null;
   try {
@@ -47,6 +52,7 @@ export async function getCachedScan(username: string): Promise<ScanResult | null
 }
 
 export async function setCachedScan(username: string, scan: ScanResult): Promise<void> {
+  if (bypassGeneratedCaches()) return;
   const r = getRedis();
   if (!r) return;
   try {
@@ -67,6 +73,7 @@ export async function coalesceScan(
   username: string,
   producer: () => Promise<ScanResult>,
 ): Promise<ScanResult> {
+  if (bypassGeneratedCaches()) return producer();
   const r = getRedis();
   if (!r) return producer();
 
@@ -175,9 +182,10 @@ export interface CachedRoast {
 
 const ROAST_TTL_SECONDS = 60 * 60 * 24;
 export const roastKey = (username: string, lang: Lang) =>
-  `roast:v2:${lang}:${username.toLowerCase()}`;
+  `roast:${ROAST_CACHE_VERSION}:${lang}:${username.toLowerCase()}`;
 
 export async function getCachedRoast(username: string, lang: Lang): Promise<CachedRoast | null> {
+  if (bypassGeneratedCaches()) return null;
   const r = getRedis();
   if (!r) return null;
   try {
@@ -192,6 +200,7 @@ export async function setCachedRoast(
   lang: Lang,
   value: CachedRoast,
 ): Promise<void> {
+  if (bypassGeneratedCaches()) return;
   const r = getRedis();
   if (!r) return;
   try {
@@ -213,6 +222,7 @@ const roastLockKey = (username: string, lang: Lang) =>
 /** Try to become the sole generator for (username, lang). `true` = leader.
  *  Without Redis there's no coordination, so everyone leads (behavior unchanged). */
 export async function acquireRoastLock(username: string, lang: Lang): Promise<boolean> {
+  if (bypassGeneratedCaches()) return true;
   const r = getRedis();
   if (!r) return true;
   try {
@@ -228,6 +238,7 @@ export async function acquireRoastLock(username: string, lang: Lang): Promise<bo
 }
 
 export async function releaseRoastLock(username: string, lang: Lang): Promise<void> {
+  if (bypassGeneratedCaches()) return;
   const r = getRedis();
   if (!r) return;
   try {
@@ -248,6 +259,7 @@ export async function waitForCachedRoast(
   lang: Lang,
   timeoutMs = 60000,
 ): Promise<CachedRoast | null> {
+  if (bypassGeneratedCaches()) return null;
   const r = getRedis();
   if (!r) return null;
   const steps = Math.max(1, Math.floor(timeoutMs / 500));


### PR DESCRIPTION
implement of #31 

## 背景

当前 scan / roast 缓存命中逻辑过于保守：评分公式或 prompt 改动后，同一用户名仍可能命中旧 scan、旧 roast，甚至 DB archived roast 回放旧报告，导致本地联调和新构建验证看到过期结果

## 改动说明

- 新增生成类缓存版本常量：
  - SCORE_CACHE_VERSION
  - ROAST_CACHE_VERSION
- Redis scan cache key 改为 scan:<scoreVersion>:<username>
- Redis roast cache key 改为 roast:<roastVersion>:<lang>:<username>
- development 环境默认绕过 scan / roast 生成缓存，确保本地热更新测试能看到最新评分和 prompt 输出
- development 下绕过 roast single-flight 等待，避免等待不会写入的缓存
- DB archived roast 增加版本保护：
  - scores 表新增 score_version / roast_version / roast_en_version
  - recordScore 写入当前 score version
  - updateRoast 写入当前语言 roast version
  - getArchivedRoast 只回放 score version 和 roast version 都匹配的报告
  - 无版本旧数据默认不 replay
- 可通过 ENABLE_DEV_GENERATED_CACHE=1 在 development 下临时启用生成类缓存，方便联调缓存逻辑

## 测试

- npm test -- --run src/lib/__tests__/db.test.ts src/lib/__tests__/lang.test.ts
- npm test
- npm run lint
- npm run typecheck
- npm run build
- git diff --check