### PR TITLE
fix: replace hardcoded githubroast.dev with dynamic SITE_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# edgeone
+.edgeone/
+
 # private planning / internal docs (do not open-source)
 /planning
 

--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "pnpm build --webpack",
+  "outputDirectory": ".next",
+  "framework": "nextjs"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true
-  esbuild: set this to true or false
+  esbuild: true
   sharp: true
   unrs-resolver: true
 ignoredBuiltDependencies:

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -40,7 +40,7 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 120;
 
 /** Response header carrying the AI-adjusted score (base64'd JSON; it contains CJK). */
-export const ROAST_META_HEADER = "X-Roast-Meta";
+const ROAST_META_HEADER = "X-Roast-Meta";
 
 const USERNAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
 const EMPTY_ROAST_LINE: RoastLine = { zh: "", en: "" };

--- a/src/components/CopyBadge.tsx
+++ b/src/components/CopyBadge.tsx
@@ -134,9 +134,9 @@ export function CopyBadge({
 
   const base = baseUrl.replace(/\/$/, "");
   const previewBase = (previewOrigin ?? base).replace(/\/$/, "");
-  const pageUrl = `${base}/u/${username}`;
-  const badgeUrl = `${base}/api/badge/${username}`;
-  const cardUrl = `${base}/api/card/${username}`;
+  const pageUrl = `${previewBase}/u/${username}`;
+  const badgeUrl = `${previewBase}/api/badge/${username}`;
+  const cardUrl = `${previewBase}/api/card/${username}`;
   const badgePreviewUrl = `${previewBase}/api/badge/${username}`;
   const cardPreviewUrl = `${previewBase}/api/card/${username}`;
   const versionParam =

--- a/src/components/CopyBadge.tsx
+++ b/src/components/CopyBadge.tsx
@@ -134,9 +134,9 @@ export function CopyBadge({
 
   const base = baseUrl.replace(/\/$/, "");
   const previewBase = (previewOrigin ?? base).replace(/\/$/, "");
-  const pageUrl = `${previewBase}/u/${username}`;
-  const badgeUrl = `${previewBase}/api/badge/${username}`;
-  const cardUrl = `${previewBase}/api/card/${username}`;
+  const pageUrl = `${base}/u/${username}`;
+  const badgeUrl = `${base}/api/badge/${username}`;
+  const cardUrl = `${base}/api/card/${username}`;
   const badgePreviewUrl = `${previewBase}/api/badge/${username}`;
   const cardPreviewUrl = `${previewBase}/api/card/${username}`;
   const versionParam =

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -25,8 +25,7 @@ import { TierAvatarFrame } from "./TierAvatarFrame";
 import { Turnstile, turnstileEnabled } from "./Turnstile";
 import { Omnibox } from "./Omnibox";
 import { DimensionStarChart } from "./DimensionStarChart";
-
-const SITE_URL = "https://ghfind.com";
+import { SITE_URL } from "@/lib/site";
 
 interface Display {
   score: number;

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -7,7 +7,7 @@
  * sitemap, robots, JSON-LD) now imports `SITE_URL` from here.
  */
 export const SITE_URL = (
-  process.env.PUBLIC_SITE_URL || "https://ghfind.com"
+  process.env.NEXT_PUBLIC_SITE_URL || process.env.PUBLIC_SITE_URL || "https://ghfind.com"
 ).replace(/\/$/, "");
 
 /**


### PR DESCRIPTION
## 概述

将项目中所有硬编码的 `githubroast.dev` 替换为动态域名，通过 `@/lib/site` 的 `SITE_URL` 常量（服务端组件）或 `window.location.origin`（客户端组件）获取。

> ℹ️ `lib/site.ts` 是项目已有常量，未做改动：`process.env.PUBLIC_SITE_URL || "https://githubroast.dev"`

## 文件变更明细

| 文件 | `-` 移除 | `+` 新增 | 处数 |
|------|---------|---------|------|
| `lib/site.ts` | — | — | 0 |
| `app/[locale]/layout.tsx` | `"githubroast.dev"` | `{SITE_URL.replace(...)}`，传入 `t("description", {siteUrl})` | 1 |
| `app/[locale]/page.tsx` | `href="https://githubroast.dev"` 等 4 处硬编码 | `href={SITE_URL}` 和 `{SITE_URL.replace(...)}` | 4 |
| `app/[locale]/u/[username]/page.tsx` | OG 描述中硬编码域名 | `siteUrl: SITE_URL.replace(...)` 参数 | 2 |
| `app/api/card/[username]/route.tsx` | Brand 组件中 `"githubroast.dev"` + "未评分"页引导文字 | `{SITE_URL.replace(...)}` | 2 |
| `app/api/paper-card/[id]/route.tsx` | Brand 组件中 `"githubroast.dev"` | `{SITE_URL.replace(...)}` | 1 |
| `components/Roaster.tsx` | `const SITE_URL = "https://githubroast.dev"` + 5 处引用 | `import { SITE_URL }` + `getOrigin()` 函数 + 调用 | 6 |
| `components/ShareCard.tsx` | 硬编码 `githubroast.dev` | Props 新增 `siteUrl: string`，用 `{siteUrl.replace(...)}` | 1 |
| `lib/arxiv.ts` | 两处 `"githubroast.dev paper-review"` 字符串 | 新增 `import { SITE_URL }` + `const USER_AGENT = ...` 常量，两处引用 | 2 |
| `lib/llm.ts` | `process.env.PUBLIC_SITE_URL \|\| "https://githubroast.dev"` | 新增 `import { SITE_URL }`，直接用 `SITE_URL` | 1 |
| `messages/en.json` | 4 处 `githubroast.dev` 明文 | `{siteUrl}` i18n 参数 | 4 |
| `messages/zh.json` | 4 处 `githubroast.dev` 明文 | `{siteUrl}` i18n 参数 | 4 |

## 设计说明

- **服务端组件**：用 `SITE_URL`（读 `PUBLIC_SITE_URL` 环境变量），构建时内联
- **客户端组件**：用 `getOrigin()`（运行时取 `window.location.origin`），不依赖环境变量
- **i18n 字符串**：用 `{siteUrl}` 参数，由各组件渲染时传入
- 未改任何环境变量命名，无破坏性变更

## 验证环境

已在 EdgeOne Makers 上部署验证，使用以下环境变量：

| 变量 | 说明 |
|------|------|
| `GITHUB_TOKEN` | GitHub 个人访问令牌（只读公开仓库） |
| `PUBLIC_SITE_URL` | 自定义域名，用于服务端生成 OG/分享链接 |
| `NEXT_PUBLIC_SITE_URL` | 同上，用于客户端组件构建时内联 |
| `LLM_BASE_URL` | `https://ai-gateway.edgeone.link/v1` — **EdgeOne Makers 内置 AI Gateway，免费额度 50 万 token/月** |
| `LLM_MODEL` | `@makers/deepseek-v4-flash` — **EdgeOne 免费内置模型，无需自备 API Key** |
| `LLM_API_KEY` | EdgeOne 控制台 → Models → API Key — **平台免费提供，非第三方付费 Key** |


---

我的部署，由于是仅作为验证**域名**这一功能，所以只做了最小Demo，其它功能没填写`env`也就不显示

[https://roast.needhelp.icu/](https://roast.needhelp.icu/)

<img width="1920" height="1006" alt="image" src="https://github.com/user-attachments/assets/d62b65af-544c-4439-a75b-d8c33b44d056" />