### PR TITLE
[codex] filter one-off registry contributions

### DIFF
--- a/packages/ghfind-py/ghfind/_github.py
+++ b/packages/ghfind-py/ghfind/_github.py
@@ -700,7 +700,16 @@ def _repo_name(name_with_owner: Optional[str]) -> str:
     return repo.split("/")[-1] if "/" in repo else repo
 
 
+_LOW_SIGNAL_ENTRY_REPOS = {"is-a-dev/register", "tuna/blogroll"}
+
+
+def _is_low_signal_entry_repo(name_with_owner: Optional[str]) -> bool:
+    return (name_with_owner or "").strip().lower() in _LOW_SIGNAL_ENTRY_REPOS
+
+
 def _is_doc_like_repo(name_with_owner: Optional[str]) -> bool:
+    if _is_low_signal_entry_repo(name_with_owner):
+        return True
     name = _repo_name(name_with_owner)
     return bool(
         re.search(
@@ -753,6 +762,11 @@ def compute_impact_from_contrib_map(repos: List[Dict[str, Any]], login_lower: st
     qualifying = []
     for r in repos:
         if r["is_private"] or r["is_fork"]:
+            continue
+        # A single merged entry can surface as both one PR and one contribution-
+        # graph commit. Exclude that shallow registry/directory entry without
+        # discarding sustained maintenance work in the same repository.
+        if _is_low_signal_entry_repo(r["repo"]) and r["commits"] <= 1 and r["prs"] <= 1:
             continue
         is_external = r["owner_login"].lower() != login_lower
         threshold = 200 if is_external else 1000

--- a/packages/ghfind-py/tests/test_github.py
+++ b/packages/ghfind-py/tests/test_github.py
@@ -1,0 +1,80 @@
+"""Offline tests for GitHub contribution classification."""
+
+from ghfind._github import compute_impact_from_contrib_map, is_doc_like_impact_pr
+
+
+def _repo(**over):
+    repo = {
+        "repo": "foundation/platform",
+        "stars": 24000,
+        "is_private": False,
+        "is_fork": False,
+        "owner_login": "foundation",
+        "commits": 0,
+        "prs": 0,
+        "active_years": 1,
+    }
+    repo.update(over)
+    return repo
+
+
+def _pr(**over):
+    pr = {
+        "title": "add my entry",
+        "repo": "owner/repo",
+        "repo_stars": 0,
+        "churn": 100,
+        "changed_files": 1,
+        "trivial": False,
+    }
+    pr.update(over)
+    return pr
+
+
+def test_registry_and_directory_prs_are_doc_like():
+    assert is_doc_like_impact_pr(_pr(repo="is-a-dev/register", repo_stars=10600))
+    assert is_doc_like_impact_pr(_pr(repo="tuna/blogroll", repo_stars=2200))
+
+
+def test_one_off_registry_entries_do_not_count_as_ecosystem_impact():
+    impact = compute_impact_from_contrib_map(
+        [
+            _repo(
+                repo="is-a-dev/register",
+                owner_login="is-a-dev",
+                stars=10600,
+                commits=1,
+                prs=1,
+            ),
+            _repo(
+                repo="tuna/blogroll",
+                owner_login="tuna",
+                stars=2200,
+                commits=1,
+                prs=1,
+            ),
+            _repo(repo="org/target", owner_login="org", stars=5000, prs=1),
+        ],
+        "contributor",
+    )
+
+    assert [repo["repo"] for repo in impact["impact_repos"]] == ["org/target"]
+    assert impact["impact_repo_count"] == 1
+
+
+def test_sustained_registry_maintenance_still_counts():
+    impact = compute_impact_from_contrib_map(
+        [
+            _repo(
+                repo="is-a-dev/register",
+                owner_login="is-a-dev",
+                stars=10600,
+                commits=20,
+                prs=10,
+            ),
+        ],
+        "contributor",
+    )
+
+    assert impact["impact_repo_count"] == 1
+    assert impact["impact_repos"][0]["repo"] == "is-a-dev/register"

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -715,6 +715,50 @@ describe("computeImpactFromContribMap (all-time PR + commit impact)", () => {
     expect(m.impact_repo_count).toBe(1);
   });
 
+  it("excludes one-off personal entries in known registry and directory repos", () => {
+    const m = computeImpactFromContribMap(
+      [
+        agg({
+          repo: "is-a-dev/register",
+          owner_login: "is-a-dev",
+          stars: 10600,
+          commits: 1,
+          prs: 1,
+        }),
+        agg({
+          repo: "tuna/blogroll",
+          owner_login: "tuna",
+          stars: 2200,
+          commits: 1,
+          prs: 1,
+        }),
+        agg({ repo: "org/target", owner_login: "org", stars: 5000, prs: 1 }),
+      ],
+      me,
+    );
+    expect(m.impact_repos.map((r) => r.repo)).toEqual(["org/target"]);
+    expect(m.impact_repo_count).toBe(1);
+    expect(m.impact_commit_count).toBe(0);
+    expect(m.impact_pr_count).toBe(1);
+  });
+
+  it("preserves sustained maintenance work in a registry repo", () => {
+    const m = computeImpactFromContribMap(
+      [
+        agg({
+          repo: "is-a-dev/register",
+          owner_login: "is-a-dev",
+          stars: 10600,
+          commits: 20,
+          prs: 10,
+        }),
+      ],
+      me,
+    );
+    expect(m.impact_repo_count).toBe(1);
+    expect(m.impact_repos[0].repo).toBe("is-a-dev/register");
+  });
+
   it("ignores a single drive-by commit (needs ≥2 commits or ≥1 PR)", () => {
     const m = computeImpactFromContribMap([agg({ commits: 1, prs: 0 })], me);
     expect(m.impact_repo_count).toBe(0);
@@ -749,6 +793,8 @@ describe("impact quality caps", () => {
   it("classifies docs, website, examples, and templates as doc-like impact", () => {
     expect(isDocLikeImpactPr(pr({ repo: "foundation/project-site", repo_stars: 4000 }))).toBe(true);
     expect(isDocLikeImpactPr(pr({ repo: "docs-org/examples", repo_stars: 2000 }))).toBe(true);
+    expect(isDocLikeImpactPr(pr({ repo: "is-a-dev/register", repo_stars: 10600 }))).toBe(true);
+    expect(isDocLikeImpactPr(pr({ repo: "tuna/blogroll", repo_stars: 2200 }))).toBe(true);
     expect(isDocLikeImpactPr(pr({ title: "docs: update install guide", repo_stars: 5000 }))).toBe(true);
     expect(isDocLikeImpactPr(pr({ title: "feat: add project template", repo_stars: 5000 }))).toBe(true);
     expect(

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1100,7 +1100,17 @@ function repoName(nameWithOwner: string | null | undefined): string {
   return repo.includes("/") ? repo.split("/").pop() ?? "" : repo;
 }
 
+// Popular registries/directories where a typical contribution is a personal
+// entry rather than shipped software. Keep this exact-match list deliberately
+// small: generic names such as "register" can also belong to real codebases.
+const LOW_SIGNAL_ENTRY_REPOS = new Set(["is-a-dev/register", "tuna/blogroll"]);
+
+function isLowSignalEntryRepo(nameWithOwner: string | null | undefined): boolean {
+  return LOW_SIGNAL_ENTRY_REPOS.has((nameWithOwner ?? "").trim().toLowerCase());
+}
+
 function isDocLikeRepo(nameWithOwner: string | null | undefined): boolean {
+  if (isLowSignalEntryRepo(nameWithOwner)) return true;
   const name = repoName(nameWithOwner);
   return (
     /(^|[-_.])(docs?|site|website|blog|examples?|templates?|profile|notebook|learning|tutorial|interview|guide|manual)([-_.]|$)/.test(
@@ -1197,6 +1207,10 @@ export function computeImpactFromContribMap(
 ): ImpactMetrics {
   const qualifying = repos.filter((r) => {
     if (r.is_private || r.is_fork) return false;
+    // A single merged entry can appear as both one PR and one contribution-graph
+    // commit. Do not let that personal registry/directory entry borrow the
+    // repository's star count, while preserving credit for actual maintainers.
+    if (isLowSignalEntryRepo(r.repo) && r.commits <= 1 && r.prs <= 1) return false;
     const isExternal = r.owner_login.toLowerCase() !== loginLower;
     const threshold = isExternal ? 200 : 1000;
     if (r.stars < threshold) return false;


### PR DESCRIPTION
## What changed

- classify `is-a-dev/register` and `tuna/blogroll` as doc-like contribution targets, reusing the quality logic introduced by #27
- exclude one-off personal entries in those repositories from ecosystem impact aggregation and `impact_repos`
- keep sustained maintainer work in either repository eligible for ecosystem impact
- mirror the behavior in the TypeScript scanner and Python SDK
- add regression coverage for both reported repositories and the maintainer exception

## Why

A merged personal entry can appear as both one PR and one contribution-graph commit. Because `impact_repos` is ranked by repository stars, a domain request or blogroll entry can otherwise surface as a notable engineering contribution and borrow the target repository's popularity.

The exact-match list is intentionally small. Generic repository names such as `register` can belong to real codebases, so this avoids broad name heuristics and only filters the reported low-signal repositories when the contribution is shallow (`commits <= 1` and `prs <= 1`).

Fixes #86

## Validation

- `vitest run src/lib/__tests__/score.test.ts` — 70 passed
- `tsc --noEmit` — passed
- `eslint src/lib/github.ts src/lib/__tests__/score.test.ts` — passed
- `pytest packages/ghfind-py/tests` — 36 passed, 1 skipped
- full `vitest run` — 257 passed, 2 unrelated existing failures in `src/app/api/scan/route.test.ts` (stale `turnstile_failed` response expectation and missing `rateLimitHeaders` in its Redis mock)
- full `eslint` — existing unrelated error/warning in `scripts/langgenius-audit.mts` and `scripts/mega-ingest.mts`
