### PR TITLE
feat(leaderboard): limit ranking queries to top 20

### DIFF
--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -15,7 +15,7 @@ import {
 // One source of truth for "how many rows a board holds". The full /leaderboard
 // page wants the long list; the home page slices what it needs off the same
 // cached payload, so both share a single Redis entry per (view, window).
-export const LEADERBOARD_LIMIT = 500;
+export const LEADERBOARD_LIMIT = 20;
 
 const fetchers: Record<
   LeaderboardCacheView,


### PR DESCRIPTION
## Summary

- Limit leaderboard page, API, and leaderboard JSON-LD queries to the shared top-20 leaderboard cap.
- Remove client-side pagination so leaderboard views cannot enumerate entries beyond the capped result set.
- Add 100-entry development preview data while only returning the requested capped subset to the page.
- Stabilize profile comment ordering when comments are created within the same millisecond.

## Validation

- `pnpm typecheck`
- `pnpm test` (14 files / 128 tests passed)
- `pnpm lint`
- `curl http://localhost:3001/leaderboard?view=heat` only includes `mock-dev-001` through `mock-dev-020`.

## Generated Files

No generated files, GraphQL codegen, or DB baseline updates included.