### PR TITLE
feat(readme): parse structured README signals

### DIFF
--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   releaseRoastLock: vi.fn(),
   setCachedRoast: vi.fn(),
   waitForCachedRoast: vi.fn(),
+  buildRoastJudgeMessages: vi.fn((_scan: ScanResult, _lang?: string) => []),
+  buildRoastMessages: vi.fn((_scan: ScanResult, _lang?: string, _judge?: unknown) => []),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -79,8 +81,8 @@ vi.mock("@/lib/percentile", () => ({
 }));
 
 vi.mock("@/lib/prompt", () => ({
-  buildRoastJudgeMessages: () => [],
-  buildRoastMessages: () => [],
+  buildRoastJudgeMessages: mocks.buildRoastJudgeMessages,
+  buildRoastMessages: mocks.buildRoastMessages,
 }));
 
 vi.mock("@/lib/report", () => ({
@@ -235,5 +237,33 @@ describe("roast API persistence", () => {
       expect.stringContaining("## 毒舌点评"),
       "zh",
     );
+  });
+
+  it("drops malformed nested README summaries from client fallback scans", async () => {
+    const malformedScan = {
+      ...scan,
+      top_repos: [
+        {
+          readme_excerpt: "Fallback summary",
+          readme: {
+            features: {
+              prompt_summary: 42,
+            },
+          },
+        },
+      ],
+    } as unknown as ScanResult;
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ scan: malformedScan, lang: "zh" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const passedScan = mocks.buildRoastMessages.mock.calls[0]![0];
+    expect(passedScan.top_repos[0].readme).toBeUndefined();
+    expect(passedScan.top_repos[0].readme_excerpt).toBe("Fallback summary");
   });
 });

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -168,11 +168,24 @@ function parseJudgeResult(raw: string, scan: ScanResult, lang: Lang): RoastJudge
 function sanitizeScan(scan: ScanResult): ScanResult {
   return {
     metrics: scan.metrics,
-    top_repos: (scan.top_repos ?? []).slice(0, 10).map((r) => ({
-      ...r,
-      description: r.description?.slice(0, 300) ?? null,
-      readme_excerpt: r.readme_excerpt?.slice(0, 500) ?? null,
-    })),
+    top_repos: (scan.top_repos ?? []).slice(0, 10).map((r) => {
+      const promptSummary = r.readme?.features?.prompt_summary;
+      return {
+        ...r,
+        description: r.description?.slice(0, 300) ?? null,
+        readme_excerpt: r.readme_excerpt?.slice(0, 1500) ?? null,
+        readme:
+          typeof promptSummary === "string" && r.readme
+            ? {
+                ...r.readme,
+                features: {
+                  ...r.readme.features,
+                  prompt_summary: promptSummary.slice(0, 1500),
+                },
+              }
+            : undefined,
+      };
+    }),
     recent_prs: (scan.recent_prs ?? []).slice(0, 50).map((p) => ({
       ...p,
       title: p.title?.slice(0, 200) ?? null,

--- a/src/lib/__tests__/prompt.test.ts
+++ b/src/lib/__tests__/prompt.test.ts
@@ -97,6 +97,35 @@ describe("buildRoastMessages", () => {
     expect(payload.judge_result).toMatchObject(judge);
   });
 
+  it("does not duplicate structured README summaries in the prompt payload", () => {
+    const [, user] = buildRoastMessages(
+      {
+        ...scan,
+        top_repos: [
+          {
+            name: "project",
+            readme_excerpt: "Structured summary",
+            readme: {
+              features: {
+                prompt_summary: "Structured summary",
+              },
+            },
+          },
+          {
+            name: "legacy",
+            readme_excerpt: "Legacy summary",
+          },
+        ],
+      } as unknown as ScanResult,
+      "zh",
+    );
+    const payload = JSON.parse(user.content.match(/```json\n([\s\S]*)\n```/)![1]);
+
+    expect(payload.top_repos[0].readme.features.prompt_summary).toBe("Structured summary");
+    expect(payload.top_repos[0].readme_excerpt).toBeUndefined();
+    expect(payload.top_repos[1].readme_excerpt).toBe("Legacy summary");
+  });
+
   it("requires the report body to translate internal fields into user-facing roast language", () => {
     const [zhSys] = buildRoastMessages(scan, "zh");
     expect(zhSys.content).toContain("展示层脱敏");

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -9,6 +9,7 @@ import {
   isEcosystemImpactPr,
   isExternalTrivialFarmPr,
   originalRepoQualityScore,
+  parseReadmeFeatures,
   topStarredOriginalRepoQuality,
   type ContribRepoAgg,
 } from "../github";
@@ -380,6 +381,88 @@ describe("original project quality", () => {
       best_original_repo_quality_score: q,
     });
     expect(s.sub_scores.original_project_quality).toBeGreaterThanOrEqual(4.8);
+  });
+
+  it("scores structured README features instead of the prompt summary length", () => {
+    const features = parseReadmeFeatures(`
+# Project
+
+${"Intro copy with badges and screenshots. ".repeat(40)}
+
+## Installation
+
+Install the package and configure the service.
+
+## Usage
+
+Use the API to run tests and deploy the workflow.
+`);
+    expect(features.length).toBeGreaterThan(800);
+    expect(features.has_install).toBe(true);
+    expect(features.has_usage).toBe(true);
+    expect(features.prompt_summary.length).toBeLessThanOrEqual(1500);
+
+    const q = originalRepoQualityScore(
+      repo({
+        size: 1800,
+        readme: {
+          path: "README.md",
+          sha: "abc",
+          size: 2000,
+          html_url: null,
+          truncated: false,
+          features,
+        },
+        readme_excerpt: "Project summary.",
+      }),
+      "alice",
+      now,
+    );
+
+    expect(q).toBeGreaterThan(0.8);
+  });
+
+  it("uses the first non-empty H1 section as the README summary intro", () => {
+    const features = parseReadmeFeatures(`
+# Project
+
+A clear overview of what this project does and why it exists.
+
+## Installation
+
+Install the package.
+`);
+
+    expect(features.prompt_summary).toContain("A clear overview");
+  });
+
+  it("treats Quick Start as a usage signal", () => {
+    const features = parseReadmeFeatures(`
+# Project
+
+## Quick Start
+
+Run the CLI with the default config.
+`);
+
+    expect(features.has_usage).toBe(true);
+  });
+
+  it("does not count badges as screenshots", () => {
+    const badges = parseReadmeFeatures(`
+# Project
+
+[![CI](https://img.shields.io/badge/ci-passing-green.svg)](https://example.com)
+![license](https://img.shields.io/badge/license-MIT-blue.svg)
+`);
+    const screenshot = parseReadmeFeatures(`
+# Project
+
+![Screenshot](./assets/screenshot.png)
+`);
+
+    expect(badges.has_screenshot).toBe(false);
+    expect(screenshot.has_screenshot).toBe(true);
   });
 
   it("does not let stars alone max out original quality without project substance", () => {

--- a/src/lib/cache-version.ts
+++ b/src/lib/cache-version.ts
@@ -6,8 +6,8 @@
  * change. Development bypasses these caches entirely so local prompt/scoring
  * edits are visible on the next request.
  */
-export const SCORE_CACHE_VERSION = "v4";
-export const ROAST_CACHE_VERSION = "v4";
+export const SCORE_CACHE_VERSION = "v5";
+export const ROAST_CACHE_VERSION = "v5";
 
 export function bypassGeneratedCaches(): boolean {
   return (

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -8,9 +8,18 @@
  */
 
 import { logRatio } from "./score";
-import type { ImpactRepo, RawMetrics, RecentPr, TopRepo } from "./types";
+import type {
+  ImpactRepo,
+  RawMetrics,
+  ReadmeFeatures,
+  RecentPr,
+  RepoReadme,
+  TopRepo,
+} from "./types";
 
 const GITHUB_API = "https://api.github.com";
+const README_FETCH_LIMIT = 1024 * 1024;
+const README_PROMPT_SUMMARY_LIMIT = 1500;
 
 /** Raised when the requested account does not exist (404). */
 export class AccountNotFoundError extends Error {}
@@ -43,6 +52,16 @@ interface RestRepo {
   // Topics are returned by default on the modern REST repos endpoint; absent on
   // older proxies, so optional. A high-signal official domain label.
   topics?: string[];
+}
+
+interface RestReadme {
+  path?: string;
+  sha?: string;
+  size?: number;
+  html_url?: string | null;
+  download_url?: string | null;
+  content?: string;
+  encoding?: string;
 }
 
 interface RestUser {
@@ -128,7 +147,10 @@ function isLikelyPlaceholderProject(repo: TopRepo, loginLower: string): boolean 
     return true;
   }
   const readme = (repo.readme_excerpt ?? "").toLowerCase();
-  return /\b(wip|todo|scratch project|playground only|learning notes)\b/.test(readme);
+  return (
+    (repo.readme?.features.placeholder_score ?? 0) >= 0.6 ||
+    /\b(wip|todo|scratch project|playground only|learning notes)\b/.test(readme)
+  );
 }
 
 /**
@@ -142,7 +164,8 @@ export function originalRepoQualityScore(
 ): number {
   if (repo.size <= 0) return 0;
 
-  const readme = meaningfulText(repo.readme_excerpt);
+  const readme = repo.readme?.features;
+  const readmeLen = readme?.length ?? meaningfulText(repo.readme_excerpt).length;
   const desc = meaningfulText(repo.description);
   const pushed = parseTs(repo.pushed_at);
   const ageDays = pushed
@@ -158,11 +181,25 @@ export function originalRepoQualityScore(
   if (repo.language) s += 0.15;
   if (desc.length >= 20) s += 0.15;
 
-  if (readme.length >= 800) s += 0.25;
-  else if (readme.length >= 300) s += 0.2;
-  else if (readme.length >= 120) s += 0.12;
+  if (readmeLen >= 800) s += 0.25;
+  else if (readmeLen >= 300) s += 0.2;
+  else if (readmeLen >= 120) s += 0.12;
 
-  if (/\b(install|usage|quickstart|quick start|api|demo|features?|deploy|architecture|test|screenshot)\b/i.test(readme)) {
+  if (
+    readme
+      ? readme.has_install ||
+        readme.has_usage ||
+        readme.has_api ||
+        readme.has_demo ||
+        readme.has_features ||
+        readme.has_deploy ||
+        readme.has_test ||
+        readme.has_architecture ||
+        readme.has_screenshot
+      : /\b(install|usage|quickstart|quick start|api|demo|features?|deploy|architecture|test|screenshot)\b/i.test(
+          repo.readme_excerpt ?? "",
+        )
+  ) {
     s += 0.1;
   }
 
@@ -173,7 +210,7 @@ export function originalRepoQualityScore(
   }
 
   if (isLikelyPlaceholderProject(repo, loginLower)) {
-    s *= readme.length >= 600 && repo.size >= 200 ? 0.55 : 0.25;
+    s *= readmeLen >= 600 && repo.size >= 200 ? 0.55 : 0.25;
   }
 
   return Math.round(Math.max(0, Math.min(s, 1)) * 100) / 100;
@@ -207,21 +244,232 @@ export function topStarredOriginalRepoQuality(
   };
 }
 
-async function fetchReadmeExcerpt(
-  owner: string,
-  repo: string,
-  limit = 400,
-): Promise<string | null> {
-  const data = await restGet<{ content?: string }>(
-    `repos/${owner}/${repo}/readme`,
-  ).catch(() => null);
-  if (!data || !data.content) return null;
+function cleanReadmeLine(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed || /^(\[!\[|!\[)/.test(trimmed)) return "";
+  return trimmed
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_>|#]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function textMatches(text: string, words: string[]): boolean {
+  return words.some((word) => new RegExp(`\\b${word}\\b`, "i").test(text));
+}
+
+function clampText(text: string, limit: number): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length > limit ? `${clean.slice(0, limit - 1)}…` : clean;
+}
+
+export function parseReadmeFeatures(markdown: string): ReadmeFeatures {
+  const lines = markdown.replace(/\r\n?/g, "\n").replace(/<!--[\s\S]*?-->/g, "\n").split("\n");
+  const headings: { level: number; title: string }[] = [];
+  const sections: { title: string; text: string }[] = [];
+  let currentTitle = "intro";
+  let currentLines: string[] = [];
+  let inCode = false;
+  let hasScreenshotImage = false;
+
+  const pushSection = () => {
+    const text = currentLines.map(cleanReadmeLine).filter(Boolean).join(" ");
+    sections.push({ title: currentTitle, text });
+    currentLines = [];
+  };
+
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode) continue;
+    const imageText = [...line.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)]
+      .map(([, alt, url]) => `${alt} ${url}`)
+      .join(" ");
+    if (
+      imageText &&
+      textMatches(`${cleanReadmeLine(line)} ${imageText}`, [
+        "screenshot",
+        "screenshots",
+        "screen",
+        "demo",
+        "preview",
+      ])
+    ) {
+      hasScreenshotImage = true;
+    }
+    const heading = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      pushSection();
+      currentTitle = cleanReadmeLine(heading[2]);
+      headings.push({ level: heading[1].length, title: currentTitle });
+      continue;
+    }
+    currentLines.push(line);
+  }
+  pushSection();
+
+  const usefulText = sections.map((s) => `${s.title} ${s.text}`).join(" ");
+  const length = meaningfulText(usefulText).length;
+  const signals = {
+    install: textMatches(usefulText, ["install", "installation", "setup"]),
+    usage: textMatches(usefulText, ["usage", "quickstart", "quick start", "examples?", "guide"]),
+    api: textMatches(usefulText, ["api", "sdk", "reference"]),
+    demo: textMatches(usefulText, ["demo", "preview", "playground"]),
+    features: textMatches(usefulText, ["features?"]),
+    deploy: textMatches(usefulText, ["deploy", "deployment"]),
+    test: textMatches(usefulText, ["test", "testing", "tests"]),
+    architecture: textMatches(usefulText, ["architecture", "design", "internals"]),
+    screenshot:
+      hasScreenshotImage || textMatches(usefulText, ["screenshot", "screenshots", "screen"]),
+  };
+  const placeholderHits = [
+    /\bwip\b/i,
+    /\btodo\b/i,
+    /\bscratch\b/i,
+    /\bplayground only\b/i,
+    /\blearning notes?\b/i,
+  ].filter((pattern) => pattern.test(usefulText)).length;
+  const signalCount = Object.values(signals).filter(Boolean).length;
+  const placeholder_score = Math.min(
+    1,
+    placeholderHits * 0.35 + (length < 300 && placeholderHits > 0 ? 0.3 : 0),
+  );
+  const content_depth_score = Math.min(
+    1,
+    (length >= 800 ? 0.35 : length >= 300 ? 0.2 : length >= 120 ? 0.1 : 0) +
+      Math.min(headings.length, 5) * 0.06 +
+      Math.min(signalCount, 5) * 0.07,
+  );
+  const title = headings.find((h) => h.level === 1)?.title ?? headings[0]?.title ?? null;
+  const intro =
+    sections.find((s) => s.title === "intro" && s.text)?.text ??
+    sections.find((s) => s.text)?.text ??
+    "";
+  const picked = sections
+    .filter((s) =>
+      textMatches(s.title, [
+        "install",
+        "installation",
+        "setup",
+        "usage",
+        "quickstart",
+        "quick start",
+        "api",
+        "architecture",
+        "design",
+        "test",
+        "demo",
+        "features?",
+        "deploy",
+        "deployment",
+      ]),
+    )
+    .slice(0, 4);
+  const promptParts = [
+    title ? `Title: ${title}` : "",
+    intro ? `Intro: ${clampText(intro, 350)}` : "",
+    headings.length ? `Sections: ${headings.slice(0, 12).map((h) => h.title).join(", ")}` : "",
+    ...picked.map((s) => `${s.title}: ${clampText(s.text, 220)}`),
+    signalCount
+      ? `Signals: ${Object.entries(signals)
+          .filter(([, present]) => present)
+          .map(([name]) => name)
+          .join(", ")}`
+      : "",
+  ].filter(Boolean);
+
+  return {
+    length,
+    heading_count: headings.length,
+    has_install: signals.install,
+    has_usage: signals.usage,
+    has_api: signals.api,
+    has_demo: signals.demo,
+    has_features: signals.features,
+    has_deploy: signals.deploy,
+    has_test: signals.test,
+    has_architecture: signals.architecture,
+    has_screenshot: signals.screenshot,
+    placeholder_score: Math.round(placeholder_score * 100) / 100,
+    content_depth_score: Math.round(content_depth_score * 100) / 100,
+    prompt_summary: clampText(promptParts.join("\n"), README_PROMPT_SUMMARY_LIMIT),
+  };
+}
+
+async function readTextWithLimit(
+  url: string,
+  limit: number,
+): Promise<{ text: string; truncated: boolean } | null> {
+  let res: Response;
   try {
-    const text = Buffer.from(data.content, "base64").toString("utf-8");
-    return text.split(/\s+/).join(" ").slice(0, limit);
+    res = await fetch(url, {
+      headers: { "User-Agent": "github-roast", Range: `bytes=0-${limit - 1}` },
+      cache: "no-store",
+    });
   } catch {
     return null;
   }
+  if (!res.ok) return null;
+  const reader = res.body?.getReader();
+  if (!reader) return null;
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let truncated = false;
+  try {
+    while (total < limit) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (total + value.byteLength > limit) {
+        chunks.push(value.slice(0, limit - total));
+        truncated = true;
+        break;
+      }
+      chunks.push(value);
+      total += value.byteLength;
+    }
+    if (total >= limit) truncated = true;
+    if (truncated) await reader.cancel().catch(() => undefined);
+  } catch {
+    return null;
+  }
+  return {
+    text: Buffer.concat(chunks).toString("utf-8"),
+    truncated,
+  };
+}
+
+async function fetchReadmeDocument(owner: string, repo: string): Promise<RepoReadme | null> {
+  const data = await restGet<RestReadme>(
+    `repos/${owner}/${repo}/readme`,
+  ).catch(() => null);
+  if (!data) return null;
+
+  let markdown: string | null = null;
+  let truncated = (data.size ?? 0) > README_FETCH_LIMIT;
+  try {
+    if (data.content && data.encoding === "base64" && (data.size ?? 0) <= README_FETCH_LIMIT) {
+      markdown = Buffer.from(data.content.replace(/\s+/g, ""), "base64").toString("utf-8");
+    } else if (data.download_url) {
+      const raw = await readTextWithLimit(data.download_url, README_FETCH_LIMIT);
+      markdown = raw?.text ?? null;
+      truncated = truncated || (raw?.truncated ?? false);
+    }
+  } catch {
+    return null;
+  }
+  if (markdown === null) return null;
+  const features = parseReadmeFeatures(markdown);
+  return {
+    path: data.path ?? "README",
+    sha: data.sha ?? null,
+    size: data.size ?? markdown.length,
+    html_url: data.html_url ?? null,
+    truncated,
+    features,
+  };
 }
 
 /** Per-language byte breakdown for one repo (e.g. {Python: 12000, Cuda: 4000}),
@@ -906,14 +1154,13 @@ export async function collect(username: string): Promise<{
   // limit API calls — same top-6 budget as the README fetch).
   await Promise.all(
     topRepos.slice(0, 6).map(async (repo) => {
-      if (repo.stars > 0 || repo.name) {
-        const [readme, languages] = await Promise.all([
-          fetchReadmeExcerpt(login, repo.name),
-          fetchRepoLanguages(login, repo.name),
-        ]);
-        repo.readme_excerpt = readme;
-        repo.languages = languages;
-      }
+      const [readme, languages] = await Promise.all([
+        fetchReadmeDocument(login, repo.name),
+        fetchRepoLanguages(login, repo.name),
+      ]);
+      repo.readme = readme ?? undefined;
+      repo.readme_excerpt = readme?.features.prompt_summary ?? null;
+      repo.languages = languages;
     }),
   );
   const bestOriginalQuality = bestOriginalRepoQuality(topRepos, loginLower, now);

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -271,6 +271,9 @@ function buildPayload(
       ? { impact_prs_outside_quality_sample: outsideQualitySample }
       : {}),
   };
+  const topRepos = (scan.top_repos ?? []).map((repo) =>
+    repo.readme?.features.prompt_summary ? { ...repo, readme_excerpt: undefined } : repo,
+  );
   const verifiedImpactSampleCount = scan.verified_impact_prs?.length ?? 0;
   const impactSummary =
     lang === "en"
@@ -379,7 +382,7 @@ function buildPayload(
   const payload = {
     context_notes: contextNotes,
     metrics: modelMetrics,
-    top_repos: scan.top_repos,
+    top_repos: topRepos,
     recent_prs: scan.recent_prs,
     impact_summary: impactSummary,
     impact_repos: scan.impact_repos,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,32 @@
  * is identical between the website and the open-source Claude skill.
  */
 
+export interface ReadmeFeatures {
+  length: number;
+  heading_count: number;
+  has_install: boolean;
+  has_usage: boolean;
+  has_api: boolean;
+  has_demo: boolean;
+  has_features: boolean;
+  has_deploy: boolean;
+  has_test: boolean;
+  has_architecture: boolean;
+  has_screenshot: boolean;
+  placeholder_score: number;
+  content_depth_score: number;
+  prompt_summary: string;
+}
+
+export interface RepoReadme {
+  path: string;
+  sha: string | null;
+  size: number;
+  html_url: string | null;
+  truncated: boolean;
+  features: ReadmeFeatures;
+}
+
 export interface TopRepo {
   name: string;
   stars: number;
@@ -15,6 +41,7 @@ export interface TopRepo {
   language: string | null;
   description: string | null;
   pushed_at: string | null;
+  readme?: RepoReadme;
   readme_excerpt?: string | null;
   /** GitHub repo topics (official domain labels). Optional — empty when the
    * REST payload omits them or for scans cached before this field existed. */


### PR DESCRIPTION
### What's changed?

- Replace fixed-length README excerpts with structured README ingestion and feature extraction.
- Feed structured README summaries into scoring and prompt payloads without duplicate summary fields.
- Guard client-provided nested README summaries in the roast fallback path.
- Bump score and roast cache versions so production recomputes changed semantics.

### Why

- README quality signals should come from document structure instead of the first few hundred characters.
- Prompt payloads should stay bounded and avoid stale cached scan/roast behavior after scoring changes.

### Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

Close #56 