### PR TITLE
fix(arxiv): remove public roast entrypoints

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { getAllPaperIds, getAllPublicUsernames } from "@/lib/db";
+import { getAllPublicUsernames } from "@/lib/db";
 import { PUBLIC_INDEX_MIN_SCORE, SITE_URL } from "@/lib/site";
 
 // Re-generate at most hourly — new profiles are scored continuously, but the
@@ -26,15 +26,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [
     entry("/", { changeFrequency: "daily", priority: 1 }),
     entry("/leaderboard", { changeFrequency: "hourly", priority: 0.9 }),
-    entry("/arxiv", { changeFrequency: "weekly", priority: 0.8 }),
-    entry("/arxiv/leaderboard", { changeFrequency: "daily", priority: 0.8 }),
   ];
 
-  const [profiles, papers] = await Promise.all([
-    // Indexable profiles (non-hidden, score ≥ floor). Below-floor pages omitted.
-    getAllPublicUsernames(PUBLIC_INDEX_MIN_SCORE),
-    getAllPaperIds(),
-  ]);
+  // Indexable profiles (non-hidden, score ≥ floor). Below-floor pages omitted.
+  const profiles = await getAllPublicUsernames(PUBLIC_INDEX_MIN_SCORE);
   const profileRoutes: MetadataRoute.Sitemap = profiles.map((p) =>
     entry(`/u/${p.username}`, {
       lastModified: p.scanned_at ? new Date(p.scanned_at) : undefined,
@@ -42,13 +37,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     }),
   );
-  const paperRoutes: MetadataRoute.Sitemap = papers.map((p) =>
-    entry(`/arxiv/${p.arxiv_id}`, {
-      lastModified: p.scored_at ? new Date(p.scored_at) : undefined,
-      changeFrequency: "weekly",
-      priority: 0.7,
-    }),
-  );
 
-  return [...staticRoutes, ...profileRoutes, ...paperRoutes];
+  return [...staticRoutes, ...profileRoutes];
 }

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -25,14 +25,7 @@ export type NavItem = {
 };
 
 export const NAV_ITEMS: NavItem[] = [
-  // 「锐评」是下拉父级:GitHub 锐评(首页)+ arxiv 锐评(beta)。
-  {
-    key: "roast",
-    children: [
-      { key: "githubRoast", href: "/", exact: true },
-      { key: "arxivRoast", href: "/arxiv", badge: "beta" },
-    ],
-  },
+  { key: "roast", href: "/", exact: true },
   { key: "leaderboard", href: "/leaderboard" },
   // P1 落地后加: { key: "developers", href: "/developers" },
 ];

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -10,8 +10,6 @@
   "nav": {
     "brand": "GitHub Roast",
     "roast": "Roast",
-    "githubRoast": "GitHub Roast",
-    "arxivRoast": "arXiv Roast",
     "leaderboard": "Leaderboard",
     "openMenu": "Open menu",
     "closeMenu": "Close menu"

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -10,8 +10,6 @@
   "nav": {
     "brand": "毒舌 GitHub",
     "roast": "锐评",
-    "githubRoast": "GitHub 锐评",
-    "arxivRoast": "arxiv 锐评",
     "leaderboard": "榜单",
     "openMenu": "打开菜单",
     "closeMenu": "关闭菜单"


### PR DESCRIPTION
## Summary
- Remove the arXiv roast beta entry from primary navigation so Roast links directly to the GitHub roast home.
- Stop publishing arXiv tool, board, and paper detail URLs in the sitemap.
- Remove unused arXiv navigation message keys from both locales.

## Validation
- pnpm test -- src/messages/__tests__/messages.test.ts
- pnpm typecheck
- pnpm build

## Generated artifacts
- Generated files: none
- GraphQL codegen: none
- DB baseline updates: none