### PR TITLE
feat(db): persist roast generation snapshots

### DIFF
--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -1,0 +1,236 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScanResult } from "@/lib/types";
+
+const mocks = vi.hoisted(() => ({
+  getArchivedRoast: vi.fn(),
+  getPercentile: vi.fn(),
+  recordScore: vi.fn(),
+  updateRoast: vi.fn(),
+  chatStream: vi.fn(),
+  defaultLlmConfig: vi.fn(),
+  acquireRoastLock: vi.fn(),
+  checkRoastRateLimit: vi.fn(),
+  getCachedRoast: vi.fn(),
+  getCachedScan: vi.fn(),
+  releaseRoastLock: vi.fn(),
+  setCachedRoast: vi.fn(),
+  waitForCachedRoast: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getArchivedRoast: mocks.getArchivedRoast,
+  getPercentile: mocks.getPercentile,
+  recordScore: mocks.recordScore,
+  updateRoast: mocks.updateRoast,
+}));
+
+vi.mock("@/lib/badge", () => ({
+  TIER_EN: {
+    夯: "GOD",
+    顶级: "TOP",
+    人上人: "ELITE",
+    NPC: "NPC",
+    拉完了: "LOW",
+  },
+  TIER_LABEL_EN: {
+    夯: "Legendary",
+    顶级: "Top developer",
+    人上人: "Trusted contributor",
+    NPC: "Average account",
+    拉完了: "Low value",
+  },
+}));
+
+vi.mock("@/lib/lang", () => ({
+  normLang: (lang?: string) => (lang === "en" ? "en" : "zh"),
+}));
+
+vi.mock("@/lib/llm", () => {
+  class LlmQuotaError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    LlmQuotaError,
+    chatStream: mocks.chatStream,
+    defaultLlmConfig: mocks.defaultLlmConfig,
+  };
+});
+
+vi.mock("@/lib/redis", () => ({
+  acquireRoastLock: mocks.acquireRoastLock,
+  checkRoastRateLimit: mocks.checkRoastRateLimit,
+  getCachedRoast: mocks.getCachedRoast,
+  getCachedScan: mocks.getCachedScan,
+  releaseRoastLock: mocks.releaseRoastLock,
+  setCachedRoast: mocks.setCachedRoast,
+  waitForCachedRoast: mocks.waitForCachedRoast,
+}));
+
+vi.mock("@/lib/percentile", () => ({
+  beatPercent: () => 50,
+}));
+
+vi.mock("@/lib/prompt", () => ({
+  buildRoastJudgeMessages: () => [],
+  buildRoastMessages: () => [],
+}));
+
+vi.mock("@/lib/report", () => ({
+  reportMatchesLang: () => true,
+}));
+
+vi.mock("@/lib/identity", () => ({
+  sanitizeIdentityClaims: (
+    _scan: unknown,
+    tags: unknown,
+    roastLine: unknown,
+    report: unknown,
+  ) => ({ tags, roastLine, report }),
+}));
+
+vi.mock("@/lib/score", () => ({
+  clampScore: (score: number) => Math.max(0, Math.min(100, score)),
+  spamBotScore: () => 0,
+  tierFor: (score: number) =>
+    score >= 70
+      ? { tier: "人上人", tier_label: "优质贡献者 · 值得信任" }
+      : { tier: "NPC", tier_label: "普通账号 · 特征平庸存疑" },
+}));
+
+import { POST } from "./route";
+
+async function* streamText(text: string): AsyncGenerator<string> {
+  yield text;
+}
+
+const scan: ScanResult = {
+  metrics: {
+    username: "DemoDev",
+    profile_url: "https://github.com/DemoDev",
+    avatar_url: "https://avatars.githubusercontent.com/u/1",
+    name: "Demo Dev",
+    bio: "Maintainer",
+    company: null,
+    account_age_years: 5,
+    created_at: "2020-01-01T00:00:00Z",
+    followers: 120,
+    following: 20,
+    public_repos: 12,
+    fetched_repo_count: 12,
+    original_repo_count: 8,
+    nonempty_original_repo_count: 8,
+    fork_repo_count: 4,
+    empty_original_repo_count: 0,
+    total_stars: 500,
+    max_stars: 260,
+    merged_pr_count: 30,
+    total_pr_count: 35,
+    issues_created: 12,
+    last_year_contributions: 900,
+    activity_type_count: 4,
+    contribution_years_active: 4,
+    days_since_last_activity: 2,
+    recent_merged_pr_sample: 10,
+    recent_trivial_pr_count: 1,
+    external_trivial_pr_count: 1,
+    max_impact_repo_stars: 10_000,
+    impact_pr_count: 8,
+    impact_depth_raw: 3,
+    star_inflation_suspect: false,
+    closed_unmerged_pr_count: 1,
+    pr_rejection_rate: 0.03,
+    recent_pr_sample: 12,
+    top_repo_pr_target: null,
+    top_repo_pr_share: 0,
+    templated_pr_ratio: 0,
+    pr_flood_suspect: false,
+  },
+  top_repos: [],
+  recent_prs: [],
+  flood_pr_titles: [],
+  impact_repos: [],
+  verified_impact_prs: [],
+  scoring: {
+    sub_scores: {
+      account_maturity: 8,
+      original_project_quality: 12,
+      contribution_quality: 18,
+      ecosystem_impact: 12,
+      community_influence: 5,
+      activity_authenticity: 13,
+    },
+    base_score: 68,
+    red_flags: [],
+    total_penalty: 0,
+    final_score: 68,
+    tier: "NPC",
+    tier_label: "普通账号 · 特征平庸存疑",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.defaultLlmConfig.mockReturnValue({
+    baseURL: "https://llm.example.test/v1",
+    apiKey: "test-key",
+    model: "test-model",
+  });
+  mocks.getCachedScan.mockResolvedValue(null);
+  mocks.getCachedRoast.mockResolvedValue(null);
+  mocks.getArchivedRoast.mockResolvedValue(null);
+  mocks.checkRoastRateLimit.mockResolvedValue({ success: true });
+  mocks.acquireRoastLock.mockResolvedValue(true);
+  mocks.waitForCachedRoast.mockResolvedValue(null);
+  mocks.getPercentile.mockResolvedValue({ below: 5, total: 10 });
+  mocks.recordScore.mockResolvedValue(undefined);
+  mocks.updateRoast.mockResolvedValue(undefined);
+  mocks.setCachedRoast.mockResolvedValue(undefined);
+  mocks.releaseRoastLock.mockResolvedValue(undefined);
+  mocks.chatStream
+    .mockReturnValueOnce(streamText(`{"delta":3,"reason":"ok","verdict":"正常","risk_notes":[]}`))
+    .mockReturnValueOnce(
+      streamText(
+        [
+          "@@ADJUST 3@@",
+          "@@TAGS zh=进步,维护者|en=improving,maintainer@@",
+          "@@ROAST zh=稳步进步。|en=Steady improvement.@@",
+          "## 毒舌点评",
+          "开源活跃度在上升。",
+        ].join("\n"),
+      ),
+    );
+});
+
+describe("roast API persistence", () => {
+  it("persists the score and completed roast for a fresh default generation", async () => {
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ scan, lang: "zh" }),
+      }),
+    );
+
+    await expect(response.text()).resolves.toContain("开源活跃度在上升");
+    expect(response.status).toBe(200);
+    expect(mocks.recordScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: "DemoDev",
+        final_score: 71,
+        tier: "人上人",
+        tags: { zh: ["进步", "维护者"], en: ["improving", "maintainer"] },
+        roast_line: { zh: "稳步进步。", en: "Steady improvement." },
+      }),
+    );
+    expect(mocks.updateRoast).toHaveBeenCalledWith(
+      "DemoDev",
+      expect.stringContaining("## 毒舌点评"),
+      "zh",
+    );
+  });
+});

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -89,6 +89,39 @@ describe("getArchivedRoast", () => {
   });
 });
 
