### PR TITLE
[codex] adapt login nudge to light theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -238,6 +238,15 @@ html[data-theme="light"] .tier-avatar-emoji-shell {
     0 0 0 1px rgba(15, 23, 42, 0.08);
 }
 
+html[data-theme="light"] .login-nudge-card {
+  background-color: rgba(255, 255, 255, 0.94);
+  border-color: rgba(234, 88, 12, 0.24);
+  --tw-ring-color: rgba(234, 88, 12, 0.12);
+  box-shadow:
+    0 18px 50px rgba(15, 23, 42, 0.14),
+    0 4px 18px rgba(234, 88, 12, 0.08);
+}
+
 html[data-theme="light"] [data-force-dark] {
   background-color: #0a0a0b;
   color: #ffffff;

--- a/src/components/LoginNudge.tsx
+++ b/src/components/LoginNudge.tsx
@@ -18,9 +18,8 @@ const EXIT_MS = 300;
  * has to know about auth — it just owns the timing, the slide animation, and the
  * "don't nag me again" snooze. Sits at the top-right (just under the sticky
  * navbar) on desktop, full-width under the navbar on mobile, sliding down into
- * view. Styling reuses the same zinc/white
- * utility classes as the rest of the app, which `globals.css` remaps for the
- * light theme, so the card adapts automatically.
+ * view. The outer card has a dedicated theme hook so its translucent panel can
+ * stay dark in dark mode and become a real light surface in light mode.
  *
  * `signInAction` is a server action passed down from the layout (`signIn("github")`).
  */
@@ -67,7 +66,7 @@ export function LoginNudge({ signInAction }: { signInAction: () => Promise<void>
         visible ? "translate-y-0 opacity-100" : "-translate-y-6 opacity-0"
       }`}
     >
-      <div className="relative rounded-2xl border border-orange-400/25 bg-zinc-900/95 p-5 shadow-2xl ring-1 ring-orange-500/10 backdrop-blur">
+      <div className="login-nudge-card relative rounded-2xl border border-orange-400/25 bg-zinc-900/95 p-5 shadow-2xl ring-1 ring-orange-500/10 backdrop-blur">
         <button
           type="button"
           onClick={dismiss}


### PR DESCRIPTION
## Summary

- Add a dedicated theme hook to the signed-out login nudge card.
- Give the nudge a real light-mode surface, border, ring, and shadow while preserving the existing dark-mode panel.

## Root Cause

The new login nudge used `bg-zinc-900/95`, but the light theme only remapped the non-opacity `bg-zinc-900` utility. In light mode the panel stayed dark while text colors were remapped for a light surface.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Browser verified the login nudge in both light and dark themes on `http://localhost:3001/`.
