### PR TITLE
feat: show percentile with one decimal

### DIFF
--- a/src/app/api/card/[username]/route.tsx
+++ b/src/app/api/card/[username]/route.tsx
@@ -274,7 +274,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ username: strin
         </div>
         {beat !== null && (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
-            <span style={{ fontSize: 64, fontWeight: 800, color }}>{beat}%</span>
+            <span style={{ fontSize: 64, fontWeight: 800, color }}>{beat.toFixed(1)}%</span>
             <span style={{ fontSize: 22, color: "#a1a1aa" }}>ahead of devs</span>
           </div>
         )}

--- a/src/components/CopyBadge.tsx
+++ b/src/components/CopyBadge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 /** One copyable snippet row. Declared at module scope (not inside render) so it
  *  keeps a stable identity and doesn't reset state on every parent render. */
@@ -57,17 +57,25 @@ export function CopyBadge({
 }) {
   const T = useTranslations("badge");
   const [copied, setCopied] = useState<string | null>(null);
+  const [previewOrigin, setPreviewOrigin] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPreviewOrigin(window.location.origin);
+  }, []);
 
   const base = baseUrl.replace(/\/$/, "");
+  const previewBase = (previewOrigin ?? base).replace(/\/$/, "");
   const pageUrl = `${base}/u/${username}`;
   const badgeUrl = `${base}/api/badge/${username}`;
   const cardUrl = `${base}/api/card/${username}`;
+  const badgePreviewUrl = `${previewBase}/api/badge/${username}`;
+  const cardPreviewUrl = `${previewBase}/api/card/${username}`;
   const v =
     version !== undefined && version !== null
       ? `?v=${encodeURIComponent(String(version))}`
       : "";
-  const badgePreview = `${badgeUrl}${v}`;
-  const cardPreview = `${cardUrl}${v}`;
+  const badgePreview = `${badgePreviewUrl}${v}`;
+  const cardPreview = `${cardPreviewUrl}${v}`;
 
   const badgeAlt = T("badgeAlt");
   const cardAlt = T("cardAlt");

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -184,8 +184,8 @@ export function Roaster() {
     [username, token, scanning, roasting, runRoast, t, tScan],
   );
 
-  const beatText =
-    percentile && percentile.beat !== null ? t("shareBeat", { beat: percentile.beat }) : "";
+  const beatValue = percentile?.beat == null ? null : percentile.beat.toFixed(1);
+  const beatText = beatValue !== null ? t("shareBeat", { beat: beatValue }) : "";
   const shareText =
     scan && display
       ? t("shareText", {
@@ -396,7 +396,7 @@ export function Roaster() {
               ) : (
                 <div className="mt-3 text-sm">
                   {t.rich("beatLine", {
-                    beat: percentile.beat,
+                    beat: percentile.beat.toFixed(1),
                     total: percentile.total,
                     hl: (c) => <span className={`font-semibold ${style.text}`}>{c}</span>,
                     muted: (c) => <span className="text-zinc-400">{c}</span>,

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -98,7 +98,7 @@ export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(function Sha
         </div>
         {beat !== null && (
           <div className="mb-1 text-right">
-            <div className={`text-4xl font-black ${style.text}`}>{beat}%</div>
+            <div className={`text-4xl font-black ${style.text}`}>{beat.toFixed(1)}%</div>
             <div className="text-xs text-zinc-400">{t("beatLabel")}</div>
           </div>
         )}

--- a/src/lib/__tests__/percentile.test.ts
+++ b/src/lib/__tests__/percentile.test.ts
@@ -7,10 +7,10 @@ describe("beatPercent", () => {
     expect(beatPercent(0, 1)).toBeNull();
   });
 
-  it("computes the share of accounts scored below you, rounded", () => {
+  it("computes the share of accounts scored below you, rounded to 1 decimal", () => {
     expect(beatPercent(87, 100)).toBe(87);
-    expect(beatPercent(1, 3)).toBe(33); // 33.33 → 33
-    expect(beatPercent(2, 3)).toBe(67); // 66.66 → 67
+    expect(beatPercent(1, 3)).toBe(33.3); // 33.33 -> 33.3
+    expect(beatPercent(2, 3)).toBe(66.7); // 66.66 -> 66.7
   });
 
   it("beats 0% when nobody is below you, 100% when everyone else is", () => {

--- a/src/lib/percentile.ts
+++ b/src/lib/percentile.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * Percent of ranked accounts you beat: `below / total * 100`, rounded.
+ * Percent of ranked accounts you beat: `below / total * 100`, rounded to 1 decimal.
  *
  * `total` includes yourself (your row is upserted before the count), `below` is
  * the number of accounts scoring strictly lower. Returns `null` when you are the
@@ -12,5 +12,5 @@
 export function beatPercent(below: number, total: number): number | null {
   if (total <= 1) return null;
   const pct = (below / total) * 100;
-  return Math.max(0, Math.min(100, Math.round(pct)));
+  return Math.max(0, Math.min(100, Math.round(pct * 10) / 10));
 }


### PR DESCRIPTION
## What changed

- Round developer percentile / "ahead of" values to one decimal place.
- Render percentile values with one decimal in the roast result, saved share card, and embeddable OG card.
- Keep badge/card preview images on the current origin while preserving the public githubroast.dev URLs in copied README snippets.

## Why

Percentile math was rounded to whole numbers, so shares like 1/3 appeared as 33% instead of 33.3%. With tens of thousands of participants now involved, the top hundred or so accounts display a figure of "100% ahead of devs." which is not precise.

Before:

<img width="552" height="311" alt="image" src="https://github.com/user-attachments/assets/1ed2c9fb-67f8-48c1-afbc-e1744c671e2c" />

After:

<img width="626" height="353" alt="image" src="https://github.com/user-attachments/assets/08839e43-b08e-4f84-8256-4ebb9886721d" />

The README card preview also reused the public embed base URL, which made local/dev previews fetch stale production images instead of the freshly scored local card.

## Validation

- `pnpm typecheck`
- `pnpm vitest run src/lib/__tests__/percentile.test.ts`
- Local browser check: `gaearon` displayed `超越了 33.3% 的开发者（共 3 人受审）`
- Local card preview loaded from `http://localhost:3002/api/card/gaearon?v=96.4` and rendered `33.3% ahead of devs`