### PR TITLE
chore(seo): title/description 优化（加入开发者自测·成长关键词）

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "title": "ghfind | Savage GitHub · Discover the Best Developers",
-    "description": "ghfind — drop a GitHub handle for a 0-100 value & trust score and a savage roast in 30 seconds, then browse the board to find and become the best developers. Built to expose PR farmers, AI bots, and fork-hoarders. ghfind.com",
-    "ogTitle": "ghfind | Savage GitHub · Discover the Best Developers",
+    "title": "ghfind | Savage GitHub Score, Self-Test & Discover Top Devs",
+    "description": "ghfind: a 0-100 GitHub value & trust score plus a savage roast in 30s. See your gaps, self-test and grow, then discover top developers and get found.",
+    "ogTitle": "ghfind | Savage GitHub Score, Self-Test & Discover Top Devs",
     "ogDescription": "ghfind: score any GitHub account and discover top developers. 0-100 value & trust score + a savage roast in 30 seconds, plus a ranked developer board.",
     "twDescription": "Score any GitHub dev + discover the best on ghfind. 0-100 score & savage roast in 30s.",
     "siteName": "ghfind"

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "title": "ghfind | 毒舌 GitHub · 发现最佳开发者",
-    "description": "ghfind —— 输入 GitHub 账号，30 秒得到 0-100 分的价值与信任评分和一句扎心毒舌点评；逛发现榜，找到并成为最佳开发者。专治刷量号、AI 机器人、收藏夹开发者。ghfind.com",
-    "ogTitle": "ghfind | 毒舌 GitHub · 发现最佳开发者",
+    "title": "ghfind | 毒舌 GitHub 评分 · 开发者自测成长 · 发现最佳开发者",
+    "description": "ghfind（毒舌 GitHub 评分）：输入 GitHub 账号，30 秒得到 0-100 分价值与信任评分和一句扎心毒舌点评，看清差距、知道往哪努力，自测并持续成长；再逛发现榜找到值得关注的优质开发者，也让世界发现你。专治刷量号、AI 机器人、收藏夹开发者。",
+    "ogTitle": "ghfind | 毒舌 GitHub 评分 · 开发者自测成长 · 发现最佳开发者",
     "ogDescription": "ghfind：给 GitHub 账号打分，发现最佳开发者。30 秒出 0-100 分含金量评分 + 一句毒舌点评，还能逛开发者榜单。",
     "twDescription": "30 秒给 GitHub 账号打分 + 毒舌点评，在 ghfind 发现最佳开发者。",
     "siteName": "ghfind"


### PR DESCRIPTION
## 改动
- **title**（zh 28→41 / en →59，均 ≤60）：加入「开发者自测成长 / Self-Test & grow」关键词
  - zh：`ghfind | 毒舌 GitHub 评分 · 开发者自测成长 · 发现最佳开发者`
  - en：`ghfind | Savage GitHub Score, Self-Test & Discover Top Devs`
- **description**（zh 101→131 / en →149，均 ≤160）：关键词更丰富、把字数用足，覆盖 评分→看清差距→自测成长→发现开发者→被发现
- ogTitle 同步 title

`tsc` 通过、JSON 合法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)