### PR TITLE
chore: 域名从 githubroast.dev 切换到 ghfind.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,14 +52,14 @@ TURSO_AUTH_TOKEN=
 ADMIN_SECRET=
 
 # Public site URL (used for OpenRouter attribution + share links)
-PUBLIC_SITE_URL=https://githubroast.dev
+PUBLIC_SITE_URL=https://ghfind.com
 
 # ── 用户登录 / GitHub OAuth (optional) ────────────────────────────────────
 # Lets visitors "Login with GitHub" (identity only for now). If these are
 # absent, the login entry is hidden and everything else works unchanged.
 # Create a GitHub OAuth App: https://github.com/settings/developers
-#   Homepage URL              = https://githubroast.dev
-#   Authorization callback URL = https://githubroast.dev/api/auth/callback/github
+#   Homepage URL              = https://ghfind.com
+#   Authorization callback URL = https://ghfind.com/api/auth/callback/github
 #   For local dev, add another or use http://localhost:3000/api/auth/callback/github
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Turn any public GitHub profile into a **0–100 value & trust score**, an honest
 
 **English** · [中文](./README.zh.md)
 
-[**🔥 Roast a GitHub profile**](https://githubroast.dev/en) · [**🏆 Explore developers**](https://githubroast.dev/en/leaderboard) · [**⭐ View source**](https://github.com/hikariming/github-roast)
+[**🔥 Roast a GitHub profile**](https://ghfind.com/en) · [**🏆 Explore developers**](https://ghfind.com/en/leaderboard) · [**⭐ View source**](https://github.com/hikariming/github-roast)
 
 </div>
 
-[![GitHub Roast developer profile preview](./show_img/usercard.png)](https://githubroast.dev/en/u/hikariming)
+[![GitHub Roast developer profile preview](./show_img/usercard.png)](https://ghfind.com/en/u/hikariming)
 
 ## Assess. Discover. Show off.
 
@@ -26,7 +26,7 @@ Enter a GitHub handle to get a **0–100 value & trust score**, a five-tier verd
 
 GitHub Roast is more than a scoring tool. Use the leaderboard and public profiles to find strong open-source contributors, builders in your ecosystem, potential collaborators, and the developers you want to measure yourself against.
 
-[![GitHub Roast developer leaderboard](./show_img/leaderboard.png)](https://githubroast.dev/en/leaderboard)
+[![GitHub Roast developer leaderboard](./show_img/leaderboard.png)](https://ghfind.com/en/leaderboard)
 
 ### 🪪 Turn your GitHub work into a shareable identity
 
@@ -34,13 +34,13 @@ Every assessment can generate a live badge and light/dark developer card for you
 
 <div align="center">
 
-[![GitHub Roast score badge](https://githubroast.dev/api/badge/hikariming)](https://githubroast.dev/en/u/hikariming)
+[![GitHub Roast score badge](https://ghfind.com/api/badge/hikariming)](https://ghfind.com/en/u/hikariming)
 
-<a href="https://githubroast.dev/en/u/hikariming">
+<a href="https://ghfind.com/en/u/hikariming">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://githubroast.dev/api/card/hikariming?theme=dark">
-    <source media="(prefers-color-scheme: light)" srcset="https://githubroast.dev/api/card/hikariming?theme=light">
-    <img alt="GitHub Roast card for hikariming" src="https://githubroast.dev/api/card/hikariming?theme=light" width="720">
+    <source media="(prefers-color-scheme: dark)" srcset="https://ghfind.com/api/card/hikariming?theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://ghfind.com/api/card/hikariming?theme=light">
+    <img alt="GitHub Roast card for hikariming" src="https://ghfind.com/api/card/hikariming?theme=light" width="720">
   </picture>
 </a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,11 +10,11 @@
 
 [English](./README.md) · **中文**
 
-[**🔥 测测 GitHub 成色**](https://githubroast.dev) · [**🏆 发现更多开发者**](https://githubroast.dev/leaderboard) · [**⭐ 查看源码**](https://github.com/hikariming/github-roast)
+[**🔥 测测 GitHub 成色**](https://ghfind.com) · [**🏆 发现更多开发者**](https://ghfind.com/leaderboard) · [**⭐ 查看源码**](https://github.com/hikariming/github-roast)
 
 </div>
 
-[![GitHub Roast 中文开发者主页预览](./show_img/usercard_cn.png)](https://githubroast.dev/u/hikariming)
+[![GitHub Roast 中文开发者主页预览](./show_img/usercard_cn.png)](https://ghfind.com/u/hikariming)
 
 ## 测评、发现、展示，一站完成
 
@@ -26,7 +26,7 @@
 
 这里不只负责打分。你可以通过排行榜和公开开发者主页，找到真正活跃的开源贡献者、同技术栈伙伴、潜在合作者，也能看看那些与你旗鼓相当、值得较量的「对家」。
 
-[![GitHub Roast 开发者排行榜](./show_img/leaderboard.png)](https://githubroast.dev/leaderboard)
+[![GitHub Roast 开发者排行榜](./show_img/leaderboard.png)](https://ghfind.com/leaderboard)
 
 ### 🪪 把开发经历变成可炫耀的身份卡
 
@@ -34,13 +34,13 @@
 
 <div align="center">
 
-[![GitHub Roast 评分徽章](https://githubroast.dev/api/badge/hikariming)](https://githubroast.dev/u/hikariming)
+[![GitHub Roast 评分徽章](https://ghfind.com/api/badge/hikariming)](https://ghfind.com/u/hikariming)
 
-<a href="https://githubroast.dev/u/hikariming">
+<a href="https://ghfind.com/u/hikariming">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://githubroast.dev/api/card/hikariming?theme=dark">
-    <source media="(prefers-color-scheme: light)" srcset="https://githubroast.dev/api/card/hikariming?theme=light">
-    <img alt="hikariming 的 GitHub Roast 开发者卡片" src="https://githubroast.dev/api/card/hikariming?theme=light" width="720">
+    <source media="(prefers-color-scheme: dark)" srcset="https://ghfind.com/api/card/hikariming?theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://ghfind.com/api/card/hikariming?theme=light">
+    <img alt="hikariming 的 GitHub Roast 开发者卡片" src="https://ghfind.com/api/card/hikariming?theme=light" width="720">
   </picture>
 </a>
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -43,10 +43,10 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           {t("subtitle")}
         </p>
         <a
-          href="https://githubroast.dev"
+          href="https://ghfind.com"
           className="mt-2 text-sm font-bold tracking-wide text-orange-400 hover:text-orange-300"
         >
-          githubroast.dev
+          ghfind.com
         </a>
         <p className="mt-3 max-w-md text-zinc-400">{t("tagline")}</p>
         <DeveloperCount />
@@ -82,8 +82,8 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
           })}
         </p>
         <p className="mt-2">
-          <a href="https://githubroast.dev" className="font-bold text-orange-400 hover:text-orange-300">
-            githubroast.dev
+          <a href="https://ghfind.com" className="font-bold text-orange-400 hover:text-orange-300">
+            ghfind.com
           </a>
         </p>
       </footer>

--- a/src/app/api/card/[username]/route.tsx
+++ b/src/app/api/card/[username]/route.tsx
@@ -155,7 +155,7 @@ function Brand({ palette }: { palette: CardPalette }) {
     <div style={{ display: "flex", justifyContent: "space-between", fontSize: 22 }}>
       <div style={{ display: "flex", color: palette.subtle }}>
         GitHub Roast ·{" "}
-        <span style={{ color: "#fb923c", fontWeight: 800, marginLeft: 6 }}>githubroast.dev</span>
+        <span style={{ color: "#fb923c", fontWeight: 800, marginLeft: 6 }}>ghfind.com</span>
       </div>
       <div style={{ display: "flex", color: palette.subtle }}>Powered by {SPONSOR.name}</div>
     </div>
@@ -280,7 +280,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ username: strin
             Not yet rated
           </div>
           <div style={{ display: "flex", fontSize: 26, color: palette.subtle, marginTop: 8 }}>
-            Get roasted at githubroast.dev
+            Get roasted at ghfind.com
           </div>
         </div>
         <Brand palette={palette} />

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -19,7 +19,7 @@ import { ShareCard } from "./ShareCard";
 import { TierAvatarFrame } from "./TierAvatarFrame";
 import { Turnstile, turnstileEnabled } from "./Turnstile";
 
-const SITE_URL = "https://githubroast.dev";
+const SITE_URL = "https://ghfind.com";
 
 interface Display {
   score: number;

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -122,7 +122,7 @@ export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(function Sha
       {/* Footer brand */}
       <div className="flex items-center justify-between text-sm">
         <span className="text-zinc-500">{t("brand")}</span>
-        <span className="font-black text-orange-400">githubroast.dev</span>
+        <span className="font-black text-orange-400">ghfind.com</span>
       </div>
     </div>
   );

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -159,7 +159,7 @@ export async function* chatStreamEvents(
         "Content-Type": "application/json",
         Authorization: `Bearer ${config.apiKey}`,
         // OpenRouter attribution headers (ignored by other providers).
-        "HTTP-Referer": process.env.PUBLIC_SITE_URL || "https://githubroast.dev",
+        "HTTP-Referer": process.env.PUBLIC_SITE_URL || "https://ghfind.com",
         "X-Title": "GitHub Roast",
       },
       body: JSON.stringify({

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -7,7 +7,7 @@
  * sitemap, robots, JSON-LD) now imports `SITE_URL` from here.
  */
 export const SITE_URL = (
-  process.env.PUBLIC_SITE_URL || "https://githubroast.dev"
+  process.env.PUBLIC_SITE_URL || "https://ghfind.com"
 ).replace(/\/$/, "");
 
 /**

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "GitHub Roast | Score Developers & Discover the Best",
-    "description": "Drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds — then browse the leaderboard to discover the best developers worth following. Built to expose PR farmers, AI bots, and fork-hoarders. githubroast.dev",
+    "description": "Drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds — then browse the leaderboard to discover the best developers worth following. Built to expose PR farmers, AI bots, and fork-hoarders. ghfind.com",
     "ogTitle": "GitHub Roast | Score Developers & Discover the Best",
     "ogDescription": "Score any GitHub account and discover top developers. 0-100 value & trust score + a savage roast in 30 seconds, plus a ranked developer leaderboard.",
     "twDescription": "Score any GitHub dev + discover the best on the leaderboard. 0-100 score & savage roast in 30s.",
@@ -132,8 +132,8 @@
   },
   "detailMeta": {
     "title": "{username} — {score}/100 · {tier} | Savage GitHub Roast",
-    "descWithTags": "{tags} — see {username}'s full score report on githubroast.dev.",
-    "descPlain": "{username}'s GitHub value & trust report — githubroast.dev.",
+    "descWithTags": "{tags} — see {username}'s full score report on ghfind.com.",
+    "descPlain": "{username}'s GitHub value & trust report — ghfind.com.",
     "notFoundTitle": "Account not found · Savage GitHub Roast"
   },
   "roaster": {
@@ -153,7 +153,7 @@
     "pasteGithub": "📌 Pin to GitHub",
     "copied": "Copied ✓",
     "privateNote": "Note: the score uses public signals only — private contributions don't count, so active members of private orgs may be underrated.",
-    "shareText": "My GitHub just got judged: {score}/100 · {tier} ({tierLabel}){beat}. Rate yours 👉 githubroast.dev",
+    "shareText": "My GitHub just got judged: {score}/100 · {tier} ({tierLabel}){beat}. Rate yours 👉 ghfind.com",
     "shareBeat": ", beating {beat}% of developers",
     "errEmpty": "Enter a GitHub username or profile URL first.",
     "errNeedTurnstile": "Please complete the verification below first.",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "毒舌 GitHub | 开发者评分 · 发现最佳开发者",
-    "description": "输入 GitHub 账号，30 秒得到一份 0-100 分的价值与信任评分和一句扎心毒舌点评；再逛逛名人堂榜单，发现最值得关注的优质开发者。专治刷量号、AI 机器人、收藏夹开发者。githubroast.dev",
+    "description": "输入 GitHub 账号，30 秒得到一份 0-100 分的价值与信任评分和一句扎心毒舌点评；再逛逛名人堂榜单，发现最值得关注的优质开发者。专治刷量号、AI 机器人、收藏夹开发者。ghfind.com",
     "ogTitle": "毒舌 GitHub | 开发者评分 · 发现最佳开发者",
     "ogDescription": "给 GitHub 账号打分，发现最佳开发者。30 秒出 0-100 分含金量评分 + 一句毒舌点评，还能逛开发者排行榜。",
     "twDescription": "30 秒给 GitHub 账号打分 + 毒舌点评，还能逛榜单发现最佳开发者。",
@@ -132,8 +132,8 @@
   },
   "detailMeta": {
     "title": "{username} — {score}/100 · {tier} | 毒舌 GitHub 评分",
-    "descWithTags": "{tags} —— 在 githubroast.dev 查看 {username} 的完整评分报告。",
-    "descPlain": "{username} 的 GitHub 价值评分报告 —— githubroast.dev。",
+    "descWithTags": "{tags} —— 在 ghfind.com 查看 {username} 的完整评分报告。",
+    "descPlain": "{username} 的 GitHub 价值评分报告 —— ghfind.com。",
     "notFoundTitle": "查无此号 · 毒舌 GitHub 评分"
   },
   "roaster": {
@@ -153,7 +153,7 @@
     "pasteGithub": "📌 贴到 GitHub",
     "copied": "已复制 ✓",
     "privateNote": "注：评分仅基于公开信号，私有贡献不计入，可能低估私有组织的活跃员工。",
-    "shareText": "我的 GitHub 含金量被审判了：{score}/100 · {tier}（{tierLabel}）{beat}。来测测你的 👉 githubroast.dev",
+    "shareText": "我的 GitHub 含金量被审判了：{score}/100 · {tier}（{tierLabel}）{beat}。来测测你的 👉 ghfind.com",
     "shareBeat": "，超越了 {beat}% 的开发者",
     "errEmpty": "请先输入 GitHub 用户名或主页链接。",
     "errNeedTurnstile": "请先完成下方的人机校验。",


### PR DESCRIPTION
## 改动内容

把代码里所有 `githubroast.dev` 域名字符串替换为 `ghfind.com`（11 个文件）。

### 替换范围
- **环境驱动 fallback**：`src/lib/site.ts`、`src/lib/llm.ts`（OpenRouter HTTP-Referer 归因头）
- **写死域名**：`Roaster.tsx`（client 组件）、`page.tsx`、`api/card/route.tsx`（OG 卡片）、`ShareCard.tsx`
- **i18n 文案**：`zh.json` / `en.json`
- **配置/文档**：`.env.example`（含 OAuth 回调注释）、`README.md`、`README.zh.md`

### 故意未改动
- 品牌名 `GitHub Roast`
- localStorage key（`gh-roast-*`）、User-Agent、`db.ts` 盐值 —— 改了会让用户本地缓存/登录失效
- `.env` 本地 `localhost` 配置

## 合并前需在 dashboard 完成
- [ ] Vercel 添加 `ghfind.com` 设为 Primary，旧域名设 **308 Permanent Redirect**
- [ ] Vercel 生产环境 `PUBLIC_SITE_URL=https://ghfind.com`
- [ ] GitHub OAuth App 的 Homepage / callback 改为新域名
- [ ] Google Search Console 加新资源 + 网站迁移工具关联旧域名

🤖 Generated with [Claude Code](https://claude.com/claude-code)