### PR TITLE
ci: 加 build/typecheck/lint/test 校验,合并前拦住生产构建崩溃

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# 在 PR 和 push 到 main 时跑全套检查,合并前拦住会让生产构建崩溃的改动。
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# 同一分支的旧 run 自动取消,省 CI 时间。
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ pnpm dev
 | `pnpm typecheck` | `tsc --noEmit` |
 | `pnpm lint` | ESLint |
 
+### Continuous integration (CI)
+
+Every pull request and every push to `main` runs [`.github/workflows/ci.yml`](./.github/workflows/ci.yml), which executes the full gate in order: **typecheck → lint → test → build**. The goal is to catch build-breaking regressions (type errors, bad imports, build-time failures, broken tests) *before* they reach a production deploy.
+
+**Caveat — environment-specific failures aren't always reproducible in CI.** CI has no Turso credentials, so DB-backed code paths (e.g. `getClient()`) short-circuit to empty and run instantly. A failure that only manifests under production data/connectivity — like the `/sitemap.xml` route that timed out doing a full-table scan during build-time prerender — will *not* surface here. Those are guarded at the code level instead (that route was moved to `force-dynamic` so it renders at request time, not build time). Treat CI as the net for the common case, not a substitute for production-like verification.
+
 ## Environment variables
 
 See [`.env.example`](./.env.example). The minimum to run is `GITHUB_TOKEN` + `LLM_API_KEY` (defaults to StepFun, OpenAI-compatible; swap in any OpenAI-compatible service). Cache, rate limiting, human verification, GitHub login, and the leaderboard **degrade silently** when unconfigured (fine for local). Configure everything for production.

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,6 +42,12 @@ pnpm dev
 | `pnpm typecheck` | `tsc --noEmit` |
 | `pnpm lint` | ESLint |
 
+### 持续集成(CI)
+
+每个 Pull Request 以及每次 push 到 `main`,都会运行 [`.github/workflows/ci.yml`](./.github/workflows/ci.yml),按顺序跑完整套关卡:**typecheck → lint → test → build**。目的是在改动**合并进生产部署之前**,就拦住会让构建崩溃的回归(类型错误、import 写错、构建期报错、测试挂掉)。
+
+**注意 —— 环境相关的崩溃 CI 未必能复现。** CI 没有 Turso 凭据,所以依赖数据库的代码路径(如 `getClient()`)会短路返回空、秒级跑完。只有在生产数据量/连接下才暴露的问题——比如 `/sitemap.xml` 在构建期预渲染时做全表扫描而超时——在这里**不会**出现。这类问题靠代码层兜底(该路由已改为 `force-dynamic`,在请求时渲染而非构建时)。把 CI 当作覆盖常见情况的网,而不是生产级验证的替代品。
+
 ## 环境变量
 
 见 [`.env.example`](./.env.example)。最小可跑只需 `GITHUB_TOKEN` + `LLM_API_KEY`(默认 StepFun 阶跃,OpenAI 兼容;可换任意 OpenAI 兼容服务);缓存、限流、人机校验、GitHub 登录、排行榜在未配置时会**静默降级**(适合本地)。生产强烈建议全配齐。

--- a/src/components/CopyBadge.tsx
+++ b/src/components/CopyBadge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 
 /** One copyable snippet row. Declared at module scope (not inside render) so it
  *  keeps a stable identity and doesn't reset state on every parent render. */
@@ -57,11 +57,14 @@ export function CopyBadge({
 }) {
   const T = useTranslations("badge");
   const [copied, setCopied] = useState<string | null>(null);
-  const [previewOrigin, setPreviewOrigin] = useState<string | null>(null);
-
-  useEffect(() => {
-    setPreviewOrigin(window.location.origin);
-  }, []);
+  // Read the browser origin without an effect: server snapshot is null, client
+  // snapshot is the real origin. Avoids a hydration mismatch and the
+  // setState-in-effect anti-pattern. No external updates, so subscribe is a noop.
+  const previewOrigin = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => null,
+  );
 
   const base = baseUrl.replace(/\/$/, "");
   const previewBase = (previewOrigin ?? base).replace(/\/$/, "");


### PR DESCRIPTION
## 背景
生产构建因 `/sitemap.xml` 全表扫描查询超 60s 而崩溃(已在 main `575589b` 紧急修复代码)。但没有 CI,这类「构建崩了」的回归只能等到部署才发现。

## 改动
- **`.github/workflows/ci.yml`**:在 PR 和 push 到 main 时跑 `typecheck → lint → test → build`,合并前就能拦住绝大多数构建期回归。
- **`CopyBadge.tsx`**:修掉 main 上已存在的 `react-hooks/set-state-in-effect` lint 报错(改用 `useSyncExternalStore` 读 `window.location.origin`,行为不变),让 lint 步骤能纳入 CI 且全绿。

## 说明 / 局限
- 本次具体的崩溃是**环境相关**(生产连了 Turso、数据量大才超时);普通 CI 无 DB 凭据,`getClient()` 秒返回空,未必能复现这一例。真正堵住这一类的是已合并的 `force-dynamic` 代码改动。
- CI 的价值在于拦住更常见的翻车:类型错误、import 写错、构建期报错、测试挂掉。

## 本地验证
typecheck ✅ / lint ✅ / test 129 passed ✅ / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)