### PR TITLE
feat(comments): add profile comment bubbles

### DIFF
--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -5,19 +5,20 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
-import { getAccountDetail, getSimilarAccounts } from "@/lib/db";
+import { getAccountDetail, getProfileComments, getSimilarAccounts } from "@/lib/db";
 import { JsonLd, profileJsonLd } from "@/components/JsonLd";
 import { SITE_URL, PUBLIC_INDEX_MIN_SCORE } from "@/lib/site";
 import { CopyBadge } from "@/components/CopyBadge";
+import { FloatingCommentBubbles } from "@/components/FloatingCommentBubbles";
 import { TierAvatarFrame } from "@/components/TierAvatarFrame";
 import { SUBSCORE_MAX } from "@/lib/score";
 import { TIER_KEY, tierStyle } from "@/lib/tier";
 import { normLang } from "@/lib/lang";
 import type { SubScoreKey } from "@/lib/types";
 
-// Re-render at most hourly; on-demand pages are then served from the cache, so a
-// viral account doesn't hammer the DB or rack up function time on every view.
-export const revalidate = 3600;
+// Profile comments must be fresh; score/roast data is still fetched from the DB
+// and remains cached at the persistence layer where applicable.
+export const dynamic = "force-dynamic";
 
 // Dedupe the DB read between generateMetadata() and the page render.
 const getDetail = cache((username: string) => getAccountDetail(username));
