### PR TITLE
chore(brand): 导航 + 首页 SEO 品牌名改为 ghfind

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "title": "GitHub Roast | Score Developers & Discover the Best",
-    "description": "Drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds — then browse the leaderboard to discover the best developers worth following. Built to expose PR farmers, AI bots, and fork-hoarders. ghfind.com",
-    "ogTitle": "GitHub Roast | Score Developers & Discover the Best",
-    "ogDescription": "Score any GitHub account and discover top developers. 0-100 value & trust score + a savage roast in 30 seconds, plus a ranked developer leaderboard.",
-    "twDescription": "Score any GitHub dev + discover the best on the leaderboard. 0-100 score & savage roast in 30s.",
-    "siteName": "Savage GitHub Roast"
+    "title": "ghfind | Savage GitHub · Discover the Best Developers",
+    "description": "ghfind — drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds, then browse the board to find and become the best developers. Built to expose PR farmers, AI bots, and fork-hoarders. ghfind.com",
+    "ogTitle": "ghfind | Savage GitHub · Discover the Best Developers",
+    "ogDescription": "ghfind: score any GitHub account and discover top developers. 0-100 value & trust score + a savage roast in 30 seconds, plus a ranked developer board.",
+    "twDescription": "Score any GitHub dev + discover the best on ghfind. 0-100 score & savage roast in 30s.",
+    "siteName": "ghfind"
   },
   "nav": {
-    "brand": "GitHub Roast",
+    "brand": "ghfind",
     "roast": "Roast",
     "leaderboard": "Leaderboard",
     "openMenu": "Open menu",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "title": "毒舌 GitHub | 开发者评分 · 发现最佳开发者",
-    "description": "输入 GitHub 账号，30 秒得到一份 0-100 分的价值与信任评分和一句扎心毒舌点评；再逛逛名人堂榜单，发现最值得关注的优质开发者。专治刷量号、AI 机器人、收藏夹开发者。ghfind.com",
-    "ogTitle": "毒舌 GitHub | 开发者评分 · 发现最佳开发者",
-    "ogDescription": "给 GitHub 账号打分，发现最佳开发者。30 秒出 0-100 分含金量评分 + 一句毒舌点评，还能逛开发者排行榜。",
-    "twDescription": "30 秒给 GitHub 账号打分 + 毒舌点评，还能逛榜单发现最佳开发者。",
-    "siteName": "毒舌 GitHub 评分"
+    "title": "ghfind | 毒舌 GitHub · 发现最佳开发者",
+    "description": "ghfind —— 输入 GitHub 账号，30 秒得到 0-100 分的价值与信任评分和一句扎心毒舌点评；逛发现榜，找到并成为最佳开发者。专治刷量号、AI 机器人、收藏夹开发者。ghfind.com",
+    "ogTitle": "ghfind | 毒舌 GitHub · 发现最佳开发者",
+    "ogDescription": "ghfind：给 GitHub 账号打分，发现最佳开发者。30 秒出 0-100 分含金量评分 + 一句毒舌点评，还能逛开发者榜单。",
+    "twDescription": "30 秒给 GitHub 账号打分 + 毒舌点评，在 ghfind 发现最佳开发者。",
+    "siteName": "ghfind"
   },
   "nav": {
-    "brand": "毒舌 GitHub",
+    "brand": "ghfind",
     "roast": "锐评",
     "leaderboard": "榜单",
     "openMenu": "打开菜单",


### PR DESCRIPTION
## 改动
- 头部导航品牌 `nav.brand`：毒舌 GitHub / GitHub Roast → **ghfind**
- 首页 SEO：title / description / ogTitle / ogDescription / twDescription / siteName 统一为 ghfind 开头（中英）

新 title：`ghfind | 毒舌 GitHub · 发现最佳开发者`

## 暂未改
个人主页 / 分享卡上的旧品牌名（profile title、notFoundTitle、card siteName、分享横幅）留作后续一并处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)