### PR TITLE
feat(leaderboard): remove progress board display

### DIFF
--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -39,9 +39,7 @@ export default async function LeaderboardPage({
       ? "score"
       : query?.view === "heat"
         ? "heat"
-        : query?.view === "progress"
-          ? "progress"
-          : "trending";
+        : "trending";
   await connection();
   setRequestLocale(locale);
   const t = await getTranslations("leaderboard");
@@ -50,21 +48,17 @@ export default async function LeaderboardPage({
       ? t("scoreView")
       : view === "heat"
         ? t("heatView")
-        : view === "progress"
-          ? t("progressView")
-          : t("trendView");
+        : t("trendView");
   const subtitle =
     view === "score"
       ? t("scoreSubtitle")
       : view === "heat"
         ? t("heatSubtitle")
-        : view === "progress"
-          ? t("progressSubtitle")
-          : t("trendSubtitle");
+        : t("trendSubtitle");
 
   // Structured data only for the canonical score ranking — the directory's main
-  // "top developers" list. Heat/progress are sort variants behind query params,
-  // so emitting one ItemList keeps the markup unambiguous for crawlers.
+  // "top developers" list. Heat is a sort variant behind query params, so
+  // emitting one ItemList keeps the markup unambiguous for crawlers.
   const rankingEntries = view === "score" ? await getLeaderboard(50) : [];
 
   return (
@@ -86,7 +80,7 @@ export default async function LeaderboardPage({
               {t("heading")}
             </h1>
             <p className="mt-2 text-xl font-black text-zinc-300">{viewTitle}</p>
-            <div className="mt-4 grid w-full max-w-[40rem] grid-cols-2 items-center gap-1 rounded-full border border-white/10 bg-white/[0.03] p-1 text-sm font-bold sm:grid-cols-4">
+            <div className="mt-4 grid w-full max-w-[40rem] grid-cols-1 items-center gap-1 rounded-2xl border border-white/10 bg-white/[0.03] p-1 text-sm font-bold sm:grid-cols-3 sm:rounded-full">
               <Link
                 href="/leaderboard"
                 className={`whitespace-nowrap rounded-full px-2 py-1.5 text-center transition-colors ${
@@ -116,16 +110,6 @@ export default async function LeaderboardPage({
                 }`}
               >
                 {t("heatView")}
-              </Link>
-              <Link
-                href="/leaderboard?view=progress"
-                className={`whitespace-nowrap rounded-full px-2 py-1.5 text-center transition-colors ${
-                  view === "progress"
-                    ? "bg-white/10 text-zinc-100"
-                    : "text-zinc-500 hover:text-zinc-200"
-                }`}
-              >
-                {t("progressView")}
               </Link>
             </div>
           </div>

--- a/src/components/HomeLeaderboard.tsx
+++ b/src/components/HomeLeaderboard.tsx
@@ -2,7 +2,6 @@ import { getTranslations } from "next-intl/server";
 import {
   getHeatLeaderboard,
   getLeaderboard,
-  getProgressLeaderboard,
   getTrendingLeaderboard,
 } from "@/lib/db";
 import { HomeLeaderboardClient, type HomeLeaderboardLabels } from "./HomeLeaderboardClient";
@@ -24,9 +23,6 @@ export async function HomeLeaderboard({ pageSize = 10 }: { pageSize?: number }) 
     scoreTitle: tBoard("scoreTitle"),
     heatLabel: tBoard("heatLabel"),
     heatTitle: tBoard("heatTitle"),
-    progressLabel: tBoard("progressLabel"),
-    progressTitle: tBoard("progressTitle"),
-    progressEmpty: tBoard("progressEmpty"),
   };
   const labels: HomeLeaderboardLabels = {
     heading: tHome("boardHeading"),
@@ -34,14 +30,12 @@ export async function HomeLeaderboard({ pageSize = 10 }: { pageSize?: number }) 
     trendView: tBoard("trendView"),
     scoreView: tBoard("scoreView"),
     heatView: tBoard("heatView"),
-    progressView: tBoard("progressView"),
   };
 
-  const [trendingEntries, scoreEntries, heatEntries, progressEntries] = await Promise.all([
+  const [trendingEntries, scoreEntries, heatEntries] = await Promise.all([
     getTrendingLeaderboard(500),
     getLeaderboard(500),
     getHeatLeaderboard(500),
-    getProgressLeaderboard(500),
   ]);
 
   return (
@@ -52,7 +46,6 @@ export async function HomeLeaderboard({ pageSize = 10 }: { pageSize?: number }) 
       scoreEntries={scoreEntries}
       heatEntries={heatEntries}
       trendingEntries={trendingEntries}
-      progressEntries={progressEntries}
     />
   );
 }

--- a/src/components/HomeLeaderboardClient.tsx
+++ b/src/components/HomeLeaderboardClient.tsx
@@ -15,7 +15,6 @@ export interface HomeLeaderboardLabels {
   trendView: string;
   scoreView: string;
   heatView: string;
-  progressView: string;
 }
 
 function TabDivider() {
@@ -29,7 +28,6 @@ export function HomeLeaderboardClient({
   pageSize,
   scoreEntries,
   trendingEntries,
-  progressEntries = [],
 }: {
   heatEntries: LeaderboardClientEntry[];
   labels: HomeLeaderboardLabels;
@@ -37,16 +35,13 @@ export function HomeLeaderboardClient({
   pageSize: number;
   scoreEntries: LeaderboardClientEntry[];
   trendingEntries: LeaderboardClientEntry[];
-  progressEntries?: LeaderboardClientEntry[];
 }) {
   const [view, setView] = useState<LeaderboardView>("trending");
   const fullBoardHref =
     view === "score"
       ? "/leaderboard?view=score"
       : view === "heat"
-      ? "/leaderboard?view=heat"
-      : view === "progress"
-        ? "/leaderboard?view=progress"
+        ? "/leaderboard?view=heat"
         : "/leaderboard";
   const tabClass = (tab: LeaderboardView) =>
     `shrink-0 text-base font-black leading-tight sm:text-lg ${
@@ -87,15 +82,6 @@ export function HomeLeaderboardClient({
             >
               {labels.heatView}
             </button>
-            <TabDivider />
-            <button
-              type="button"
-              onClick={() => setView("progress")}
-              className={tabClass("progress")}
-              aria-pressed={view === "progress"}
-            >
-              {labels.progressView}
-            </button>
           </div>
         </div>
         <Link
@@ -113,7 +99,6 @@ export function HomeLeaderboardClient({
         scoreEntries={scoreEntries}
         heatEntries={heatEntries}
         trendingEntries={trendingEntries}
-        progressEntries={progressEntries}
       />
     </section>
   );

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -2,7 +2,6 @@ import { getTranslations } from "next-intl/server";
 import {
   getHeatLeaderboard,
   getLeaderboard,
-  getProgressLeaderboard,
   getTrendingLeaderboard,
 } from "@/lib/db";
 import {
@@ -32,16 +31,12 @@ export async function Leaderboard({
     scoreTitle: t("scoreTitle"),
     heatLabel: t("heatLabel"),
     heatTitle: t("heatTitle"),
-    progressLabel: t("progressLabel"),
-    progressTitle: t("progressTitle"),
-    progressEmpty: t("progressEmpty"),
   };
 
-  const [trendingEntries, scoreEntries, heatEntries, progressEntries] = await Promise.all([
+  const [trendingEntries, scoreEntries, heatEntries] = await Promise.all([
     initialView === "trending" ? getTrendingLeaderboard(500) : Promise.resolve([]),
     initialView === "score" ? getLeaderboard(500) : Promise.resolve([]),
     initialView === "heat" ? getHeatLeaderboard(500) : Promise.resolve([]),
-    initialView === "progress" ? getProgressLeaderboard(500) : Promise.resolve([]),
   ]);
 
   return (
@@ -53,7 +48,6 @@ export async function Leaderboard({
       scoreEntries={scoreEntries}
       heatEntries={heatEntries}
       trendingEntries={trendingEntries}
-      progressEntries={progressEntries}
     />
   );
 }

--- a/src/components/LeaderboardClient.tsx
+++ b/src/components/LeaderboardClient.tsx
@@ -35,12 +35,9 @@ export interface LeaderboardLabels {
   scoreTitle: string;
   heatLabel: string;
   heatTitle: string;
-  progressLabel: string;
-  progressTitle: string;
-  progressEmpty: string;
 }
 
-export type LeaderboardView = "trending" | "score" | "heat" | "progress";
+export type LeaderboardView = "trending" | "score" | "heat";
 
 const RANK_BADGE = ["🥇", "🥈", "🥉"];
 const TAG_TONE: Record<TagLocale, string> = {
@@ -148,7 +145,6 @@ export function LeaderboardClient({
   scoreEntries,
   heatEntries,
   trendingEntries,
-  progressEntries = [],
 }: {
   initialView: LeaderboardView;
   labels: LeaderboardLabels;
@@ -156,7 +152,6 @@ export function LeaderboardClient({
   scoreEntries: LeaderboardClientEntry[];
   heatEntries: LeaderboardClientEntry[];
   trendingEntries: LeaderboardClientEntry[];
-  progressEntries?: LeaderboardClientEntry[];
 }) {
   const locale = useLocale();
   const tTier = useTranslations("tiers");
@@ -166,9 +161,7 @@ export function LeaderboardClient({
     initialView === "score"
       ? scoreEntries
       : initialView === "heat"
-      ? heatEntries
-      : initialView === "progress"
-        ? progressEntries
+        ? heatEntries
         : trendingEntries;
   const tagLocale = tagLocaleFor(locale);
   const totalPages = pageSize ? Math.max(1, Math.ceil(entries.length / pageSize)) : 1;
@@ -194,10 +187,7 @@ export function LeaderboardClient({
     commitPageInput();
   }
 
-  if (entries.length === 0) {
-    const emptyMsg = initialView === "progress" ? labels.progressEmpty : labels.empty;
-    return <p className="text-center text-zinc-500">{emptyMsg}</p>;
-  }
+  if (entries.length === 0) return <p className="text-center text-zinc-500">{labels.empty}</p>;
 
   return (
     <>
@@ -207,7 +197,6 @@ export function LeaderboardClient({
           const style = tierStyle(e.tier);
           const tierName = tTier(`${TIER_KEY[e.tier]}.name`);
           const detailLabel = labels.viewDetail.replace("{username}", e.username);
-          const delta = e.delta ?? e.final_score - (e.prev_score ?? e.final_score);
           const trendingScore = e.trending_score ?? 0;
           const recentLookupCount = e.recent_lookup_count ?? 0;
           const heatValue = initialView === "trending" ? recentLookupCount : e.lookup_count;
@@ -224,29 +213,40 @@ export function LeaderboardClient({
           const heatMetricValue = <span className="text-amber-300">{heatValue}</span>;
           const divider = <span className="px-1 text-zinc-600">/</span>;
           const metricRows: MetricRow[] =
-            initialView === "progress"
+            initialView === "score"
               ? [
-                  {
-                    label: <span className="text-emerald-300">📈 {labels.progressLabel}</span>,
-                    value: <span className="text-emerald-300">+{delta.toFixed(2)}</span>,
-                    title: labels.progressTitle,
-                    ariaLabel: `${labels.progressLabel} +${delta.toFixed(2)}`,
-                    valueClass: "text-lg",
-                  },
                   {
                     label: scoreLabel,
                     value: scoreValue,
                     title: labels.scoreTitle,
                     ariaLabel: `${labels.scoreLabel} ${e.final_score.toFixed(2)}`,
+                    valueClass: "text-lg",
+                  },
+                  {
+                    label: (
+                      <>
+                        {trendLabel}
+                        {divider}
+                        {heatLabel}
+                      </>
+                    ),
+                    value: (
+                      <>
+                        {trendValue}
+                        {divider}
+                        <span className="text-amber-300">{e.lookup_count}</span>
+                      </>
+                    ),
+                    title: labels.trendTitle,
                   },
                 ]
-              : initialView === "score"
+              : initialView === "heat"
                 ? [
                     {
-                      label: scoreLabel,
-                      value: scoreValue,
-                      title: labels.scoreTitle,
-                      ariaLabel: `${labels.scoreLabel} ${e.final_score.toFixed(2)}`,
+                      label: heatLabel,
+                      value: <span className="text-amber-300">{e.lookup_count}</span>,
+                      title: labels.heatTitle,
+                      ariaLabel: `${labels.heatLabel} ${e.lookup_count}`,
                       valueClass: "text-lg",
                     },
                     {
@@ -254,72 +254,45 @@ export function LeaderboardClient({
                         <>
                           {trendLabel}
                           {divider}
-                          {heatLabel}
+                          {scoreLabel}
                         </>
                       ),
                       value: (
                         <>
                           {trendValue}
                           {divider}
-                          <span className="text-amber-300">{e.lookup_count}</span>
+                          {scoreValue}
                         </>
                       ),
-                      title: labels.trendTitle,
+                      title: labels.scoreTitle,
                     },
                   ]
-                : initialView === "heat"
-                  ? [
-                      {
-                        label: heatLabel,
-                        value: <span className="text-amber-300">{e.lookup_count}</span>,
-                        title: labels.heatTitle,
-                        ariaLabel: `${labels.heatLabel} ${e.lookup_count}`,
-                        valueClass: "text-lg",
-                      },
-                      {
-                        label: (
-                          <>
-                            {trendLabel}
-                            {divider}
-                            {scoreLabel}
-                          </>
-                        ),
-                        value: (
-                          <>
-                            {trendValue}
-                            {divider}
-                            {scoreValue}
-                          </>
-                        ),
-                        title: labels.scoreTitle,
-                      },
-                    ]
-                  : [
-                      {
-                        label: trendLabel,
-                        value: trendValue,
-                        title: labels.trendTitle,
-                        ariaLabel: `${labels.trendLabel} ${trendingScore.toFixed(1)}`,
-                        valueClass: "text-lg",
-                      },
-                      {
-                        label: (
-                          <>
-                            {scoreLabel}
-                            {divider}
-                            {heatLabel}
-                          </>
-                        ),
-                        value: (
-                          <>
-                            {scoreValue}
-                            {divider}
-                            {heatMetricValue}
-                          </>
-                        ),
-                        title: labels.scoreTitle,
-                      },
-                    ];
+                : [
+                    {
+                      label: trendLabel,
+                      value: trendValue,
+                      title: labels.trendTitle,
+                      ariaLabel: `${labels.trendLabel} ${trendingScore.toFixed(1)}`,
+                      valueClass: "text-lg",
+                    },
+                    {
+                      label: (
+                        <>
+                          {scoreLabel}
+                          {divider}
+                          {heatLabel}
+                        </>
+                      ),
+                      value: (
+                        <>
+                          {scoreValue}
+                          {divider}
+                          {heatMetricValue}
+                        </>
+                      ),
+                      title: labels.scoreTitle,
+                    },
+                  ];
           return (
             <li
               key={e.username}
@@ -366,7 +339,7 @@ export function LeaderboardClient({
                   <TagRow labels={labels} locale={tagLocale} tags={e.tags} />
                 </div>
               </div>
-              <MetricBlock compact={initialView === "progress"} rows={metricRows} />
+              <MetricBlock rows={metricRows} />
             </li>
           );
         })}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -126,14 +126,9 @@
     "heatLabel": "Heat",
     "heatTitle": "Successful roast count",
     "viewDetail": "View @{username}'s score detail",
-    "progressView": "📈 Most Improved",
-    "progressLabel": "Gain",
-    "progressTitle": "Points gained since last scan",
     "trendSubtitle": "Trend blends score, unique 7-day visitor heat, and recent lookup recency; heat is normalized so raw attention cannot overwhelm quality.",
     "scoreSubtitle": "Ranked by the 0-100 value and trust score.",
-    "heatSubtitle": "Ranked by total successful roast lookups.",
-    "progressSubtitle": "Climb from your last scan to make the board.",
-    "progressEmpty": "🧮 Crunching the numbers — check back soon…"
+    "heatSubtitle": "Ranked by total successful roast lookups."
   },
   "detail": {
     "back": "← Back to Hall of Fame",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -126,14 +126,9 @@
     "heatLabel": "热度",
     "heatTitle": "被成功查询的次数",
     "viewDetail": "查看 @{username} 的评分详情",
-    "progressView": "📈 进步榜",
-    "progressLabel": "进步",
-    "progressTitle": "相比上次扫描的涨分",
     "trendSubtitle": "趋势分综合评分、近 7 天唯一访客热度和最近查询时间；热度会先归一化，避免刷量压过高质量账号。",
     "scoreSubtitle": "按 0-100 分价值与信任评分排序。",
-    "heatSubtitle": "按被成功查询审判的累计次数排序。",
-    "progressSubtitle": "比上次扫描涨分即可上榜。",
-    "progressEmpty": "🧮 正在计算中，稍后再来看看…"
+    "heatSubtitle": "按被成功查询审判的累计次数排序。"
   },
   "detail": {
     "back": "← 返回名人堂",


### PR DESCRIPTION
## Summary
- Remove the progress board tab from the homepage leaderboard preview and the full leaderboard page.
- Stop prefetching progress-board data for rendered leaderboard UI.
- Remove unused progress-board labels from English and Chinese messages.

## Impact
Users now see only Trending, Top Scores, and Most Roasted leaderboard views. A direct `?view=progress` URL falls back to Trending instead of rendering the progress board.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (14 files, 127 tests)

## Generated Files / Codegen / DB
- Generated files: none
- GraphQL codegen: none
- DB baseline updates: none