### PR TITLE
fix: replace hardcoded githubroast.dev with dynamic SITE_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-.env
+.env.playwright-cli/

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -6,6 +6,7 @@ import { DeveloperCount } from "@/components/DeveloperCount";
 import { HomeLeaderboard } from "@/components/HomeLeaderboard";
 import { Roaster } from "@/components/Roaster";
 import type { TierKey } from "@/lib/tier";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-dynamic";
 
@@ -48,10 +49,10 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           {t("subtitle")}
         </p>
         <a
-          href="https://githubroast.dev"
+          href={SITE_URL}
           className="mt-2 text-sm font-bold tracking-wide text-orange-400 hover:text-orange-300"
         >
-          githubroast.dev
+          {SITE_URL.replace(/^https?:\/\//, "")}
         </a>
         <p className="mt-3 max-w-md text-zinc-400">{t("tagline")}</p>
         <DeveloperCount />
@@ -87,8 +88,8 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           })}
         </p>
         <p className="mt-2">
-          <a href="https://githubroast.dev" className="font-bold text-orange-400 hover:text-orange-300">
-            githubroast.dev
+          <a href={SITE_URL} className="font-bold text-orange-400 hover:text-orange-300">
+            {SITE_URL.replace(/^https?:\/\//, "")}
           </a>
         </p>
       </footer>

--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -58,8 +58,8 @@ export async function generateMetadata({
   });
   const tags = locale === "en" ? d.tags.en : d.tags.zh;
   const description = tags.length
-    ? t("descWithTags", { tags: tags.map((x) => `#${x}`).join(" "), username: d.username })
-    : t("descPlain", { username: d.username });
+    ? t("descWithTags", { tags: tags.map((x) => `#${x}`).join(" "), username: d.username, siteUrl: SITE_URL.replace(/^https?:\/\//, "") })
+    : t("descPlain", { username: d.username, siteUrl: SITE_URL.replace(/^https?:\/\//, "") });
   // The flex card doubles as the social preview image (resolved absolute via
   // metadataBase in layout.tsx) — so shared /u links render a rich card.
   const image = `/api/card/${d.username}`;

--- a/src/app/api/card/[username]/route.tsx
+++ b/src/app/api/card/[username]/route.tsx
@@ -4,6 +4,7 @@ import { getAccountDetail, getPercentile } from "@/lib/db";
 import { BADGE_COLOR, TIER_EN, TIER_LABEL_EN } from "@/lib/badge";
 import { beatPercent } from "@/lib/percentile";
 import { SPONSOR } from "@/lib/sponsor";
+import { SITE_URL } from "@/lib/site";
 import { tierAvatarFrame } from "@/lib/tier";
 import type { TierAvatarFramePlacement } from "@/lib/tier";
 import type { Tier } from "@/lib/types";
@@ -155,7 +156,7 @@ function Brand({ palette }: { palette: CardPalette }) {
     <div style={{ display: "flex", justifyContent: "space-between", fontSize: 22 }}>
       <div style={{ display: "flex", color: palette.subtle }}>
         GitHub Roast ·{" "}
-        <span style={{ color: "#fb923c", fontWeight: 800, marginLeft: 6 }}>githubroast.dev</span>
+        <span style={{ color: "#fb923c", fontWeight: 800, marginLeft: 6 }}>{SITE_URL.replace(/^https?:\/\//, "")}</span>
       </div>
       <div style={{ display: "flex", color: palette.subtle }}>Powered by {SPONSOR.name}</div>
     </div>
@@ -280,7 +281,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ username: strin
             Not yet rated
           </div>
           <div style={{ display: "flex", fontSize: 26, color: palette.subtle, marginTop: 8 }}>
-            Get roasted at githubroast.dev
+            Get roasted at {SITE_URL.replace(/^https?:\/\//, "")}
           </div>
         </div>
         <Brand palette={palette} />

--- a/src/app/api/paper-card/[id]/route.tsx
+++ b/src/app/api/paper-card/[id]/route.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from "next/og";
 import { getPaper } from "@/lib/db";
 import { normalizeArxivId } from "@/lib/arxiv";
 import { SPONSOR } from "@/lib/sponsor";
+import { SITE_URL } from "@/lib/site";
 import type { PaperTierKey } from "@/lib/paper-types";
 
 export const runtime = "nodejs";
@@ -59,7 +60,7 @@ function Brand() {
     <div style={{ display: "flex", justifyContent: "space-between", fontSize: 22 }}>
       <div style={{ display: "flex", color: "#71717a" }}>
         arXiv Roast ·{" "}
-        <span style={{ color: "#fb923c", fontWeight: 800, marginLeft: 6 }}>githubroast.dev</span>
+        <span style={{ color: "#fb923c", fontWeight: 800, marginLeft: 6 }}>{SITE_URL.replace(/^https?:\/\//, "")}</span>
       </div>
       <div style={{ display: "flex", color: "#71717a" }}>Powered by {SPONSOR.name}</div>
     </div>

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -18,8 +18,7 @@ import { SponsorPill } from "./Sponsor";
 import { ShareCard } from "./ShareCard";
 import { TierAvatarFrame } from "./TierAvatarFrame";
 import { Turnstile, turnstileEnabled } from "./Turnstile";
-
-const SITE_URL = "https://githubroast.dev";
+import { SITE_URL } from "@/lib/site";
 
 interface Display {
   score: number;
@@ -193,6 +192,7 @@ export function Roaster() {
           tier: tTier(`${TIER_KEY[display.tier]}.name`),
           tierLabel: display.tierLabel,
           beat: beatText,
+          siteUrl: SITE_URL.replace(/^https?:\/\//, ""),
         })
       : "";
 
@@ -471,6 +471,7 @@ export function Roaster() {
               tierLabel={display.tierLabel}
               beat={percentile?.beat ?? null}
               tags={tags ?? { zh: [], en: [] }}
+              siteUrl={SITE_URL}
             />
           </div>
         </div>

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -15,6 +15,7 @@ interface ShareCardProps {
   tierLabel: string;
   beat: number | null;
   tags: Tags;
+  siteUrl: string;
 }
 
 /**
@@ -23,7 +24,7 @@ interface ShareCardProps {
  * URL up-front so the cross-origin image never taints the export canvas.
  */
 export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(function ShareCard(
-  { username, name, avatarUrl, score, tier, tierLabel, beat, tags },
+  { username, name, avatarUrl, score, tier, tierLabel, beat, tags, siteUrl },
   ref,
 ) {
   const t = useTranslations("shareCard");
@@ -122,7 +123,7 @@ export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(function Sha
       {/* Footer brand */}
       <div className="flex items-center justify-between text-sm">
         <span className="text-zinc-500">{t("brand")}</span>
-        <span className="font-black text-orange-400">githubroast.dev</span>
+        <span className="font-black text-orange-400">{siteUrl.replace(/^https?:\/\//, "")}</span>
       </div>
     </div>
   );

--- a/src/lib/arxiv.ts
+++ b/src/lib/arxiv.ts
@@ -9,6 +9,7 @@ import type { PaperData } from "./paper-types";
 
 const ARXIV_API = "https://export.arxiv.org/api/query";
 const S2_API = "https://api.semanticscholar.org/graph/v1/paper";
+const USER_AGENT = `${process.env.PUBLIC_SITE_URL || "githubroast.dev"} paper-review`;
 
 export class PaperNotFoundError extends Error {}
 
@@ -56,7 +57,7 @@ function tag(xml: string, name: string): string | null {
 async function fetchArxivMeta(id: string): Promise<Omit<PaperData, "citation_count" | "influential_citation_count" | "venue" | "tldr">> {
   const res = await fetchTimeout(
     `${ARXIV_API}?id_list=${encodeURIComponent(id)}&max_results=1`,
-    { headers: { "User-Agent": "githubroast.dev paper-review" } },
+    { headers: { "User-Agent": USER_AGENT } },
     12000,
   );
   if (!res.ok) throw new Error(`arXiv API ${res.status}`);
@@ -99,7 +100,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  */
 async function fetchCitations(id: string): Promise<Pick<PaperData, "citation_count" | "influential_citation_count" | "venue" | "tldr">> {
   const empty = { citation_count: null, influential_citation_count: null, venue: null, tldr: null };
-  const headers: Record<string, string> = { "User-Agent": "githubroast.dev paper-review" };
+  const headers: Record<string, string> = { "User-Agent": USER_AGENT };
   if (process.env.SEMANTIC_SCHOLAR_API_KEY) headers["x-api-key"] = process.env.SEMANTIC_SCHOLAR_API_KEY;
   const url = `${S2_API}/arXiv:${encodeURIComponent(id)}?fields=citationCount,influentialCitationCount,venue,tldr`;
   // One initial try + 2 retries: a keyless 429 usually clears within ~1–2s once

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "GitHub Roast | Score Developers & Discover the Best",
-    "description": "Drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds — then browse the leaderboard to discover the best developers worth following. Built to expose PR farmers, AI bots, and fork-hoarders. githubroast.dev",
+    "description": "Drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds — then browse the leaderboard to discover the best developers worth following. Built to expose PR farmers, AI bots, and fork-hoarders.",
     "ogTitle": "GitHub Roast | Score Developers & Discover the Best",
     "ogDescription": "Score any GitHub account and discover top developers. 0-100 value & trust score + a savage roast in 30 seconds, plus a ranked developer leaderboard.",
     "twDescription": "Score any GitHub dev + discover the best on the leaderboard. 0-100 score & savage roast in 30s.",
@@ -158,8 +158,8 @@
   },
   "detailMeta": {
     "title": "{username} — {score}/100 · {tier} | Savage GitHub Roast",
-    "descWithTags": "{tags} — see {username}'s full score report on githubroast.dev.",
-    "descPlain": "{username}'s GitHub value & trust report — githubroast.dev.",
+    "descWithTags": "{tags} — see {username}'s full score report on {siteUrl}.",
+    "descPlain": "{username}'s GitHub value & trust report — {siteUrl}.",
     "notFoundTitle": "Account not found · Savage GitHub Roast"
   },
   "roaster": {
@@ -178,7 +178,7 @@
     "pasteGithub": "📌 Pin to GitHub",
     "copied": "Copied ✓",
     "privateNote": "Note: the score uses public signals only — private contributions don't count, so active members of private orgs may be underrated.",
-    "shareText": "My GitHub just got judged: {score}/100 · {tier} ({tierLabel}){beat}. Rate yours 👉 githubroast.dev",
+    "shareText": "My GitHub just got judged: {score}/100 · {tier} ({tierLabel}){beat}. Rate yours 👉 {siteUrl}",
     "shareBeat": ", beating {beat}% of developers",
     "errEmpty": "Enter a GitHub username or profile URL first.",
     "errNeedTurnstile": "Please complete the verification below first.",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "毒舌 GitHub | 开发者评分 · 发现最佳开发者",
-    "description": "输入 GitHub 账号，30 秒得到一份 0-100 分的价值与信任评分和一句扎心毒舌点评；再逛逛名人堂榜单，发现最值得关注的优质开发者。专治刷量号、AI 机器人、收藏夹开发者。githubroast.dev",
+    "description": "输入 GitHub 账号，30 秒得到一份 0-100 分的价值与信任评分和一句扎心毒舌点评；再逛逛名人堂榜单，发现最值得关注的优质开发者。专治刷量号、AI 机器人、收藏夹开发者。",
     "ogTitle": "毒舌 GitHub | 开发者评分 · 发现最佳开发者",
     "ogDescription": "给 GitHub 账号打分，发现最佳开发者。30 秒出 0-100 分含金量评分 + 一句毒舌点评，还能逛开发者排行榜。",
     "twDescription": "30 秒给 GitHub 账号打分 + 毒舌点评，还能逛榜单发现最佳开发者。",
@@ -158,8 +158,8 @@
   },
   "detailMeta": {
     "title": "{username} — {score}/100 · {tier} | 毒舌 GitHub 评分",
-    "descWithTags": "{tags} —— 在 githubroast.dev 查看 {username} 的完整评分报告。",
-    "descPlain": "{username} 的 GitHub 价值评分报告 —— githubroast.dev。",
+    "descWithTags": "{tags} —— 在 {siteUrl} 查看 {username} 的完整评分报告。",
+    "descPlain": "{username} 的 GitHub 价值评分报告 —— {siteUrl}。",
     "notFoundTitle": "查无此号 · 毒舌 GitHub 评分"
   },
   "roaster": {
@@ -178,7 +178,7 @@
     "pasteGithub": "📌 贴到 GitHub",
     "copied": "已复制 ✓",
     "privateNote": "注：评分仅基于公开信号，私有贡献不计入，可能低估私有组织的活跃员工。",
-    "shareText": "我的 GitHub 含金量被审判了：{score}/100 · {tier}（{tierLabel}）{beat}。来测测你的 👉 githubroast.dev",
+    "shareText": "我的 GitHub 含金量被审判了：{score}/100 · {tier}（{tierLabel}）{beat}。来测测你的 👉 {siteUrl}",
     "shareBeat": "，超越了 {beat}% 的开发者",
     "errEmpty": "请先输入 GitHub 用户名或主页链接。",
     "errNeedTurnstile": "请先完成下方的人机校验。",


### PR DESCRIPTION
## Summary

Replace all hardcoded `githubroast.dev` domain references with dynamic values from the `PUBLIC_SITE_URL` environment variable, using `SITE_URL` from `@/lib/site`.

## Changes

- **`src/components/Roaster.tsx`** — Import `SITE_URL` from `@/lib/site` instead of hardcoded string
- **`src/components/ShareCard.tsx`** — Add `siteUrl` prop for dynamic domain rendering
- **`src/app/[locale]/page.tsx`** — Use `SITE_URL` for homepage links
- **`src/app/api/card/[username]/route.tsx`** — OG card branding text
- **`src/app/api/paper-card/[id]/route.tsx`** — Paper OG card branding
- **`src/lib/arxiv.ts`** — User-Agent based on `PUBLIC_SITE_URL`
- **`src/messages/en.json / zh.json`** — Parameterize `{siteUrl}` in share texts and OG descriptions
- **`src/app/[locale]/u/[username]/page.tsx`** — Pass `siteUrl` to OG description translations

## Effect

Setting `PUBLIC_SITE_URL` env var now dynamically updates badge/card embed URLs, share links, OG card branding, and page links — no code changes needed for custom domain deployments.