### PR TITLE
fix(scan): fail on github graphql outages

### DIFF
--- a/src/app/api/profile/backfill/route.ts
+++ b/src/app/api/profile/backfill/route.ts
@@ -7,6 +7,7 @@ import {
 import {
   AccountNotFoundError,
   GitHubAuthRequiredError,
+  GitHubDataUnavailableError,
   GitHubRateLimitError,
   collect,
 } from "@/lib/github";
@@ -96,6 +97,12 @@ export async function POST(req: NextRequest) {
     }
     if (e instanceof GitHubRateLimitError) {
       return NextResponse.json({ error: "github_rate_limited" }, { status: 503 });
+    }
+    if (e instanceof GitHubDataUnavailableError) {
+      return NextResponse.json(
+        { error: "github_unavailable", retry_after: 60 },
+        { status: 503, headers: { "Retry-After": "60" } },
+      );
     }
     console.error("profile backfill failed:", e);
     return NextResponse.json({ error: "backfill_failed" }, { status: 500 });

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -3,6 +3,7 @@ import { recordAccountLookup } from "@/lib/db";
 import {
   AccountNotFoundError,
   GitHubAuthRequiredError,
+  GitHubDataUnavailableError,
   GitHubRateLimitError,
   collect,
 } from "@/lib/github";
@@ -110,6 +111,12 @@ export async function POST(req: NextRequest) {
     }
     if (e instanceof GitHubRateLimitError) {
       return NextResponse.json({ error: "github_rate_limited" }, { status: 503 });
+    }
+    if (e instanceof GitHubDataUnavailableError) {
+      return NextResponse.json(
+        { error: "github_unavailable", retry_after: 60 },
+        { status: 503, headers: { "Retry-After": "60" } },
+      );
     }
     console.error("scan failed:", e);
     return NextResponse.json({ error: "scan_failed" }, { status: 500 });

--- a/src/lib/__tests__/github.test.ts
+++ b/src/lib/__tests__/github.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { collect, GitHubDataUnavailableError } from "../github";
+
+const originalToken = process.env.GITHUB_TOKEN;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("collect", () => {
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalToken;
+    vi.unstubAllGlobals();
+  });
+
+  it("fails when required GitHub GraphQL data is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url === "https://api.github.com/users/alice") {
+          return jsonResponse({
+            login: "alice",
+            id: 1,
+            html_url: "https://github.com/alice",
+            avatar_url: null,
+            name: null,
+            bio: null,
+            company: null,
+            created_at: "2020-01-01T00:00:00Z",
+            followers: 0,
+            following: 0,
+            public_repos: 0,
+          });
+        }
+
+        if (url.includes("/users/alice/repos")) {
+          return jsonResponse([]);
+        }
+
+        if (url === "https://api.github.com/graphql") {
+          return jsonResponse({ errors: [{ message: "temporary outage" }] });
+        }
+
+        return jsonResponse({}, 404);
+      }),
+    );
+
+    await expect(collect("alice")).rejects.toBeInstanceOf(GitHubDataUnavailableError);
+  });
+});

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -18,6 +18,7 @@ export class AccountNotFoundError extends Error {}
 export class GitHubRateLimitError extends Error {}
 /** Raised when the app cannot collect GraphQL-only scoring dimensions safely. */
 export class GitHubAuthRequiredError extends Error {}
+export class GitHubDataUnavailableError extends Error {}
 
 function authHeaders(): Record<string, string> {
   const token = process.env.GITHUB_TOKEN;
@@ -87,9 +88,9 @@ async function restGet<T>(path: string): Promise<T | null> {
 async function graphql<T>(
   query: string,
   variables: Record<string, unknown>,
-): Promise<T | null> {
+): Promise<T> {
   const token = process.env.GITHUB_TOKEN;
-  if (!token) return null; // GraphQL requires auth
+  if (!token) throw new GitHubAuthRequiredError("GITHUB_TOKEN is required.");
   let res: Response;
   try {
     res = await fetch(`${GITHUB_API}/graphql`, {
@@ -99,15 +100,28 @@ async function graphql<T>(
       cache: "no-store",
     });
   } catch {
-    return null;
+    throw new GitHubDataUnavailableError("GitHub GraphQL request failed.");
   }
-  if (!res.ok) return null;
+  if (res.status === 403 || res.status === 429) {
+    throw new GitHubRateLimitError();
+  }
+  if (!res.ok) {
+    throw new GitHubDataUnavailableError(`GitHub GraphQL HTTP ${res.status}.`);
+  }
+  let json: { data?: T; errors?: { message?: string }[] };
   try {
-    const json = (await res.json()) as { data?: T };
-    return json.data ?? null;
+    json = (await res.json()) as { data?: T; errors?: { message?: string }[] };
   } catch {
-    return null;
+    throw new GitHubDataUnavailableError("GitHub GraphQL returned invalid JSON.");
   }
+  if (json.errors?.length) {
+    const message = json.errors[0]?.message ?? "GitHub GraphQL error.";
+    throw /rate.?limit/i.test(message)
+      ? new GitHubRateLimitError(message)
+      : new GitHubDataUnavailableError(message);
+  }
+  if (!json.data) throw new GitHubDataUnavailableError("GitHub GraphQL returned no data.");
+  return json.data;
 }
 
 function parseTs(value: string | null | undefined): Date | null {
@@ -269,10 +283,11 @@ async function fetchRecentPrs(username: string, count = 50): Promise<RecentPr[]>
           }
         }
       }
-    }`,
+  }`,
     { login: username, count },
   );