+describe("score snapshots", () => {
+  it("stores one generated-at stub when a completed roast is persisted", async () => {
+    const username = "roast-snapshot";
+    const before = Date.now();
+    await db.recordScore({ ...entry, username, final_score: 90 });
+    await db.updateRoast(username, "## first report", "zh");
+    await db.recordScore({
+      ...entry,
+      username,
+      final_score: 96.1,
+      scanned_at: entry.scanned_at + 2 * 60 * 60 * 1000,
+    });
+    await db.updateRoast(username, "## second report", "en");
+    const after = Date.now();
+
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    const res = await client.execute({
+      sql: `SELECT COUNT(*) AS n,
+                   MIN(generated_at) AS first_generated_at,
+                   MAX(generated_at) AS last_generated_at,
+                   GROUP_CONCAT(roast_lang, ',') AS langs
+            FROM score_snapshots
+            WHERE username = ?`,
+      args: [username],
+    });
+
+    expect(Number(res.rows[0]?.n)).toBe(2);
+    expect(Number(res.rows[0]?.first_generated_at)).toBeGreaterThanOrEqual(before);
+    expect(Number(res.rows[0]?.last_generated_at)).toBeLessThanOrEqual(after);
+    expect(String(res.rows[0]?.langs).split(",").sort()).toEqual(["en", "zh"]);
+  });
+});
+
 describe("profile comments", () => {
   it("stores anonymous and GitHub comments for a profile", async () => {
     const anonymous = await db.createProfileComment({

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,10 +2,10 @@
  * Turso (libSQL) persistence for the leaderboard + percentile.
  *
  * Optional, like {@link ./redis}: if `TURSO_DATABASE_URL` is unset, every function
- * no-ops (returns null/empty) so the app runs fine without it. Stores exactly one
- * row per scanned account (latest score). The score itself is still computed
- * deterministically by `lib/score.ts`; this layer only persists the result for
- * cross-account ranking.
+ * no-ops (returns null/empty) so the app runs fine without it. Stores one latest
+ * row per scanned account plus append-only score snapshots for long-term progress.
+ * The score itself is still computed deterministically by `lib/score.ts`; this
+ * layer only persists the result for cross-account ranking.
  */
 
 import { Client, createClient } from "@libsql/client";
@@ -155,6 +155,25 @@ function ensureSchema(db: Client): Promise<void> {
           // so a composite index lets one seek cover both conditions.
           `CREATE INDEX IF NOT EXISTS idx_scores_hidden_score
              ON scores(hidden, final_score DESC)`,
+          `CREATE TABLE IF NOT EXISTS score_snapshots (
+             id            TEXT PRIMARY KEY,
+             username      TEXT NOT NULL,
+             display_name  TEXT,
+             avatar_url    TEXT,
+             profile_url   TEXT,
+             final_score   REAL NOT NULL,
+             tier          TEXT NOT NULL,
+             tags          TEXT,
+             roast_line    TEXT,
+             bot_score     REAL,
+             sub_scores    TEXT,
+             score_version TEXT NOT NULL,
+             roast_version TEXT NOT NULL,
+             roast_lang    TEXT NOT NULL CHECK(roast_lang IN ('zh', 'en')),
+             generated_at  INTEGER NOT NULL
+           )`,
+          `CREATE INDEX IF NOT EXISTS idx_score_snapshots_username_generated
+             ON score_snapshots(username, generated_at DESC)`,
           `CREATE TABLE IF NOT EXISTS account_stats (
              username        TEXT PRIMARY KEY,
              lookup_count    INTEGER NOT NULL DEFAULT 0,
@@ -430,9 +449,30 @@ export async function updateRoast(username: string, roast: string, lang: Lang): 
   const versionCol = lang === "en" ? "roast_en_version" : "roast_version";
   try {
     await ensureSchema(db);
+    const normalizedUsername = username.toLowerCase();
+    const generatedAt = Date.now();
     await db.execute({
       sql: `UPDATE scores SET ${col} = ?, ${versionCol} = ? WHERE username = ?`,
-      args: [roast, ROAST_CACHE_VERSION, username.toLowerCase()],
+      args: [roast, ROAST_CACHE_VERSION, normalizedUsername],
+    });
+    await db.execute({
+      sql: `INSERT INTO score_snapshots
+              (id, username, display_name, avatar_url, profile_url, final_score, tier,
+               tags, roast_line, score_version, roast_version, roast_lang, bot_score,
+               sub_scores, generated_at)
+            SELECT ?, username, display_name, avatar_url, profile_url, final_score, tier,
+                   tags, roast_line, COALESCE(score_version, ?), ?, ?, bot_score,
+                   sub_scores, ?
+            FROM scores
+            WHERE username = ?`,
+      args: [
+        randomUUID(),
+        SCORE_CACHE_VERSION,
+        ROAST_CACHE_VERSION,
+        lang,
+        generatedAt,
+        normalizedUsername,
+      ],
     });
   } catch (e) {
     console.error("updateRoast failed:", e);


### PR DESCRIPTION
## Summary

- add an append-only `score_snapshots` table for lightweight generated score history
- append a snapshot when a completed roast is persisted through `updateRoast`
- add route-level and DB-level coverage for roast generation persistence

## Validation

- `pnpm test -- src/app/api/roast/route.test.ts src/lib/__tests__/db.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Notes

- No generated files, GraphQL codegen, or DB baseline updates are included.
- `pnpm build` reports the existing Next.js `middleware` deprecation warning; the build succeeds.