### PR TITLE
feat(dimensions): add animated six-star chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.9.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.4)
+      recharts:
+        specifier: ^3.9.1
+        version: 3.9.1(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1166,6 +1169,17 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1272,6 +1286,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/core-darwin-arm64@1.15.43':
     resolution: {integrity: sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==}
@@ -1467,6 +1484,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1513,6 +1557,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1995,6 +2042,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2030,6 +2121,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -2125,6 +2219,9 @@ packages:
   es-to-primitive@1.3.1:
     resolution: {integrity: sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2268,6 +2365,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2457,6 +2557,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2471,6 +2574,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@11.2.9:
     resolution: {integrity: sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA==}
@@ -3178,6 +3285,18 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -3212,6 +3331,22 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.9.1:
+    resolution: {integrity: sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3238,6 +3373,9 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3432,6 +3570,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3571,11 +3712,19 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.1.0:
     resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
@@ -4630,6 +4779,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
 
@@ -4686,6 +4847,8 @@ snapshots:
   '@schummar/icu-type-parser@1.21.5': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/core-darwin-arm64@1.15.43':
     optional: true
@@ -4830,6 +4993,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -4875,6 +5062,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -5318,6 +5507,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -5347,6 +5574,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -5512,6 +5741,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -5759,6 +5990,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -5954,6 +6187,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5968,6 +6203,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  internmap@2.0.3: {}
 
   intl-messageformat@11.2.9:
     dependencies:
@@ -6871,6 +7108,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -6899,6 +7145,32 @@ snapshots:
       '@types/react': 19.2.17
 
   react@19.2.4: {}
+
+  recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.49.0
+      eventemitter3: 5.0.4
+      immer: 11.1.8
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 16.13.1
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6957,6 +7229,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -7227,6 +7501,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -7419,6 +7695,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -7428,6 +7708,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.1.0(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4):
     dependencies:

--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -20,8 +20,9 @@ import { CopyBadge } from "@/components/CopyBadge";
 import { ProfileShare } from "@/components/ProfileShare";
 import { FloatingCommentBubbles } from "@/components/FloatingCommentBubbles";
 import { TierAvatarFrame } from "@/components/TierAvatarFrame";
-import { SUBSCORE_MAX, nextTier } from "@/lib/score";
-import { DIMENSIONS, barColor } from "@/lib/dimensions";
+import { DimensionStarChart } from "@/components/DimensionStarChart";
+import { nextTier } from "@/lib/score";
+import { DIMENSIONS } from "@/lib/dimensions";
 import { beatPercent } from "@/lib/percentile";
 import { TIER_KEY, tierStyle } from "@/lib/tier";
 import { normLang } from "@/lib/lang";
@@ -125,6 +126,9 @@ export default async function AccountPage({
   const promoTierName = promo ? tTier(`${TIER_KEY[promo.tier]}.name`) : null;
   const beat = rank ? beatPercent(rank.below, rank.total) : null;
   const detailPath = locale === "en" ? `/en/u/${d.username}` : `/u/${d.username}`;
+  const dimensionLabels = Object.fromEntries(
+    DIMENSIONS.map((key) => [key, tDim(key)]),
+  ) as Record<(typeof DIMENSIONS)[number], string>;
 
   // Evidence blocks (only when a sedimented snapshot exists). Featured work =
   // the user's own top repos, with self-pinned repos floated to the front.
@@ -371,30 +375,7 @@ export default async function AccountPage({
       {/* Dimension breakdown */}
       <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-5 sm:p-6">
         <h2 className="mb-4 text-base font-bold text-zinc-200">{t("dimensionsHeading")}</h2>
-        <div className="flex flex-col gap-3">
-          {DIMENSIONS.map((key) => {
-            const max = SUBSCORE_MAX[key];
-            const v = d.sub_scores[key] ?? 0;
-            const pct = Math.max(0, Math.min(1, v / max));
-            return (
-              <div key={key}>
-                <div className="mb-1 flex items-baseline justify-between text-sm">
-                  <span className="text-zinc-300">{tDim(key)}</span>
-                  <span className="tabular-nums text-zinc-400">
-                    {v.toFixed(1)}
-                    <span className="text-zinc-600"> / {max}</span>
-                  </span>
-                </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
-                  <div
-                    className={`h-full rounded-full ${barColor(pct)}`}
-                    style={{ width: `${pct * 100}%` }}
-                  />
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        <DimensionStarChart scores={d.sub_scores} labels={dimensionLabels} tier={d.tier} />
       </section>
 
       {/* Featured work — the user's own popular repos, self-pinned floated up. */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -457,10 +457,132 @@ html[data-theme="light"] [data-force-dark] .text-orange-400 {
   animation: profile-reaction-bump 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+@keyframes dimension-star-radar-dot {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+  68% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.dimension-star-radar .recharts-wrapper,
+.dimension-star-radar .recharts-surface {
+  overflow: visible;
+}
+
+.dimension-star-radar {
+  --dimension-star-stroke: #f97316;
+  --dimension-star-fill: rgba(249, 115, 22, 0.16);
+  --dimension-star-shadow: rgba(249, 115, 22, 0.18);
+}
+
+.dimension-star-radar[data-tone="god"] {
+  --dimension-star-stroke: #f59e0b;
+  --dimension-star-fill: rgba(245, 158, 11, 0.16);
+  --dimension-star-shadow: rgba(245, 158, 11, 0.2);
+}
+
+.dimension-star-radar[data-tone="elite"] {
+  --dimension-star-stroke: #a78bfa;
+  --dimension-star-fill: rgba(167, 139, 250, 0.15);
+  --dimension-star-shadow: rgba(167, 139, 250, 0.18);
+}
+
+.dimension-star-radar[data-tone="solid"] {
+  --dimension-star-stroke: #34d399;
+  --dimension-star-fill: rgba(52, 211, 153, 0.14);
+  --dimension-star-shadow: rgba(52, 211, 153, 0.16);
+}
+
+.dimension-star-radar[data-tone="npc"] {
+  --dimension-star-stroke: #94a3b8;
+  --dimension-star-fill: rgba(148, 163, 184, 0.14);
+  --dimension-star-shadow: rgba(148, 163, 184, 0.14);
+}
+
+.dimension-star-radar[data-tone="trash"] {
+  --dimension-star-stroke: #fb7185;
+  --dimension-star-fill: rgba(251, 113, 133, 0.14);
+  --dimension-star-shadow: rgba(251, 113, 133, 0.16);
+}
+
+html[data-theme="light"] .dimension-star-radar {
+  --dimension-star-stroke: #c2410c;
+  --dimension-star-fill: rgba(194, 65, 12, 0.11);
+  --dimension-star-shadow: rgba(194, 65, 12, 0.14);
+}
+
+html[data-theme="light"] .dimension-star-radar[data-tone="god"] {
+  --dimension-star-stroke: #a16207;
+  --dimension-star-fill: rgba(161, 98, 7, 0.12);
+  --dimension-star-shadow: rgba(161, 98, 7, 0.16);
+}
+
+html[data-theme="light"] .dimension-star-radar[data-tone="elite"] {
+  --dimension-star-stroke: #6d28d9;
+  --dimension-star-fill: rgba(109, 40, 217, 0.1);
+  --dimension-star-shadow: rgba(109, 40, 217, 0.13);
+}
+
+html[data-theme="light"] .dimension-star-radar[data-tone="solid"] {
+  --dimension-star-stroke: #047857;
+  --dimension-star-fill: rgba(4, 120, 87, 0.1);
+  --dimension-star-shadow: rgba(4, 120, 87, 0.12);
+}
+
+html[data-theme="light"] .dimension-star-radar[data-tone="npc"] {
+  --dimension-star-stroke: #475569;
+  --dimension-star-fill: rgba(71, 85, 105, 0.1);
+  --dimension-star-shadow: rgba(71, 85, 105, 0.12);
+}
+
+html[data-theme="light"] .dimension-star-radar[data-tone="trash"] {
+  --dimension-star-stroke: #be123c;
+  --dimension-star-fill: rgba(190, 18, 60, 0.1);
+  --dimension-star-shadow: rgba(190, 18, 60, 0.12);
+}
+
+.dimension-star-radar .recharts-radar-polygon .recharts-polygon {
+  fill: var(--dimension-star-fill);
+  filter: drop-shadow(0 18px 34px var(--dimension-star-shadow));
+  stroke: var(--dimension-star-stroke);
+  stroke-linejoin: round;
+}
+
+.dimension-star-radar-dot {
+  animation: dimension-star-radar-dot 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: 520ms;
+  fill: var(--dimension-star-stroke);
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.dimension-star-radar-label {
+  fill: var(--foreground);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.dimension-star-radar-score {
+  fill: var(--dimension-star-stroke);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .floating-comment-bubble,
   .mobile-danmaku-comment,
-  .profile-reaction-bump {
+  .profile-reaction-bump,
+  .dimension-star-radar-dot {
     animation: none;
   }
 

--- a/src/components/DimensionStarChart.tsx
+++ b/src/components/DimensionStarChart.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { DIMENSIONS } from "@/lib/dimensions";
+import { SUBSCORE_MAX } from "@/lib/score";
+import { TIER_KEY } from "@/lib/tier";
+import type { SubScoreKey, SubScores, Tier } from "@/lib/types";
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+} from "recharts";
+
+interface DimensionStarChartProps {
+  scores: SubScores;
+  labels: Record<SubScoreKey, string>;
+  tier?: Tier;
+  animate?: boolean;
+}
+
+interface DimensionDatum {
+  key: SubScoreKey;
+  label: string;
+  value: number;
+  max: number;
+  pct: number;
+  scoreLabel: string;
+}
+
+interface AxisTickPayload {
+  value?: unknown;
+}
+
+interface AxisTickProps {
+  x?: number | string;
+  y?: number | string;
+  index?: number;
+  payload?: AxisTickPayload;
+}
+
+const SCORE_DOMAIN = [0, 100] as const;
+const CHART_MARGIN = { top: 60, right: 92, bottom: 60, left: 92 };
+
+function clampPct(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function formatScore(value: number, max: number): string {
+  return `${value.toFixed(1)} / ${max}`;
+}
+
+function splitLabel(label: string): string[] {
+  const trimmed = label.trim();
+  if (!trimmed) return [""];
+
+  if (trimmed.includes("/")) {
+    const [first, ...rest] = trimmed.split("/");
+    const second = rest.join("/");
+    return second ? [`${first}/`, second] : [trimmed];
+  }
+
+  if (/[\s-]/.test(trimmed) && trimmed.length > 16) {
+    const words = trimmed.split(/(\s+|-)/).filter(Boolean);
+    const midpoint = Math.ceil(words.length / 2);
+    const first = words.slice(0, midpoint).join("").trim();
+    const second = words.slice(midpoint).join("").trim();
+    return second ? [first, second] : [trimmed];
+  }
+
+  return [trimmed];
+}
+
+function coerceNumber(value: number | string | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function tickAnchor(index: number): "start" | "middle" | "end" {
+  if (index === 1 || index === 2) return "start";
+  if (index === 4 || index === 5) return "end";
+  return "middle";
+}
+
+function tickDy(index: number, lineCount: number): number {
+  if (index === 0) return -8 - lineCount * 3;
+  if (index === 3) return 12;
+  return 4;
+}
+
+function isTickProps(props: unknown): props is AxisTickProps {
+  if (!props || typeof props !== "object") return false;
+  return "payload" in props || "x" in props || "y" in props;
+}
+
+export function DimensionStarChart({
+  scores,
+  labels,
+  tier,
+  animate = true,
+}: DimensionStarChartProps) {
+  const data: DimensionDatum[] = DIMENSIONS.map((key) => {
+    const max = SUBSCORE_MAX[key];
+    const value = scores[key] ?? 0;
+    const pct = clampPct(value / max);
+    return {
+      key,
+      label: labels[key],
+      value,
+      max,
+      pct: pct * 100,
+      scoreLabel: formatScore(value, max),
+    };
+  });
+
+  const chartKey = data
+    .map((dimension) => `${dimension.key}:${dimension.value.toFixed(2)}`)
+    .join("|");
+  const ariaLabel = data
+    .map((dimension) => `${dimension.label} ${dimension.scoreLabel}`)
+    .join(", ");
+  const toneKey = tier ? TIER_KEY[tier] : "brand";
+
+  const renderTick = (rawProps: unknown) => {
+    if (!isTickProps(rawProps)) return <g />;
+    const x = coerceNumber(rawProps.x);
+    const y = coerceNumber(rawProps.y);
+    if (x === null || y === null) return <g />;
+
+    const key = rawProps.payload?.value;
+    const dimension =
+      typeof key === "string"
+        ? data.find((item) => item.key === key)
+        : typeof rawProps.index === "number"
+          ? data[rawProps.index]
+          : undefined;
+    if (!dimension) return <g />;
+
+    const index = data.findIndex((item) => item.key === dimension.key);
+    const labelLines = splitLabel(dimension.label).slice(0, 2);
+    const textAnchor = tickAnchor(index);
+    const labelDy = tickDy(index, labelLines.length);
+
+    return (
+      <g transform={`translate(${x}, ${y})`}>
+        <text
+          textAnchor={textAnchor}
+          dominantBaseline="middle"
+          className="dimension-star-radar-label"
+        >
+          {labelLines.map((line, lineIndex) => (
+            <tspan key={line} x="0" dy={lineIndex === 0 ? labelDy : 16}>
+              {line}
+            </tspan>
+          ))}
+          <tspan
+            x="0"
+            dy="17"
+            className="dimension-star-radar-score"
+          >
+            {dimension.scoreLabel}
+          </tspan>
+        </text>
+      </g>
+    );
+  };
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      data-tone={toneKey}
+      className="dimension-star-radar mx-auto h-[23rem] w-full max-w-3xl sm:h-[26rem]"
+    >
+      <RadarChart
+        responsive
+        data={data}
+        margin={CHART_MARGIN}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <PolarGrid
+          gridType="polygon"
+          radialLines
+          stroke="var(--border-soft)"
+          strokeWidth={1}
+          fill="var(--surface)"
+          fillOpacity={0.32}
+        />
+        <PolarAngleAxis
+          dataKey="key"
+          axisLine={false}
+          tick={renderTick}
+          tickLine={false}
+          tickSize={22}
+        />
+        <PolarRadiusAxis
+          angle={90}
+          domain={SCORE_DOMAIN}
+          axisLine={false}
+          tick={false}
+          tickCount={5}
+        />
+        <Radar
+          key={animate ? chartKey : "dimension-star-radar"}
+          dataKey="pct"
+          stroke="#f97316"
+          fill="rgba(249, 115, 22, 0.16)"
+          fillOpacity={1}
+          strokeWidth={3}
+          dot={{
+            r: 5.5,
+            fill: "#f97316",
+            stroke: "var(--background)",
+            strokeWidth: 2,
+            className: animate ? "dimension-star-radar-dot" : undefined,
+          }}
+          isAnimationActive={animate ? "auto" : false}
+          animationBegin={0}
+          animationDuration={760}
+          animationEasing="ease"
+        />
+      </RadarChart>
+    </div>
+  );
+}

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -5,9 +5,10 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { DIMENSIONS } from "@/lib/dimensions";
 import { splitReport } from "@/lib/report";
 import { TIER_KEY, tierStyle } from "@/lib/tier";
-import type { RoastLine, RoastMeta, ScanResult, Tags, Tier } from "@/lib/types";
+import type { RoastLine, RoastMeta, ScanResult, SubScoreKey, Tags, Tier } from "@/lib/types";
 import {
   ByoKeyConfig,
   ByoKeyModal,
@@ -23,6 +24,7 @@ import { createShareCardBlob } from "./shareCardExport";
 import { TierAvatarFrame } from "./TierAvatarFrame";
 import { Turnstile, turnstileEnabled } from "./Turnstile";
 import { Omnibox } from "./Omnibox";
+import { DimensionStarChart } from "./DimensionStarChart";
 
 const SITE_URL = "https://ghfind.com";
 
@@ -37,6 +39,8 @@ export function Roaster() {
   const t = useTranslations("roaster");
   const tScan = useTranslations("scanErrors");
   const tTier = useTranslations("tiers");
+  const tDetail = useTranslations("detail");
+  const tDim = useTranslations("dimensions");
   const locale = useLocale();
   const searchParams = useSearchParams();
 
@@ -280,6 +284,9 @@ export function Roaster() {
   // the inline 🔥 marker; either way the body renders without that line.
   const { body: reportBody, roast: inlineRoast } = splitReport(report);
   const roastLine = (metaRoast ? (locale === "en" ? metaRoast.en : metaRoast.zh) : "") || inlineRoast;
+  const dimensionLabels = Object.fromEntries(
+    DIMENSIONS.map((key) => [key, tDim(key)]),
+  ) as Record<SubScoreKey, string>;
   const cardRef = useRef<HTMLDivElement>(null);
   const badgeRef = useRef<HTMLDivElement>(null);
   const [savingImg, setSavingImg] = useState(false);
@@ -392,7 +399,7 @@ export function Roaster() {
       {scan && display && style && (
         <div ref={reportRef} className="mt-10">
           <div
-            className={`animate-pop mx-auto flex max-w-md flex-col items-center rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-center ring-1 ${style.ring}`}
+            className={`animate-pop mx-auto flex max-w-3xl flex-col items-center rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-center ring-1 ${style.ring}`}
             style={{ boxShadow: `0 0 80px -20px ${style.glow}` }}
           >
             <a
@@ -455,6 +462,17 @@ export function Roaster() {
                   ))}
                 </div>
               )}
+            </div>
+
+            <div className="mt-4 w-full rounded-xl border border-white/10 bg-white/[0.02] p-4 text-left sm:p-5">
+              <div className="mb-4 text-base font-bold text-zinc-200">
+                {tDetail("dimensionsHeading")}
+              </div>
+              <DimensionStarChart
+                scores={scan.scoring.sub_scores}
+                labels={dimensionLabels}
+                tier={display.tier}
+              />
             </div>
 
             {percentile &&


### PR DESCRIPTION
## Summary

- Add a Recharts-powered six-axis dimension chart that renders each score and max value directly on the radar labels.
- Replace the detail page dimension progress bars with the shared six-star chart.
- Add the same chart to the homepage result card, with data remounting so refreshed scan data animates outward from the center.
- Align chart colors with existing tier tones across light and dark themes.

## Validation

- `pnpm typecheck`
- `./node_modules/.bin/eslint src/components/DimensionStarChart.tsx src/components/Roaster.tsx 'src/app/[locale]/u/[username]/page.tsx'`
- `git diff --check`
- `curl http://localhost:3002/u/codex-god-96` -> 200
- `curl http://localhost:3002/u/codex-trash-12` -> 200
- Local light/dark/auto visual checks on the six-star detail and result-card surfaces

## Notes

- `pnpm lint` still fails on pre-existing unrelated script issues: `scripts/langgenius-audit.mts:50:19` (`no-explicit-any`) and `scripts/mega-ingest.mts:2:40` (unused `existsSync`).
- No generated files, GraphQL codegen, or DB baseline updates are included. `pnpm-lock.yaml` changes only come from adding `recharts`.