### PR TITLE
feat(home): 首页转向「发现最佳开发者，也成为其中之一」

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -36,10 +36,13 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
   return (
     <main className="flex flex-1 flex-col items-center px-5 py-14 sm:py-20">
       <header className="mb-10 flex flex-col items-center text-center">
-        <h1 className="text-4xl font-black tracking-tight sm:text-5xl">
-          {t("titleBefore")} <span className="text-orange-500">GitHub</span> {t("titleAfter")}
+        <p className="mb-3 text-sm font-bold tracking-wide text-zinc-400">
+          {t("brand")} <span className="text-orange-500">GitHub</span>
+        </p>
+        <h1 className="max-w-2xl text-balance text-4xl font-black tracking-tight sm:text-5xl">
+          {t("headline")}
         </h1>
-        <p className="mt-2 text-base font-semibold tracking-wide text-zinc-300 sm:text-lg">
+        <p className="mt-3 text-base font-semibold tracking-wide text-zinc-300 sm:text-lg">
           {t("subtitle")}
         </p>
         <a

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -43,11 +43,11 @@
     "title": "Source code & scoring algorithm are open source · View on GitHub"
   },
   "home": {
-    "titleBefore": "Savage",
-    "titleAfter": "Roast",
-    "subtitle": "Score yourself · Discover the best developers",
-    "tagline": "Drop a GitHub handle for a 0–100 value & trust score and a savage roast — then browse the Hall of Fame to discover the developers worth following.",
-    "boardHeading": "🏆 Hall of Fame",
+    "brand": "Savage",
+    "headline": "Discover the best developers — and become one.",
+    "subtitle": "Start with a brutally honest 0–100 score. See where you stand, learn where to go.",
+    "tagline": "Get a real 0–100 score in 30 seconds, a savage roast on what's holding you back, then find who to learn from on the board — and get found yourself.",
+    "boardHeading": "🏆 Best developers",
     "openBoard": "Open full leaderboard →",
     "disclaimer1": "Scores and roasts are generated automatically from <b>public GitHub data</b> only. We roast an account's public behavior and stats, not the person. Results are not factual claims about anyone — please don't use them to harass.",
     "disclaimer2": "The scoring core is open-sourced as the <code>github-account-value</code> skill · your own API key stays in your browser only."

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -43,11 +43,11 @@
     "title": "源码与评分算法均开源 · 在 GitHub 查看"
   },
   "home": {
-    "titleBefore": "毒舌",
-    "titleAfter": "评分",
-    "subtitle": "给自己打分 · 发现最佳开发者",
-    "tagline": "输入 GitHub 账号，30 秒得到 0–100 分的价值与信任评分和一句扎心毒舌点评；再逛逛名人堂，发现最值得关注的优质开发者。",
-    "boardHeading": "🏆 名人堂",
+    "brand": "毒舌",
+    "headline": "发现最佳开发者，也成为其中之一",
+    "subtitle": "先来一发 0–100 分的毒舌成色检测，看清你在哪，知道往哪走。",
+    "tagline": "30 秒测出真实成色，毒舌点醒你差在哪，再去发现榜找到该向谁学——也让世界发现你。",
+    "boardHeading": "🏆 发现最佳开发者",
     "openBoard": "打开完整榜单 →",
     "disclaimer1": "本站仅基于 GitHub <b>公开数据</b>自动生成评分与点评，吐槽的是账号的公开行为与数据，非针对个人。结果不构成对任何人的事实认定，请勿用于骚扰。",
     "disclaimer2": "评分核心开源于 <code>github-account-value</code> 技能 · 自带 Key 仅存于你的浏览器本地。"


### PR DESCRIPTION
## 改动
首页 Hero 围绕新战略口号重构,毒舌品牌保留为印记。

- **品牌印记**:`毒舌 GitHub`(小字,橙色 GitHub 高亮)—— 保留爆火名
- **H1**:升级为口号「发现最佳开发者,也成为其中之一」
- **副标题 / tagline**:重写为「测分 → 成长 → 被发现」三段弧,毒舌定位成入口
- **boardHeading**:名人堂 → 发现最佳开发者

i18n（zh/en）同步;`tsc` 通过、JSON 合法、无残留旧 key。

## 暂未做
「离最佳还差这几步」成长模块 —— 评分报告已含 LLM suggestion,做强需改 prompt（后端），不放空占位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)