### PR TITLE
fix: 仅将已合并 PR 计入高星影响贡献

### DIFF
--- a/src/lib/__tests__/github.test.ts
+++ b/src/lib/__tests__/github.test.ts
@@ -273,6 +273,154 @@ ${"Useful project detail. ".repeat(50)}
     );
   });
 
+  it("does not count unmerged PR contribution graph entries as high-star impact", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url === "https://api.github.com/users/lamp") {
+          return jsonResponse({
+            login: "lamp",
+            id: 1,
+            html_url: "https://github.com/lamp",
+            avatar_url: null,
+            name: "Lamp",
+            bio: null,
+            company: null,
+            created_at: "2020-01-01T00:00:00Z",
+            followers: 0,
+            following: 0,
+            public_repos: 0,
+          });
+        }
+
+        if (url.includes("/users/lamp/repos")) {
+          return jsonResponse([]);
+        }
+
+        if (url === "https://api.github.com/graphql") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { query?: string };
+          const query = body.query ?? "";
+
+          if (query.includes("organizations(first: 20)")) {
+            return jsonResponse({ data: { user: { organizations: { nodes: [] } } } });
+          }
+
+          if (query.includes("contributionsCollection(from:")) {
+            expect(query).not.toContain("pullRequestContributionsByRepository");
+            return jsonResponse({
+              data: {
+                user: {
+                  y0: {
+                    commitContributionsByRepository: [],
+                    // This used to be the source of the bug: GitHub's PR
+                    // contribution graph can include opened-but-unmerged PRs.
+                    // The scanner must ignore it for landed impact.
+                    pullRequestContributionsByRepository: [
+                      {
+                        contributions: { totalCount: 1 },
+                        repository: {
+                          nameWithOwner: "trekhleb/javascript-algorithms",
+                          stargazerCount: 196000,
+                          isPrivate: false,
+                          isFork: false,
+                          owner: { login: "trekhleb" },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            });
+          }
+
+          if (
+            query.includes("mergedPRs: pullRequests") &&
+            query.includes("pinnedItems(first: 6, types: REPOSITORY)")
+          ) {
+            return jsonResponse({
+              data: {
+                user: {
+                  pinnedItems: { nodes: [] },
+                  mergedPRs: { totalCount: 0 },
+                  allPRs: { totalCount: 1 },
+                  closedPRs: {
+                    totalCount: 1,
+                    nodes: [
+                      {
+                        author: { login: "lamp" },
+                        repository: { owner: { login: "trekhleb" } },
+                        timelineItems: { nodes: [{ actor: { login: "lamp" } }] },
+                      },
+                    ],
+                  },
+                  issues: { totalCount: 0 },
+                  contributionsCollection: {
+                    totalCommitContributions: 0,
+                    totalPullRequestContributions: 1,
+                    totalIssueContributions: 0,
+                    totalPullRequestReviewContributions: 0,
+                    restrictedContributionsCount: 0,
+                    contributionCalendar: { totalContributions: 1 },
+                  },
+                  contributionYears: { contributionYears: [2023] },
+                },
+              },
+            });
+          }
+
+          if (query.includes("pullRequests(first: $count, states: MERGED")) {
+            return jsonResponse({
+              data: {
+                user: {
+                  pullRequests: {
+                    nodes: [],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              },
+            });
+          }
+
+          if (
+            query.includes("pullRequests(first: $count, orderBy: {field: CREATED_AT, direction: DESC})")
+          ) {
+            return jsonResponse({
+              data: {
+                user: {
+                  pullRequests: {
+                    nodes: [
+                      {
+                        title: "Add fastPoweringBitwise function",
+                        repository: { nameWithOwner: "trekhleb/javascript-algorithms" },
+                      },
+                    ],
+                  },
+                },
+              },
+            });
+          }
+        }
+
+        return jsonResponse({}, 404);
+      }),
+    );
+
+    const result = await collect("lamp");
+
+    expect(result.metrics.merged_pr_count).toBe(0);
+    expect(result.metrics.self_closed_external_pr_count).toBe(1);
+    expect(result.metrics.impact_pr_count).toBe(0);
+    expect(result.metrics.max_impact_repo_stars).toBe(0);
+    expect(result.impact_repos).toEqual([]);
+  });
+
   it("degrades gracefully when organization lookup lacks read:org scope", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1068,7 +1068,10 @@ export function computeImpactQualitySignals(
   };
 }
 
-/** One repo's all-time contribution aggregate, keyed by `nameWithOwner`. */
+/** One repo's all-time contribution aggregate, keyed by `nameWithOwner`.
+ * `commits` comes from the contribution graph; `prs` must come from merged PRs
+ * only. GitHub's PR contribution graph can include opened-but-unmerged PRs, so
+ * it is not safe as a landed-impact source. */
 export interface ContribRepoAgg {
   repo: string;
   stars: number;
@@ -1240,15 +1243,14 @@ interface ContribByRepoNode {
 
 interface YearContribs {
   commitContributionsByRepository: ContribByRepoNode[];
-  pullRequestContributionsByRepository: ContribByRepoNode[];
 }
 
 /**
- * Fetch all-time per-repo commit + PR contributions by aliasing one
+ * Fetch all-time per-repo commit contributions by aliasing one
  * `contributionsCollection(from,to)` per year (GraphQL caps each to a 1-year
  * span), capped to the most recent {@link IMPACT_YEAR_CAP} years.
  */
-async function fetchContribReposByYear(
+async function fetchCommitContribReposByYear(
   username: string,
   years: number[],
 ): Promise<ContribRepoAgg[] | null> {
@@ -1257,10 +1259,6 @@ async function fetchContribReposByYear(
 
   const fragment = `fragment RepoContribs on ContributionsCollection {
     commitContributionsByRepository(maxRepositories: 100) {
-      contributions { totalCount }
-      repository { nameWithOwner stargazerCount isPrivate isFork owner { login } }
-    }
-    pullRequestContributionsByRepository(maxRepositories: 100) {
       contributions { totalCount }
       repository { nameWithOwner stargazerCount isPrivate isFork owner { login } }
     }
@@ -1293,7 +1291,7 @@ async function fetchContribReposByYear(
   // Merge per-year per-repo aggregates: sum commits/prs, take max stars.
   const map = new Map<string, ContribRepoAgg>();
   const yearsByRepo = new Map<string, Set<number>>();
-  const ingest = (node: ContribByRepoNode, kind: "commits" | "prs", year: number): void => {
+  const ingest = (node: ContribByRepoNode, year: number): void => {
     const repo = node.repository;
     if (!repo) return;
     const key = repo.nameWithOwner;
@@ -1310,7 +1308,7 @@ async function fetchContribReposByYear(
         active_years: 0,
       };
     entry.stars = Math.max(entry.stars, repo.stargazerCount ?? 0);
-    entry[kind] += node.contributions?.totalCount ?? 0;
+    entry.commits += node.contributions?.totalCount ?? 0;
     map.set(key, entry);
     const years = yearsByRepo.get(key) ?? new Set<number>();
     years.add(year);
@@ -1319,13 +1317,127 @@ async function fetchContribReposByYear(
   for (let i = 0; i < capped.length; i++) {
     const yc = data.user[`y${i}`];
     if (!yc) continue;
-    for (const n of yc.commitContributionsByRepository ?? []) ingest(n, "commits", capped[i]);
-    for (const n of yc.pullRequestContributionsByRepository ?? []) ingest(n, "prs", capped[i]);
+    for (const n of yc.commitContributionsByRepository ?? []) ingest(n, capped[i]);
   }
   return [...map.entries()].map(([key, value]) => ({
     ...value,
     active_years: yearsByRepo.get(key)?.size ?? 0,
   }));
+}
+
+interface MergedPrRepoNode {
+  mergedAt: string | null;
+  repository: {
+    nameWithOwner: string;
+    stargazerCount: number;
+    isPrivate: boolean;
+    isFork: boolean;
+    owner: { login: string } | null;
+  } | null;
+}
+
+type MergedPrPageInfo = { hasNextPage: boolean; endCursor: string | null };
+
+interface MergedPrReposResponse {
+  user: {
+    pullRequests: {
+      nodes: MergedPrRepoNode[];
+      pageInfo: MergedPrPageInfo;
+    };
+  } | null;
+}
+
+async function fetchMergedPrContribRepos(
+  username: string,
+  maxPrs = 300,
+): Promise<ContribRepoAgg[]> {
+  const map = new Map<string, ContribRepoAgg>();
+  const yearsByRepo = new Map<string, Set<number>>();
+  let after: string | null = null;
+
+  while (map.size < maxPrs) {
+    const remaining = Math.max(0, maxPrs - [...map.values()].reduce((a, r) => a + r.prs, 0));
+    if (remaining === 0) break;
+    const count = Math.min(100, remaining);
+    const data: MergedPrReposResponse = await graphql<MergedPrReposResponse>(
+      `query($login: String!, $count: Int!, $after: String) {
+        user(login: $login) {
+          pullRequests(first: $count, states: MERGED, after: $after,
+                       orderBy: {field: CREATED_AT, direction: DESC}) {
+            nodes {
+              mergedAt
+              repository { nameWithOwner stargazerCount isPrivate isFork owner { login } }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`,
+      { login: username, count, after },
+    );
+    if (!data.user) throw new GitHubDataUnavailableError("GitHub GraphQL returned no merged PR data.");
+
+    const pullRequests = data.user.pullRequests;
+    for (const node of pullRequests.nodes ?? []) {
+      const repo = node.repository;
+      if (!repo) continue;
+      const key = repo.nameWithOwner;
+      const entry =
+        map.get(key) ??
+        {
+          repo: key,
+          stars: 0,
+          is_private: repo.isPrivate,
+          is_fork: repo.isFork,
+          owner_login: repo.owner?.login ?? key.split("/", 1)[0],
+          commits: 0,
+          prs: 0,
+          active_years: 0,
+        };
+      entry.stars = Math.max(entry.stars, repo.stargazerCount ?? 0);
+      entry.prs += 1;
+      map.set(key, entry);
+      const year = node.mergedAt ? parseTs(node.mergedAt)?.getUTCFullYear() : null;
+      if (year) {
+        const years = yearsByRepo.get(key) ?? new Set<number>();
+        years.add(year);
+        yearsByRepo.set(key, years);
+      }
+    }
+
+    const pageInfo: MergedPrPageInfo = pullRequests.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    after = pageInfo.endCursor;
+  }
+
+  return [...map.entries()].map(([key, value]) => ({
+    ...value,
+    active_years: yearsByRepo.get(key)?.size ?? 0,
+  }));
+}
+
+export function mergeContribRepoAggs(groups: ContribRepoAgg[][]): ContribRepoAgg[] {
+  const map = new Map<string, ContribRepoAgg>();
+  for (const group of groups) {
+    for (const repo of group) {
+      const entry =
+        map.get(repo.repo) ??
+        {
+          ...repo,
+          stars: 0,
+          commits: 0,
+          prs: 0,
+          active_years: 0,
+        };
+      entry.stars = Math.max(entry.stars, repo.stars);
+      entry.is_private = entry.is_private || repo.is_private;
+      entry.is_fork = entry.is_fork || repo.is_fork;
+      entry.commits += repo.commits;
+      entry.prs += repo.prs;
+      entry.active_years = Math.max(entry.active_years, repo.active_years);
+      map.set(repo.repo, entry);
+    }
+  }
+  return [...map.values()];
 }
 
 export async function collect(username: string): Promise<{
@@ -1432,7 +1544,14 @@ export async function collect(username: string): Promise<{
   const pinnedRepos = (contrib.user.pinnedItems?.nodes ?? [])
     .map((n) => n?.nameWithOwner)
     .filter((s): s is string => typeof s === "string");
-  const contribRepos = await fetchContribReposByYear(login, contributionYears);
+  const [commitContribRepos, mergedPrContribRepos] = await Promise.all([
+    fetchCommitContribReposByYear(login, contributionYears),
+    fetchMergedPrContribRepos(login),
+  ]);
+  const contribRepos = mergeContribRepoAggs([
+    commitContribRepos ?? [],
+    mergedPrContribRepos,
+  ]);
   const organizations = await fetchOrganizations(login);
   const mergedPrCount = contrib.user.mergedPRs?.totalCount ?? 0;
   const totalPrCount = contrib.user.allPRs?.totalCount ?? 0;
@@ -1545,25 +1664,10 @@ export async function collect(username: string): Promise<{
   // Ecosystem & maintainer impact: substantial work (PRs + landed commits) into
   // popular repos — others' projects (≥200★) or the user's own genuinely popular
   // repos (≥1000★). Computed from all-time per-repo contribution aggregates so
-  // old high-value work (e.g. apache/flink commits) still counts; falls back to
-  // the recent-PR window when unauthenticated (no GraphQL).
-  let impact: ImpactMetrics;
-  if (contribRepos) {
-    impact = computeImpactFromContribMap(contribRepos, loginLower);
-  } else {
-    const impactPrs = recentPrs.filter((p) => isEcosystemImpactPr(p, loginLower));
-    impact = {
-      max_impact_repo_stars: impactPrs.reduce((a, p) => Math.max(a, p.repo_stars), 0),
-      impact_depth_raw:
-        Math.round(
-          impactPrs.reduce((a, p) => a + logRatio(p.repo_stars, 5000), 0) * 100,
-        ) / 100,
-      impact_repo_count: impactPrs.length,
-      impact_commit_count: 0,
-      impact_pr_count: impactPrs.length,
-      impact_repos: [],
-    };
-  }
+  // old high-value work (e.g. apache/flink commits) still counts. PR impact is
+  // sourced from states: MERGED only; contribution-graph PR entries are not
+  // treated as landed work because closed/unmerged PRs can appear there.
+  let impact = computeImpactFromContribMap(contribRepos, loginLower);
   const impactQuality = computeImpactQualitySignals(
     recentPrWindow,
     impact.impact_pr_count,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "scripts"]
+  "exclude": ["node_modules", "scripts", "packages"]
 }


### PR DESCRIPTION
## 背景

用户反馈 Lampese 页面把 `trekhleb/javascript-algorithms` 展示为贡献过的高星项目，但对应 PR #983 实际是 closed/unmerged，不应该进入“贡献过的明星项目”和生态影响评分。

## 改动

- 不再把 GitHub contribution graph 里的 `pullRequestContributionsByRepository` 当作已落地 PR。
- 高星 PR 影响改为显式查询 `user.pullRequests(states: MERGED)` 后聚合，只统计真正 merged 的外部 PR。
- commit 贡献仍沿用 contribution graph 聚合，不改动 commit 影响链路。
- 新增回归测试，覆盖“未合并 PR 不应计入高星 impact_repos / impact_pr_count”的场景。
- `tsconfig` 排除 `packages`，避免 Next 应用构建被独立 SDK 包的 tsup 配置牵连，保证本分支可独立 `next build`。

## 自检

- 评分链路：只收紧 PR impact 来源为 merged PR，原有 scan/score/judge 主链路未被替换；commit impact 保持原逻辑。
- 真实前端测试：使用真实 GitHub token 扫描并落库 Lampese，本地访问 `/u/Lampese`，页面正常渲染分数、用户信息、维度评分；`trekhleb/javascript-algorithms` 不再出现，`OI-wiki/OI-wiki` 等真实 merged/high-star impact 仍展示。
- 测试与构建：
  - `vitest run src/lib/__tests__/github.test.ts src/lib/__tests__/score.test.ts src/app/api/scan/route.test.ts`
  - `eslint src/lib/github.ts src/lib/__tests__/github.test.ts src/app/api/scan/route.test.ts`
  - `tsc --noEmit --pretty false --project tsconfig.json`
  - `next build`