-  const nodes = data?.user?.pullRequests?.nodes ?? [];
+  if (!data.user) throw new GitHubDataUnavailableError("GitHub GraphQL returned no PR data.");
+  const nodes = data.user.pullRequests?.nodes ?? [];
   return nodes.map((n): RecentPr => {
     const repo = n.repository;
     const churn = (n.additions ?? 0) + (n.deletions ?? 0);
@@ -355,10 +370,11 @@ async function fetchRecentAllPrs(username: string, count = 30): Promise<AnyPr[]>
           nodes { title repository { nameWithOwner } }
         }
       }
-    }`,
+  }`,
     { login: username, count },
   );
-  const nodes = data?.user?.pullRequests?.nodes ?? [];
+  if (!data.user) throw new GitHubDataUnavailableError("GitHub GraphQL returned no PR data.");
+  const nodes = data.user.pullRequests?.nodes ?? [];
   return nodes
     .filter((n) => n.title && n.repository)
     .map((n) => ({ title: n.title as string, repo: n.repository!.nameWithOwner }));
@@ -658,8 +674,7 @@ interface YearContribs {
 /**
  * Fetch all-time per-repo commit + PR contributions by aliasing one
  * `contributionsCollection(from,to)` per year (GraphQL caps each to a 1-year
- * span), capped to the most recent {@link IMPACT_YEAR_CAP} years. Returns null
- * when unauthenticated (caller falls back to the recent-PR computation).
+ * span), capped to the most recent {@link IMPACT_YEAR_CAP} years.
  */
 async function fetchContribReposByYear(
   username: string,
@@ -701,7 +716,7 @@ async function fetchContribReposByYear(
     query,
     variables,
   );
-  if (!data?.user) return null;
+  if (!data.user) throw new GitHubDataUnavailableError("GitHub GraphQL returned no contribution data.");
 
   // Merge per-year per-repo aggregates: sum commits/prs, take max stars.
   const map = new Map<string, ContribRepoAgg>();
@@ -837,22 +852,25 @@ export async function collect(username: string): Promise<{
     }`,
     { login: username },
   );
-  const cc = contrib?.user?.contributionsCollection;
-  const contributionYears = contrib?.user?.contributionYears?.contributionYears ?? [];
-  const pinnedRepos = (contrib?.user?.pinnedItems?.nodes ?? [])
+  if (!contrib.user) {
+    throw new GitHubDataUnavailableError("GitHub GraphQL returned no contribution data.");
+  }
+  const cc = contrib.user.contributionsCollection;
+  const contributionYears = contrib.user.contributionYears?.contributionYears ?? [];
+  const pinnedRepos = (contrib.user.pinnedItems?.nodes ?? [])
     .map((n) => n?.nameWithOwner)
     .filter((s): s is string => typeof s === "string");
-  const organizations = (contrib?.user?.organizations?.nodes ?? [])
+  const organizations = (contrib.user.organizations?.nodes ?? [])
     .map((n) => n?.login)
     .filter((s): s is string => typeof s === "string");
-  const mergedPrCount = contrib?.user?.mergedPRs?.totalCount ?? 0;
-  const totalPrCount = contrib?.user?.allPRs?.totalCount ?? 0;
+  const mergedPrCount = contrib.user.mergedPRs?.totalCount ?? 0;
+  const totalPrCount = contrib.user.allPRs?.totalCount ?? 0;
   const closedPrBreakdown = computeClosedPrBreakdown(
-    contrib?.user?.closedPRs?.nodes ?? [],
-    contrib?.user?.closedPRs?.totalCount ?? 0,
+    contrib.user.closedPRs?.nodes ?? [],
+    contrib.user.closedPRs?.totalCount ?? 0,
     loginLower,
   );
-  const issuesCreated = contrib?.user?.issues?.totalCount ?? 0;
+  const issuesCreated = contrib.user.issues?.totalCount ?? 0;
   const decidedPrCount = mergedPrCount + closedPrBreakdown.maintainer_closed_unmerged_pr_count;
   const prRejectionRate =
     decidedPrCount > 0

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -234,6 +234,7 @@
     "turnstile_failed": "Verification failed — refresh the page and retry.",
     "rate_limited": "Too fast — take a breath and try again in a minute.",
     "github_rate_limited": "GitHub's API is maxed out right now — give it a moment.",
+    "github_unavailable": "GitHub data is temporarily unavailable — try again later.",
     "scan_failed": "The scan crashed — try again later."
   },
   "share": {

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -234,6 +234,7 @@
     "turnstile_failed": "人机校验没过，刷新页面重试。",
     "rate_limited": "手速太快了，喘口气，一分钟后再来。",
     "github_rate_limited": "GitHub 接口暂时被打满了，缓一会儿再试。",
+    "github_unavailable": "GitHub 数据暂时不可用，稍后再试。",
     "scan_failed": "扫描翻车了，稍后再试。"
   },
   "share": {


### PR DESCRIPTION
### What's changed?

- Fail required GitHub GraphQL collection when GitHub returns errors, invalid JSON, no data, or unavailable responses instead of scoring partial zero data.
- Return `github_unavailable` 503 responses from scan/backfill routes and add localized error text.
- Add a regression test for GraphQL errors during collection.

### Why

- Prevent transient GitHub GraphQL failures from producing and caching low-score scans.

### Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
