### PR TITLE
fix(omnibox): allow deleting unlocked duel text

### DIFF
--- a/src/components/Omnibox.tsx
+++ b/src/components/Omnibox.tsx
@@ -9,6 +9,7 @@ import {
   omniboxRoute,
   omniboxSuggestions,
   parseOmnibox,
+  shouldAutoLockPkIntent,
 } from "@/lib/omnibox";
 import type { UserSuggestion } from "@/lib/db";
 import { tierStyle } from "@/lib/tier";
@@ -69,6 +70,7 @@ export function Omnibox({
   const t = useTranslations("omnibox");
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
+  const suppressNextHalfLockRef = useRef(false);
 
   // The locked first handle once a PK separator is typed; while set, `value`
   // holds only the opponent's handle and the combined string is reconstructed.
@@ -185,15 +187,12 @@ export function Omnibox({
       // left handle into a chip and start collecting the opponent.
       if (!pkA) {
         const parsed = parseOmnibox(next);
-        if (parsed.kind === "pk-half") {
-          setPkA(parsed.a);
-          onChange("");
-          return;
+        if (suppressNextHalfLockRef.current && parsed.kind !== "pk-half") {
+          suppressNextHalfLockRef.current = false;
         }
-        if (parsed.kind === "pk") {
-          // Pasted "a vs b" — lock the first, keep the second as editable text.
+        if (shouldAutoLockPkIntent(parsed, suppressNextHalfLockRef.current)) {
           setPkA(parsed.a);
-          onChange(parsed.b);
+          onChange(parsed.kind === "pk" ? parsed.b : "");
           return;
         }
       }
@@ -205,6 +204,7 @@ export function Omnibox({
   const popChip = useCallback(() => {
     if (pkA == null) return;
     const restored = `${pkA} vs `;
+    suppressNextHalfLockRef.current = true;
     setPkA(null);
     onChange(restored);
     requestAnimationFrame(() => inputRef.current?.focus());

--- a/src/lib/__tests__/omnibox.test.ts
+++ b/src/lib/__tests__/omnibox.test.ts
@@ -3,6 +3,7 @@ import {
   omniboxRoute,
   omniboxSuggestions,
   parseOmnibox,
+  shouldAutoLockPkIntent,
 } from "../omnibox";
 
 describe("parseOmnibox — PK (P0)", () => {
@@ -127,5 +128,16 @@ describe("omniboxSuggestions", () => {
 
   it("returns nothing for empty input", () => {
     expect(omniboxSuggestions("   ")).toEqual([]);
+  });
+});
+
+describe("shouldAutoLockPkIntent", () => {
+  it("does not relock a restored half-PK string while the user backspaces it", () => {
+    expect(shouldAutoLockPkIntent(parseOmnibox("torvalds vs"), true)).toBe(false);
+    expect(shouldAutoLockPkIntent(parseOmnibox("torvalds vs"), false)).toBe(true);
+  });
+
+  it("still auto-locks a complete pasted PK while half-lock suppression is active", () => {
+    expect(shouldAutoLockPkIntent(parseOmnibox("torvalds vs linus"), true)).toBe(true);
   });
 });

--- a/src/lib/omnibox.ts
+++ b/src/lib/omnibox.ts
@@ -28,6 +28,13 @@ export type OmniIntent =
   | { kind: "user"; username: string }
   | { kind: "freetext"; query: string };
 
+export function shouldAutoLockPkIntent(
+  intent: OmniIntent,
+  suppressHalfLock: boolean,
+): intent is Extract<OmniIntent, { kind: "pk" | "pk-half" }> {
+  return intent.kind === "pk" || (intent.kind === "pk-half" && !suppressHalfLock);
+}
+
 /** Language alias → canonical GitHub Linguist name (matches stored facet value). */
 export const LANGUAGE_ALIASES: Record<string, string> = {
   rust: "Rust",


### PR DESCRIPTION
## Summary
- Stop the Omnibox from immediately re-locking a restored `a vs ` half-duel string after the user removes the chip.
- Keep full pasted duel input (`a vs b`) auto-lock behavior intact.
- Add unit coverage for the half-duel suppression case.

## Root cause
Removing the locked duel chip restored the input to `a vs `. The next edit parsed that value as `pk-half` again, so Backspace re-created the chip instead of deleting text.

## Validation
- `./node_modules/.bin/vitest run src/lib/__tests__/omnibox.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/components/Omnibox.tsx src/lib/omnibox.ts src/lib/__tests__/omnibox.test.ts`
- Manual check by @KurosawaGeeker: removing the chip and pressing Backspace now deletes text instead of cycling.

## Generated files
- No generated files.
- No GraphQL codegen updates.
- No DB baseline updates.
