### PR TITLE
chore(brand): 个人主页 + 分享卡品牌名改为 ghfind

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -131,10 +131,10 @@
     "cooldown": "Refresh available in {hours}h"
   },
   "detailMeta": {
-    "title": "{username} — {score}/100 · {tier} | Savage GitHub Roast",
+    "title": "{username} — {score}/100 · {tier} | ghfind",
     "descWithTags": "{tags} — see {username}'s full score report on ghfind.com.",
     "descPlain": "{username}'s GitHub value & trust report — ghfind.com.",
-    "notFoundTitle": "Account not found · Savage GitHub Roast"
+    "notFoundTitle": "Account not found · ghfind"
   },
   "roaster": {
     "inputPlaceholder": "Enter a GitHub username or profile URL",
@@ -181,7 +181,7 @@
     "copyLink": "Copy link",
     "copied": "Copied ✓",
     "native": "More…",
-    "siteName": "Savage GitHub Roast"
+    "siteName": "ghfind"
   },
   "badge": {
     "heading": "📌 Pin to your GitHub profile",
@@ -211,7 +211,7 @@
   "developerCount": "<n>{count, number}</n> developers have entered the arena ⚔️",
   "shareCard": {
     "beatLabel": "developers beaten",
-    "brand": "🔥 Savage GitHub Roast · see how you stack up"
+    "brand": "🔥 ghfind · see how you stack up"
   },
   "tiers": {
     "god": { "name": "GOD", "blurb": "Legendary · Hall of Fame" },

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -131,10 +131,10 @@
     "cooldown": "{hours} 小时后可重新检测"
   },
   "detailMeta": {
-    "title": "{username} — {score}/100 · {tier} | 毒舌 GitHub 评分",
+    "title": "{username} — {score}/100 · {tier} | ghfind",
     "descWithTags": "{tags} —— 在 ghfind.com 查看 {username} 的完整评分报告。",
     "descPlain": "{username} 的 GitHub 价值评分报告 —— ghfind.com。",
-    "notFoundTitle": "查无此号 · 毒舌 GitHub 评分"
+    "notFoundTitle": "查无此号 · ghfind"
   },
   "roaster": {
     "inputPlaceholder": "输入 GitHub 用户名或主页链接",
@@ -181,7 +181,7 @@
     "copyLink": "复制链接",
     "copied": "已复制 ✓",
     "native": "系统分享…",
-    "siteName": "毒舌 GitHub 评分"
+    "siteName": "ghfind"
   },
   "badge": {
     "heading": "📌 贴到你的 GitHub 主页",
@@ -211,7 +211,7 @@
   "developerCount": "已经有 <n>{count, number}</n> 名开发者参与战斗 ⚔️",
   "shareCard": {
     "beatLabel": "超越的开发者",
-    "brand": "🔥 毒舌 GitHub 评分 · 来测测你的含金量"
+    "brand": "🔥 ghfind · 来测测你的含金量"
   },
   "tiers": {
     "god": { "name": "夯", "blurb": "封神 · 殿堂级标杆" },


### PR DESCRIPTION
完成全站品牌名统一,改掉剩余 4 处:
- `detailMeta.title`：个人主页 `<title>` 后缀 → `| ghfind`
- `detailMeta.notFoundTitle`：查无此号标题 → `· ghfind`
- `share.siteName`：主页 OG siteName → `ghfind`
- `shareCard.brand`：分享卡横幅 → `🔥 ghfind · 来测测你的含金量`

中英同步;`tsc` 通过、JSON 合法、无残留旧品牌名。

🤖 Generated with [Claude Code](https://claude.com/claude-code)