@@ -107,23 +108,33 @@ export default async function AccountPage({
   // visitor's language even when the full report exists only in the other one.
   // Empty for legacy rows — those still carry the one-liner inline in `roast`.
   const roastLine = lang === "en" ? d.roast_line.en : d.roast_line.zh;
-  const similar = await getSimilarAccounts(d.username, d.final_score, d.sub_scores);
+  const [similar, comments] = await Promise.all([
+    getSimilarAccounts(d.username, d.final_score, d.sub_scores),
+    getProfileComments(d.username),
+  ]);
 
   return (
-    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-5 py-14 sm:py-20">
-      <JsonLd
-        data={profileJsonLd({
-          username: d.username,
-          displayName: d.display_name,
-          avatarUrl: d.avatar_url,
-          profileUrl: d.profile_url,
-          score: d.final_score,
-          locale,
-        })}
+    <main className="relative isolate flex w-full flex-1 justify-center overflow-hidden px-5 py-14 sm:py-20">
+      <FloatingCommentBubbles
+        key={d.username}
+        lang={lang}
+        profileUsername={d.username}
+        initialComments={comments}
       />
-      <Link href="/leaderboard" className="text-sm text-zinc-400 hover:text-zinc-200">
-        {t("back")}
-      </Link>
+      <div className="relative z-10 flex w-full max-w-2xl flex-col">
+        <JsonLd
+          data={profileJsonLd({
+            username: d.username,
+            displayName: d.display_name,
+            avatarUrl: d.avatar_url,
+            profileUrl: d.profile_url,
+            score: d.final_score,
+            locale,
+          })}
+        />
+        <Link href="/leaderboard" className="text-sm text-zinc-400 hover:text-zinc-200">
+          {t("back")}
+        </Link>
 
       {/* Header card */}
       <div
@@ -285,6 +296,7 @@ export default async function AccountPage({
           {t("selfCta")}
         </Link>
       </footer>
+      </div>
     </main>
   );
 }

--- a/src/app/api/profile-comments/[username]/route.ts
+++ b/src/app/api/profile-comments/[username]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, authConfigured } from "@/lib/auth";
+import {
+  normalizeCommentText,
+  normalizeGitHubUsername,
+  type CreateProfileCommentResponse,
+  type ProfileCommentAuthor,
+  type ProfileCommentsResponse,
+} from "@/lib/comments";
+import { createProfileComment, getProfileComments } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
+
+interface CreateProfileCommentBody {
+  text?: unknown;
+  anonymous?: unknown;
+}
+
+function jsonNoStore(body: unknown, init?: ResponseInit) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { ...NO_STORE_HEADERS, ...init?.headers },
+  });
+}
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: Promise<{ username: string }> },
+) {
+  const { username } = await ctx.params;
+  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  if (!target) {
+    return jsonNoStore({ error: "invalid_username" }, { status: 400 });
+  }
+
+  const comments = await getProfileComments(target);
+  return jsonNoStore({ comments } satisfies ProfileCommentsResponse);
+}
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ username: string }> },
+) {
+  const { username } = await ctx.params;
+  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  if (!target) {
+    return jsonNoStore({ error: "invalid_username" }, { status: 400 });
+  }
+
+  let body: CreateProfileCommentBody;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonNoStore({ error: "invalid_body" }, { status: 400 });
+  }
+
+  const text = normalizeCommentText(body.text);
+  if (!text) {
+    return jsonNoStore({ error: "empty_comment" }, { status: 400 });
+  }
+
+  const anonymous = body.anonymous !== false;
+  const session = authConfigured() ? await auth() : null;
+  const viewerUsername = normalizeGitHubUsername(session?.user.login ?? "");
+  const author: ProfileCommentAuthor =
+    !anonymous && viewerUsername
+      ? { type: "github", username: viewerUsername, avatarUrl: session?.user.image ?? null }
+      : { type: "anonymous" };
+
+  const comment = await createProfileComment({
+    targetUsername: target,
+    text,
+    author,
+    authorGithubId: author.type === "github" ? session?.user.githubId : undefined,
+  });
+
+  if (!comment) {
+    return jsonNoStore({ error: "comments_unavailable" }, { status: 503 });
+  }
+
+  return jsonNoStore({ comment } satisfies CreateProfileCommentResponse, { status: 201 });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,6 +75,41 @@ body {
   animation: pop-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+@keyframes floating-comment {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0.45rem, -0.65rem, 0);
+  }
+}
+
+.floating-comment-bubble {
+  animation: floating-comment 10s ease-in-out infinite;
+}
+
+@keyframes mobile-danmaku {
+  0% {
+    transform: translate3d(105vw, 0, 0);
+  }
+  100% {
+    transform: translate3d(calc(-100% - 105vw), 0, 0);
+  }
+}
+
+.mobile-danmaku-comment {
+  animation: mobile-danmaku 20s linear infinite;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-comment-bubble,
+  .mobile-danmaku-comment {
+    animation: none;
+  }
+}
+
 @keyframes blink {
   50% {
     opacity: 0;

--- a/src/components/FloatingCommentBubbles.tsx
+++ b/src/components/FloatingCommentBubbles.tsx
@@ -1,0 +1,506 @@
+"use client";
+
+import { type CSSProperties, type FormEvent, useState } from "react";
+import { Link } from "@/i18n/navigation";
+import {
+  COMMENT_MAX_LENGTH,
+  normalizeCommentText,
+  type CreateProfileCommentResponse,
+  type ProfileComment,
+} from "@/lib/comments";
+
+type FloatingCommentAuthor =
+  | { type: "anonymous" }
+  | { type: "github"; username: string; avatarUrl?: string | null };
+
+interface FloatingCommentBubble {
+  side: "left" | "right";
+  author: FloatingCommentAuthor;
+  text: string;
+  top: string;
+  laneOffset: string;
+  delay: string;
+  duration: string;
+}
+
+type FloatingCommentLang = "zh" | "en";
+
+interface FloatingCommentLabels {
+  anonymous: string;
+  anonymousActive: string;
+  button: string;
+  cancel: string;
+  failed: string;
+  panelTitle: string;
+  placeholder: string;
+  send: string;
+  sending: string;
+}
+
+const INITIAL_COMMENT_BUBBLES: Record<FloatingCommentLang, FloatingCommentBubble[]> = {
+  zh: [
+    {
+      side: "left",
+      author: { type: "github", username: "gaearon" },
+      text: "这才是开源履历该有的含金量",
+      top: "3.5rem",
+      laneOffset: "1.4rem",
+      delay: "-1.2s",
+      duration: "9s",
+    },
+    {
+      side: "left",
+      author: { type: "anonymous" },
+      text: "项目质量很硬",
+      top: "16rem",
+      laneOffset: "4.6rem",
+      delay: "-4.1s",
+      duration: "11s",
+    },
+    {
+      side: "left",
+      author: { type: "github", username: "yyx990803" },
+      text: "社区影响力拉满",
+      top: "28rem",
+      laneOffset: "0rem",
+      delay: "-2.6s",
+      duration: "10s",
+    },
+    {
+      side: "left",
+      author: { type: "anonymous" },
+      text: "这个标签比简历还会说话",
+      top: "47rem",
+      laneOffset: "5.8rem",
+      delay: "-6.5s",
+      duration: "12s",
+    },
+    {
+      side: "right",
+      author: { type: "github", username: "sindresorhus" },
+      text: "一看就是榜单常驻选手",
+      top: "6.8rem",
+      laneOffset: "3.2rem",
+      delay: "-3s",
+      duration: "10.5s",
+    },
+    {
+      side: "right",
+      author: { type: "anonymous" },
+      text: "分数和关注度都站得住",
+      top: "19rem",
+      laneOffset: "0.6rem",
+      delay: "-5.4s",
+      duration: "9.5s",
+    },
+    {
+      side: "right",
+      author: { type: "github", username: "torvalds" },
+      text: "值得点进 GitHub 看看",
+      top: "36rem",
+      laneOffset: "4.8rem",
+      delay: "-1.8s",
+      duration: "12.5s",
+    },
+    {
+      side: "right",
+      author: { type: "anonymous" },
+      text: "这个评分很难不服",
+      top: "54rem",
+      laneOffset: "1.8rem",
+      delay: "-7.2s",
+      duration: "11.5s",
+    },
+  ],
+  en: [
+    {
+      side: "left",
+      author: { type: "github", username: "gaearon" },
+      text: "This open-source track record has real weight",
+      top: "3.5rem",
+      laneOffset: "1.4rem",
+      delay: "-1.2s",
+      duration: "9s",
+    },
+    {
+      side: "left",
+      author: { type: "anonymous" },
+      text: "Project quality checks out",
+      top: "16rem",
+      laneOffset: "4.6rem",
+      delay: "-4.1s",
+      duration: "11s",
+    },
+    {
+      side: "left",
+      author: { type: "github", username: "yyx990803" },
+      text: "Community signal is loud",
+      top: "28rem",
+      laneOffset: "0rem",
+      delay: "-2.6s",
+      duration: "10s",
+    },
+    {
+      side: "left",
+      author: { type: "anonymous" },
+      text: "Those tags say more than a resume",
+      top: "47rem",
+      laneOffset: "5.8rem",
+      delay: "-6.5s",
+      duration: "12s",
+    },
+    {
+      side: "right",
+      author: { type: "github", username: "sindresorhus" },
+      text: "Looks like a Hall of Fame regular",
+      top: "6.8rem",
+      laneOffset: "3.2rem",
+      delay: "-3s",
+      duration: "10.5s",
+    },
+    {
+      side: "right",
+      author: { type: "anonymous" },
+      text: "Score and attention both hold up",
+      top: "19rem",
+      laneOffset: "0.6rem",
+      delay: "-5.4s",
+      duration: "9.5s",
+    },
+    {
+      side: "right",
+      author: { type: "github", username: "torvalds" },
+      text: "Worth opening the GitHub profile",
+      top: "36rem",
+      laneOffset: "4.8rem",
+      delay: "-1.8s",
+      duration: "12.5s",
+    },
+    {
+      side: "right",
+      author: { type: "anonymous" },
+      text: "Hard to argue with this score",
+      top: "54rem",
+      laneOffset: "1.8rem",
+      delay: "-7.2s",
+      duration: "11.5s",
+    },
+  ],
+};
+
+const ANONYMOUS_LABEL: Record<FloatingCommentLang, string> = {
+  zh: "匿名",
+  en: "Anonymous",
+};
+
+const COMMENT_LABELS: Record<FloatingCommentLang, FloatingCommentLabels> = {
+  zh: {
+    anonymous: "匿名",
+    anonymousActive: "匿名",
+    button: "留言",
+    cancel: "取消",
+    failed: "发送失败，稍后再试",
+    panelTitle: "发送留言",
+    placeholder: "写点狠的 🔥",
+    send: "发送",
+    sending: "发送中",
+  },
+  en: {
+    anonymous: "Anonymous",
+    anonymousActive: "Anonymous",
+    button: "Message",
+    cancel: "Cancel",
+    failed: "Failed to send. Try again.",
+    panelTitle: "Leave a message",
+    placeholder: "Write a quick note 🔥",
+    send: "Send",
+    sending: "Sending",
+  },
+};
+
+const FLOATING_COMMENT_SIDE_ROOM = "calc((100vw - 42rem) / 2 - 2rem)";
+const FLOATING_COMMENT_CENTER_GAP = "1rem";
+const FLOATING_COMMENT_CENTER_HALF_WIDTH = "21rem";
+const MOBILE_DANMAKU_MIN_COUNT = 16;
+const MOBILE_DANMAKU_TOPS = [
+  "0.5rem",
+  "3rem",
+  "5.5rem",
+  "8rem",
+  "10.5rem",
+  "13rem",
+  "15.5rem",
+];
+
+function bubbleStyle(bubble: FloatingCommentBubble): CSSProperties {
+  const laneOffset = `min(${bubble.laneOffset}, 5vw)`;
+  const sideOffset = `calc(50% + ${FLOATING_COMMENT_CENTER_HALF_WIDTH} + ${FLOATING_COMMENT_CENTER_GAP} + ${laneOffset})`;
+
+  return {
+    top: bubble.top,
+    maxWidth: `min(14rem, calc(${FLOATING_COMMENT_SIDE_ROOM} - ${laneOffset}))`,
+    animationDelay: bubble.delay,
+    animationDuration: bubble.duration,
+    ...(bubble.side === "left" ? { right: sideOffset } : { left: sideOffset }),
+  };
+}
+
+function mobileDanmakuStyle(index: number): CSSProperties {
+  return {
+    top: MOBILE_DANMAKU_TOPS[index % MOBILE_DANMAKU_TOPS.length],
+    animationDelay: `-${(index * 2.7) % 24}s`,
+    animationDuration: `${18 + (index % 5) * 2}s`,
+  };
+}
+
+function repeatForMobileDanmaku(bubbles: FloatingCommentBubble[]): FloatingCommentBubble[] {
+  if (bubbles.length === 0) return [];
+  if (bubbles.length >= MOBILE_DANMAKU_MIN_COUNT) return bubbles;
+  return Array.from(
+    { length: MOBILE_DANMAKU_MIN_COUNT },
+    (_, index) => bubbles[index % bubbles.length],
+  );
+}
+
+function floatingCommentFromProfileComment(
+  comment: ProfileComment,
+  index: number,
+): FloatingCommentBubble {
+  const rightSide = index % 2 === 0;
+  const topSlots = ["10rem", "24rem", "41rem", "60rem", "73rem", "88rem"];
+  const laneOffsets = ["0.8rem", "4.4rem", "2.1rem", "6rem", "0rem", "3.5rem"];
+
+  return {
+    side: rightSide ? "right" : "left",
+    author: comment.author,
+    text: comment.text,
+    top: topSlots[index % topSlots.length],
+    laneOffset: laneOffsets[index % laneOffsets.length],
+    delay: "0s",
+    duration: "10s",
+  };
+}
+
+function githubAvatarUrl(author: Extract<FloatingCommentAuthor, { type: "github" }>) {
+  return author.avatarUrl ?? `https://github.com/${encodeURIComponent(author.username)}.png?size=32`;
+}
+
+function FloatingCommentAuthorLabel({
+  author,
+  lang,
+}: {
+  author: FloatingCommentAuthor;
+  lang: FloatingCommentLang;
+}) {
+  const className =
+    "mb-1.5 inline-flex max-w-full min-w-14 items-center rounded-full bg-black/35 px-2 py-0.5 text-left text-[10px] font-semibold leading-none text-orange-300/60 ring-1 ring-orange-300/10";
+
+  if (author.type === "anonymous") {
+    return <span className={className}>{ANONYMOUS_LABEL[lang]}</span>;
+  }
+
+  return (
+    <Link
+      href={`/u/${author.username}`}
+      prefetch={false}
+      className={`${className} pointer-events-auto gap-1.5 pl-1 underline-offset-2 hover:text-orange-200 hover:underline`}
+    >
+      <span
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0 rounded-full border border-orange-300/20 bg-zinc-900 bg-cover bg-center"
+        style={{ backgroundImage: `url(${githubAvatarUrl(author)})` }}
+      />
+      <span className="truncate">@{author.username}</span>
+    </Link>
+  );
+}
+
+function FloatingCommentInlineAuthor({
+  author,
+  lang,
+}: {
+  author: FloatingCommentAuthor;
+  lang: FloatingCommentLang;
+}) {
+  const className =
+    "inline-flex shrink-0 items-center rounded-full bg-black/30 px-2 py-0.5 text-[10px] font-semibold leading-none text-orange-300/70 ring-1 ring-orange-300/10";
+
+  if (author.type === "anonymous") {
+    return <span className={className}>{ANONYMOUS_LABEL[lang]}</span>;
+  }
+
+  return (
+    <Link
+      href={`/u/${author.username}`}
+      prefetch={false}
+      className={`${className} pointer-events-auto gap-1.5 pl-1 hover:text-orange-200`}
+    >
+      <span
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0 rounded-full border border-orange-300/20 bg-zinc-900 bg-cover bg-center"
+        style={{ backgroundImage: `url(${githubAvatarUrl(author)})` }}
+      />
+      <span className="max-w-20 truncate">@{author.username}</span>
+    </Link>
+  );
+}
+
+export function FloatingCommentBubbles({
+  initialComments,
+  lang,
+  profileUsername,
+}: {
+  initialComments: ProfileComment[];
+  lang: FloatingCommentLang;
+  profileUsername: string;
+}) {
+  const labels = COMMENT_LABELS[lang];
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [anonymous, setAnonymous] = useState(true);
+  const [comments, setComments] = useState<ProfileComment[]>(initialComments);
+  const [sending, setSending] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const bubbles = [
+    ...INITIAL_COMMENT_BUBBLES[lang],
+    ...comments.map(floatingCommentFromProfileComment),
+  ];
+  const mobileDanmakuBubbles = repeatForMobileDanmaku(bubbles);
+  const trimmedDraft = normalizeCommentText(draft);
+  const canSend = Boolean(trimmedDraft) && !sending;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!trimmedDraft || sending) return;
+
+    setSending(true);
+    setFailed(false);
+    try {
+      const response = await fetch(
+        `/api/profile-comments/${encodeURIComponent(profileUsername)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ anonymous, text: trimmedDraft }),
+        },
+      );
+      if (!response.ok) throw new Error("comment_failed");
+
+      const payload = (await response.json()) as CreateProfileCommentResponse;
+      setComments((current) => [...current, payload.comment]);
+      setDraft("");
+      setOpen(false);
+    } catch {
+      setFailed(true);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="pointer-events-none absolute inset-0 z-0 hidden lg:block">
+        {bubbles.map((bubble, index) => (
+          <div
+            key={`${bubble.side}-${index}`}
+            className="floating-comment-bubble absolute w-max min-w-0 max-w-[14rem]"
+            style={bubbleStyle(bubble)}
+          >
+            <div className="flex w-full min-w-0 flex-col items-start rounded-2xl border border-orange-300/15 bg-zinc-950/60 px-3.5 py-2.5 text-orange-200/90 shadow-[0_16px_44px_rgba(0,0,0,0.42)] ring-1 ring-white/[0.05] backdrop-blur-sm">
+              <FloatingCommentAuthorLabel author={bubble.author} lang={lang} />
+              <span className="max-w-full whitespace-normal break-words text-xs font-semibold leading-relaxed text-orange-200 [overflow-wrap:anywhere] sm:text-sm">
+                {bubble.text}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="pointer-events-none fixed inset-x-0 top-16 z-20 h-72 overflow-hidden lg:hidden">
+        {mobileDanmakuBubbles.map((bubble, index) => (
+          <div
+            key={`mobile-${bubble.side}-${index}-${bubble.text}`}
+            className="mobile-danmaku-comment absolute left-0 inline-flex max-w-[88vw]"
+            style={mobileDanmakuStyle(index)}
+          >
+            <div className="inline-flex max-w-[88vw] items-center gap-2 rounded-full border border-orange-300/15 bg-zinc-950/60 px-2.5 py-1.5 text-orange-200/90 shadow-[0_10px_30px_rgba(0,0,0,0.35)] ring-1 ring-white/[0.05] backdrop-blur-sm">
+              <FloatingCommentInlineAuthor author={bubble.author} lang={lang} />
+              <span className="min-w-0 truncate text-xs font-semibold text-orange-200">
+                {bubble.text}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="fixed bottom-5 right-5 z-50 flex flex-col items-end gap-3">
+        {open && (
+          <form
+            onSubmit={handleSubmit}
+            className="w-[min(calc(100vw-2.5rem),22rem)] rounded-2xl border border-orange-300/20 bg-zinc-950/95 p-4 text-left shadow-2xl ring-1 ring-white/[0.06] backdrop-blur"
+          >
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h2 className="text-sm font-bold text-orange-200">{labels.panelTitle}</h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-full px-2 py-1 text-xs text-zinc-500 hover:bg-white/10 hover:text-zinc-200"
+              >
+                {labels.cancel}
+              </button>
+            </div>
+
+            <textarea
+              value={draft}
+              onChange={(event) => {
+                setDraft(Array.from(event.target.value).slice(0, COMMENT_MAX_LENGTH).join(""));
+                setFailed(false);
+              }}
+              rows={4}
+              maxLength={COMMENT_MAX_LENGTH}
+              placeholder={labels.placeholder}
+              className="w-full resize-none rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm leading-relaxed text-orange-100 outline-none placeholder:text-zinc-600 focus:border-orange-400/50"
+            />
+
+            <div className="mt-3 flex items-center justify-between gap-3">
+              <button
+                type="button"
+                aria-pressed={anonymous}
+                onClick={() => setAnonymous((value) => !value)}
+                className="rounded-full border border-orange-300/20 bg-black/35 px-3 py-1 text-xs font-semibold text-orange-200/80 hover:bg-orange-950/40 aria-pressed:bg-orange-500/15 aria-pressed:text-orange-100"
+              >
+                {anonymous ? labels.anonymousActive : labels.anonymous}
+              </button>
+              <span className="text-[11px] tabular-nums text-zinc-600">
+                {Array.from(draft).length}/{COMMENT_MAX_LENGTH}
+              </span>
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-3">
+              {failed ? (
+                <span className="text-xs text-red-300/80">{labels.failed}</span>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+              <button
+                type="submit"
+                disabled={!canSend}
+                className="rounded-full bg-orange-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-orange-950/30 hover:bg-orange-500 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {sending ? labels.sending : labels.send}
+              </button>
+            </div>
+          </form>
+        )}
+
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="rounded-full border border-orange-300/30 bg-orange-600 px-4 py-2 text-sm font-bold text-white shadow-[0_18px_50px_rgba(0,0,0,0.45)] hover:bg-orange-500"
+        >
+          {labels.button}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -89,6 +89,46 @@ describe("getArchivedRoast", () => {
   });
 });
 
+describe("profile comments", () => {
+  it("stores anonymous and GitHub comments for a profile", async () => {
+    const anonymous = await db.createProfileComment({
+      targetUsername: "Torvalds",
+      text: "硬核 🔥",
+      author: { type: "anonymous" },
+    });
+    const github = await db.createProfileComment({
+      targetUsername: "torvalds",
+      text: "Legend status",
+      author: {
+        type: "github",
+        username: "yyx990803",
+        avatarUrl: "https://avatars.githubusercontent.com/u/499550",
+      },
+      authorGithubId: 499550,
+    });
+
+    expect(anonymous).toMatchObject({
+      targetUsername: "torvalds",
+      author: { type: "anonymous" },
+      text: "硬核 🔥",
+    });
+    expect(github).toMatchObject({
+      targetUsername: "torvalds",
+      author: {
+        type: "github",
+        username: "yyx990803",
+        avatarUrl: "https://avatars.githubusercontent.com/u/499550",
+      },
+      text: "Legend status",
+    });
+
+    await expect(db.getProfileComments("TORVALDS")).resolves.toMatchObject([
+      { author: { type: "anonymous" }, text: "硬核 🔥" },
+      { author: { type: "github", username: "yyx990803" }, text: "Legend status" },
+    ]);
+  });
+});
+
 describe("getTrendingLeaderboard", () => {
   it("counts unique lookups from the last seven days only", async () => {
     const now = Date.now();

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -1,0 +1,38 @@
+export const COMMENT_MAX_LENGTH = 80;
+
+const USERNAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+
+export type ProfileCommentAuthor =
+  | { type: "anonymous" }
+  | { type: "github"; username: string; avatarUrl?: string | null };
+
+export interface ProfileComment {
+  id: string;
+  targetUsername: string;
+  author: ProfileCommentAuthor;
+  text: string;
+  createdAt: number;
+}
+
+export interface ProfileCommentsResponse {
+  comments: ProfileComment[];
+}
+
+export interface CreateProfileCommentResponse {
+  comment: ProfileComment;
+}
+
+export function normalizeGitHubUsername(input: string): string | null {
+  let value = input.trim();
+  const profileUrl = value.match(/github\.com\/([^/?#]+)/i);
+  if (profileUrl) value = profileUrl[1] ?? "";
+  value = value.replace(/^@/, "");
+  return USERNAME_RE.test(value) ? value.toLowerCase() : null;
+}
+
+export function normalizeCommentText(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const compact = input.replace(/\s+/g, " ").trim();
+  const text = Array.from(compact).slice(0, COMMENT_MAX_LENGTH).join("");
+  return text.length > 0 ? text : null;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -9,12 +9,18 @@
  */
 
 import { Client, createClient } from "@libsql/client";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   bypassGeneratedCaches,
   ROAST_CACHE_VERSION,
   SCORE_CACHE_VERSION,
 } from "./cache-version";
+import {
+  normalizeCommentText,
+  normalizeGitHubUsername,
+  type ProfileComment,
+  type ProfileCommentAuthor,
+} from "./comments";
 import { computeTrendingScore, rankTrending } from "./hotness";
 import type { Lang } from "./lang";
 import type { PaperDims, PaperMode, PaperTierKey } from "./paper-types";
@@ -160,6 +166,19 @@ function ensureSchema(db: Client): Promise<void> {
              last_login  INTEGER NOT NULL
            )`,
           `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_login ON users(login)`,
+          `CREATE TABLE IF NOT EXISTS profile_comments (
+             id                TEXT PRIMARY KEY,
+             target_username   TEXT NOT NULL,
+             body              TEXT NOT NULL,
+             author_kind       TEXT NOT NULL,
+             author_github_id  INTEGER,
+             author_login      TEXT,
+             author_avatar_url TEXT,
+             hidden            INTEGER NOT NULL DEFAULT 0,
+             created_at        INTEGER NOT NULL
+           )`,
+          `CREATE INDEX IF NOT EXISTS idx_profile_comments_target_created
+             ON profile_comments(target_username, created_at DESC)`,
           // arXiv 论文锐评: one row per scored paper (score fixed once computed).
           `CREATE TABLE IF NOT EXISTS papers (
              arxiv_id      TEXT PRIMARY KEY,
@@ -908,6 +927,116 @@ export async function upsertUser(u: UserUpsert): Promise<void> {
     });
   } catch (e) {
     console.error("upsertUser failed:", e);
+  }
+}
+
+interface CreateProfileCommentInput {
+  targetUsername: string;
+  text: string;
+  author: ProfileCommentAuthor;
+  authorGithubId?: number;
+}
+
+function toProfileComment(row: Record<string, unknown>): ProfileComment {
+  const authorLogin =
+    typeof row.author_login === "string" && row.author_login
+      ? row.author_login
+      : null;
+  const authorAvatarUrl =
+    typeof row.author_avatar_url === "string" && row.author_avatar_url
+      ? row.author_avatar_url
+      : null;
+  const author: ProfileCommentAuthor =
+    row.author_kind === "github" && authorLogin
+      ? { type: "github", username: authorLogin, avatarUrl: authorAvatarUrl }
+      : { type: "anonymous" };
+
+  return {
+    id: String(row.id),
+    targetUsername: String(row.target_username),
+    author,
+    text: String(row.body),
+    createdAt: Number(row.created_at),
+  };
+}
+
+export async function getProfileComments(
+  targetUsername: string,
+  limit = 24,
+): Promise<ProfileComment[]> {
+  const db = getClient();
+  if (!db) return [];
+  const target = normalizeGitHubUsername(targetUsername);
+  if (!target) return [];
+  try {
+    await ensureSchema(db);
+    const res = await db.execute({
+      sql: `SELECT id, target_username, body, author_kind, author_login,
+                   author_avatar_url, created_at
+            FROM profile_comments
+            WHERE target_username = ? AND hidden = 0
+            ORDER BY created_at DESC
+            LIMIT ?`,
+      args: [target, Math.max(1, Math.min(100, limit))],
+    });
+    return res.rows
+      .map((row) => toProfileComment(row as Record<string, unknown>))
+      .reverse();
+  } catch (e) {
+    console.error("getProfileComments failed:", e);
+    return [];
+  }
+}
+
+export async function createProfileComment(
+  input: CreateProfileCommentInput,
+): Promise<ProfileComment | null> {
+  const db = getClient();
+  if (!db) return null;
+  const target = normalizeGitHubUsername(input.targetUsername);
+  const text = normalizeCommentText(input.text);
+  if (!target || !text) return null;
+
+  const githubAuthor =
+    input.author.type === "github"
+      ? normalizeGitHubUsername(input.author.username)
+      : null;
+  const authorKind = githubAuthor ? "github" : "anonymous";
+  const authorAvatarUrl =
+    input.author.type === "github" ? input.author.avatarUrl ?? null : null;
+  const now = Date.now();
+  const id = randomUUID();
+
+  try {
+    await ensureSchema(db);
+    await db.execute({
+      sql: `INSERT INTO profile_comments
+              (id, target_username, body, author_kind, author_github_id,
+               author_login, author_avatar_url, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        id,
+        target,
+        text,
+        authorKind,
+        authorKind === "github" ? input.authorGithubId ?? null : null,
+        githubAuthor,
+        authorKind === "github" ? authorAvatarUrl : null,
+        now,
+      ],
+    });
+    return {
+      id,
+      targetUsername: target,
+      author: githubAuthor
+        ? { type: "github", username: githubAuthor, avatarUrl: authorAvatarUrl }
+        : { type: "anonymous" },
+      text,
+      createdAt: now,
+    };
+  } catch (e) {
+    console.error("createProfileComment failed:", e);
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add persistent profile comments backed by a `profile_comments` libSQL table and `/api/profile-comments/[username]` GET/POST endpoints.
- Add floating profile comment bubbles on account pages with anonymous/GitHub authors, GitHub micro avatars, and clickable `@username` links.
- Render desktop comments as loose side comment walls and mobile comments as repeated right-to-left danmaku.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Generated files / codegen / DB baseline
- Generated files: none
- GraphQL codegen: none
- DB baseline updates: none
- Runtime schema update: adds `profile_comments` via existing `ensureSchema` path
