### PR TITLE
fix(score): cap contribution quality

### DIFF
--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -301,15 +301,13 @@ export function score(m: RawMetrics): Scoring {
     issuePts +
     highImpactCorePrBonus(m) -
     authorSelfClosedExternalPenalty(m);
-  const caps = [
-    contributionQualityCap(m),
-    lowPrestigeBulkContributionCap(m),
-  ].filter((cap): cap is number => cap !== undefined);
-  const contributionCap = caps.length > 0 ? Math.min(...caps) : undefined;
+  const contributionCap = Math.min(
+    contributionQualityCap(m) ?? Infinity,
+    lowPrestigeBulkContributionCap(m) ?? Infinity,
+    SUBSCORE_MAX.contribution_quality,
+  );
   sub.contribution_quality = round(
-    contributionCap === undefined
-      ? contributionQualityRaw
-      : Math.min(contributionQualityRaw, contributionCap),
+    Math.min(contributionQualityRaw, contributionCap),
     1,
   );
 


### PR DESCRIPTION
### What's changed?

- Cap `contribution_quality` at its declared 27-point maximum after applying dynamic contribution caps.

### Why

- Prevent high-impact PR bonuses from pushing the subscore above `SUBSCORE_MAX.contribution_quality`.

### Checks

- `pnpm test src/lib/__tests__/score.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pre-ship --committed` manual skill flow
