### PR TITLE
fix(dev): 允许本地强制走 profile handoff

### DIFF
--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -194,13 +194,17 @@ export function Roaster() {
           return;
         }
         const result = data as ScanResult;
+        const byoKey = loadByoKey();
+        const forceProfileHandoff =
+          process.env.NODE_ENV !== "production" && searchParams.get("profile") === "1";
         // Hand off to the profile page: stash the fresh scan so the inner page
         // can render its evidence and stream the roast in place (drives internal
         // traffic; the user reads their repos/score while the LLM works). Passing
         // the scan through sessionStorage means the handoff works with or without
-        // a server-side cache. BYO keys stay inline — they persist nothing for
-        // the profile page to show and use the user's own credit.
-        if (!loadByoKey()) {
+        // a server-side cache. BYO keys stay inline in production because the
+        // profile page never receives/stores user secrets; local dev can force the
+        // profile handoff with ?profile=1 when the server has its own LLM config.
+        if (!byoKey || forceProfileHandoff) {
           try {
             sessionStorage.setItem(pendingScanKey(result.metrics.username), JSON.stringify(result));
           } catch {
@@ -230,7 +234,7 @@ export function Roaster() {
         setScanning(false);
       }
     },
-    [username, token, scanning, roasting, runRoast, router, t, tScan],
+    [username, token, scanning, roasting, runRoast, router, searchParams, t, tScan],
   );
 
   const beatValue = percentile?.beat == null ? null : percentile.beat.toFixed(1);


### PR DESCRIPTION
## 背景

本地开发时如果浏览器保存了 BYO API key，首页 roast 会走 inline 结果路径，不会跳转到 `/u/{username}?roasting=1`，导致无法联调 profile 页左侧侧栏、维度图、代表作等完整详情页 UI。

生产上 BYO key 保持 inline 是合理的，因为 profile 页不会接收或持久化用户自己的 API key；但本地开发环境通常已经在服务端配置了 `GITHUB_TOKEN` 和默认 LLM，因此需要一个明确的调试入口来强制走 profile handoff。

## 改动

- 新增本地开发开关：`/?profile=1`。
- 仅当 `NODE_ENV !== "production"` 且 URL 带 `profile=1` 时，即使存在 BYO key，也会把 scan 结果写入 `sessionStorage` 并跳转到 `/u/{username}?roasting=1`。
- 生产环境不生效：`NODE_ENV=production` 时 `?profile=1` 被忽略。
- 生产 BYO key 行为不变：仍然留在首页 inline roast，不把用户 API key 传给 profile 页，也不写入 DB/cache。

## 使用方式

本地打开：

```text
http://localhost:3000/?profile=1
```

然后正常输入用户名 roast，即可联调完整 profile 页面。

## 自检

- `./node_modules/.bin/eslint src/components/Roaster.tsx`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`
