### PR TITLE
[codex] recognize landed git mailing-list contributions

### DIFF
--- a/packages/ghfind-py/ghfind/_github.py
+++ b/packages/ghfind-py/ghfind/_github.py
@@ -30,6 +30,9 @@ README_PROMPT_SUMMARY_LIMIT = 1500
 
 IMPACT_YEAR_CAP = 6
 IMPACT_COMMIT_MIN = 2
+# Canonical projects whose official patch flow does not produce GitHub merged
+# PRs, even though GitHub can verify the authored commit in the final history.
+SINGLE_COMMIT_IMPACT_REPOS = {"git/git"}
 ORG_ATTRIBUTED_MIN_SCORE = 5
 ORG_ATTRIBUTED_COMMIT_MIN = 50
 ORG_ATTRIBUTED_MIXED_COMMIT_MIN = 20
@@ -758,7 +761,12 @@ def compute_impact_from_contrib_map(repos: List[Dict[str, Any]], login_lower: st
         threshold = 200 if is_external else 1000
         if r["stars"] < threshold:
             continue
-        if r["commits"] >= IMPACT_COMMIT_MIN or r["prs"] >= 1:
+        commit_min = (
+            1
+            if r["repo"].strip().lower() in SINGLE_COMMIT_IMPACT_REPOS
+            else IMPACT_COMMIT_MIN
+        )
+        if r["commits"] >= commit_min or r["prs"] >= 1:
             qualifying.append(r)
 
     max_impact_repo_stars = max((r["stars"] for r in qualifying), default=0)

--- a/packages/ghfind-py/ghfind/_github.py
+++ b/packages/ghfind-py/ghfind/_github.py
@@ -30,9 +30,10 @@ README_PROMPT_SUMMARY_LIMIT = 1500
 
 IMPACT_YEAR_CAP = 6
 IMPACT_COMMIT_MIN = 2
-# Canonical projects whose official patch flow does not produce GitHub merged
-# PRs, even though GitHub can verify the authored commit in the final history.
-SINGLE_COMMIT_IMPACT_REPOS = {"git/git"}
+# ``commitContributionsByRepository`` only reports commits after they land on
+# the upstream default branch (or gh-pages). This is sufficient landing evidence
+# for canonical projects whose official flow does not mark a GitHub PR MERGED.
+SINGLE_DEFAULT_BRANCH_COMMIT_IMPACT_REPOS = {"git/git"}
 ORG_ATTRIBUTED_MIN_SCORE = 5
 ORG_ATTRIBUTED_COMMIT_MIN = 50
 ORG_ATTRIBUTED_MIXED_COMMIT_MIN = 20
@@ -763,7 +764,7 @@ def compute_impact_from_contrib_map(repos: List[Dict[str, Any]], login_lower: st
             continue
         commit_min = (
             1
-            if r["repo"].strip().lower() in SINGLE_COMMIT_IMPACT_REPOS
+            if r["repo"].strip().lower() in SINGLE_DEFAULT_BRANCH_COMMIT_IMPACT_REPOS
             else IMPACT_COMMIT_MIN
         )
         if r["commits"] >= commit_min or r["prs"] >= 1:

--- a/packages/ghfind-py/tests/test_local.py
+++ b/packages/ghfind-py/tests/test_local.py
@@ -53,7 +53,7 @@ def test_collect_and_score_requires_token():
             os.environ["GITHUB_TOKEN"] = prev
 
 
-def test_git_git_single_authored_commit_counts_as_ecosystem_impact():
+def test_git_git_single_default_branch_commit_counts_as_ecosystem_impact():
     base = {
         "stars": 61828,
         "is_private": False,

--- a/packages/ghfind-py/tests/test_local.py
+++ b/packages/ghfind-py/tests/test_local.py
@@ -8,6 +8,7 @@ import os
 
 import pytest
 
+from ghfind._github import compute_impact_from_contrib_map
 from ghfind.local import collect_and_score, score_metrics, GitHubAuthRequiredError
 
 
@@ -50,6 +51,35 @@ def test_collect_and_score_requires_token():
     finally:
         if prev is not None:
             os.environ["GITHUB_TOKEN"] = prev
+
+
+def test_git_git_single_authored_commit_counts_as_ecosystem_impact():
+    base = {
+        "stars": 61828,
+        "is_private": False,
+        "is_fork": False,
+        "commits": 1,
+        "prs": 0,
+        "active_years": 1,
+    }
+    impact = compute_impact_from_contrib_map(
+        [
+            {**base, "repo": "git/git", "owner_login": "git"},
+            {
+                **base,
+                "repo": "foundation/drive-by",
+                "owner_login": "foundation",
+            },
+        ],
+        "contributor",
+    )
+
+    assert impact["impact_repos"] == [
+        {"repo": "git/git", "stars": 61828, "commits": 1, "prs": 0},
+    ]
+    assert impact["impact_repo_count"] == 1
+    assert impact["impact_commit_count"] == 1
+    assert impact["impact_pr_count"] == 0
 
 
 @pytest.mark.skipif(not os.environ.get("GITHUB_TOKEN"), reason="needs GITHUB_TOKEN for a live crawl")

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -721,7 +721,7 @@ describe("computeImpactFromContribMap (all-time PR + commit impact)", () => {
     expect(m.max_impact_repo_stars).toBe(0);
   });
 
-  it("credits one authored git/git commit despite its non-GitHub merge workflow", () => {
+  it("credits one git/git default-branch commit despite its non-GitHub merge workflow", () => {
     const m = computeImpactFromContribMap(
       [
         agg({

--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -721,6 +721,34 @@ describe("computeImpactFromContribMap (all-time PR + commit impact)", () => {
     expect(m.max_impact_repo_stars).toBe(0);
   });
 
+  it("credits one authored git/git commit despite its non-GitHub merge workflow", () => {
+    const m = computeImpactFromContribMap(
+      [
+        agg({
+          repo: "git/git",
+          owner_login: "git",
+          stars: 61828,
+          commits: 1,
+          prs: 0,
+        }),
+        agg({
+          repo: "foundation/drive-by",
+          owner_login: "foundation",
+          stars: 61828,
+          commits: 1,
+          prs: 0,
+        }),
+      ],
+      me,
+    );
+    expect(m.impact_repos).toEqual([
+      { repo: "git/git", stars: 61828, commits: 1, prs: 0 },
+    ]);
+    expect(m.impact_repo_count).toBe(1);
+    expect(m.impact_commit_count).toBe(1);
+    expect(m.impact_pr_count).toBe(0);
+  });
+
   it("excludes forks and private repos", () => {
     const m = computeImpactFromContribMap(
       [

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1180,14 +1180,26 @@ export interface ImpactMetrics {
 export const IMPACT_YEAR_CAP = 6;
 /** Min landed commits for a repo to qualify on commits alone (avoids drive-bys). */
 export const IMPACT_COMMIT_MIN = 2;
+// Some canonical projects accept patches outside GitHub's merge flow. Their
+// authored commits are verifiable, but the corresponding GitHub PR is never
+// marked MERGED, so one landed commit must be sufficient evidence.
+const SINGLE_COMMIT_IMPACT_REPOS = new Set(["git/git"]);
+
+function impactCommitMin(nameWithOwner: string): number {
+  return SINGLE_COMMIT_IMPACT_REPOS.has(nameWithOwner.trim().toLowerCase())
+    ? 1
+    : IMPACT_COMMIT_MIN;
+}
 
 /**
  * Compute Ecosystem & Maintainer Impact from all-time per-repo contribution
  * aggregates (commits + PRs), instead of the recent-PR window. A repo qualifies
  * when it is popular enough (external ≥200★, the user's own ≥1000★ — same
  * thresholds as {@link isEcosystemImpactPr}) AND the user did real work in it
- * (≥{@link IMPACT_COMMIT_MIN} landed commits OR ≥1 PR). Private and fork repos
- * are excluded (a fork's star count is borrowed; pushing to it isn't impact).
+ * (normally ≥{@link IMPACT_COMMIT_MIN} landed commits OR ≥1 PR). Canonical
+ * projects whose official patch flow does not produce GitHub merged PRs can use
+ * a narrower repo-specific commit minimum. Private and fork repos are excluded
+ * (a fork's star count is borrowed; pushing to it isn't impact).
  *
  * Pure so it can be unit-tested without network access.
  */
@@ -1200,7 +1212,7 @@ export function computeImpactFromContribMap(
     const isExternal = r.owner_login.toLowerCase() !== loginLower;
     const threshold = isExternal ? 200 : 1000;
     if (r.stars < threshold) return false;
-    return r.commits >= IMPACT_COMMIT_MIN || r.prs >= 1;
+    return r.commits >= impactCommitMin(r.repo) || r.prs >= 1;
   });
 
   const maxImpactRepoStars = qualifying.reduce((a, r) => Math.max(a, r.stars), 0);

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1180,13 +1180,14 @@ export interface ImpactMetrics {
 export const IMPACT_YEAR_CAP = 6;
 /** Min landed commits for a repo to qualify on commits alone (avoids drive-bys). */
 export const IMPACT_COMMIT_MIN = 2;
-// Some canonical projects accept patches outside GitHub's merge flow. Their
-// authored commits are verifiable, but the corresponding GitHub PR is never
-// marked MERGED, so one landed commit must be sufficient evidence.
-const SINGLE_COMMIT_IMPACT_REPOS = new Set(["git/git"]);
+// GitHub only includes commits in commitContributionsByRepository after they
+// land on the upstream default branch (or gh-pages). For canonical projects
+// whose official patch flow never marks the corresponding GitHub PR as MERGED,
+// that single default-branch contribution is sufficient landing evidence.
+const SINGLE_DEFAULT_BRANCH_COMMIT_IMPACT_REPOS = new Set(["git/git"]);
 
-function impactCommitMin(nameWithOwner: string): number {
-  return SINGLE_COMMIT_IMPACT_REPOS.has(nameWithOwner.trim().toLowerCase())
+function defaultBranchCommitMin(nameWithOwner: string): number {
+  return SINGLE_DEFAULT_BRANCH_COMMIT_IMPACT_REPOS.has(nameWithOwner.trim().toLowerCase())
     ? 1
     : IMPACT_COMMIT_MIN;
 }
@@ -1212,7 +1213,7 @@ export function computeImpactFromContribMap(
     const isExternal = r.owner_login.toLowerCase() !== loginLower;
     const threshold = isExternal ? 200 : 1000;
     if (r.stars < threshold) return false;
-    return r.commits >= impactCommitMin(r.repo) || r.prs >= 1;
+    return r.commits >= defaultBranchCommitMin(r.repo) || r.prs >= 1;
   });
 
   const maxImpactRepoStars = qualifying.reduce((a, r) => Math.max(a, r.stars), 0);


### PR DESCRIPTION
## What changed

- let one contribution-graph commit qualify `git/git` for ecosystem impact
- keep the normal two-commit minimum for every other commit-only repository
- preserve the real signal as `1 commit · 0 PR` instead of inventing a merged PR
- mirror the rule in the TypeScript scanner and Python SDK
- add regression coverage against an equally popular ordinary repository

## Why

`git/git` is a publish-only mirror whose official contribution workflow runs through mailing-list review. GitGitGadget can turn a GitHub PR into patches for that workflow, but the original GitHub PR is not merged in the usual way. The landed commit preserves the contributor as Author while a maintainer such as Junio C Hamano is the Committer.

Authorship alone is not landing evidence. The important distinction is that ghfind reads `commitContributionsByRepository`, and [GitHub only counts commit contributions](https://docs.github.com/en/account-and-profile/reference/profile-contributions-reference#contribution-criteria-for-commits) after they are in the upstream repository's default branch (or `gh-pages`), not merely in an unmerged branch or fork.

For the reported account, that API returns one contribution for `git/git`, confirming the commit is in the upstream contribution history. ghfind nevertheless requires either two such commits or one GitHub `MERGED` PR. That combination drops a real first Git contribution from `impact_repos` and Notable contributions.

This PR uses a deliberately narrow exact-match exception for `git/git`. Existing star-based prestige and depth scoring then reflects the project's value without adding an arbitrary multiplier.

Evidence:

- [Git's official SubmittingPatches workflow](https://git-scm.com/docs/SubmittingPatches.html)
- [Real contributor account and landed commit](https://koutian.is-a.dev/zh/posts/2026/06/official-git-contributor/)
- [`0bf506e`: Author Koutian Wu, Committer Junio C Hamano](https://github.com/git/git/commit/0bf506efd40251ebdc9ed829d8bb90d879d2c7aa)

Fixes #88

## Validation

- `vitest run src/lib/__tests__/score.test.ts` — 69 passed
- `tsc --noEmit` — passed
- `eslint src/lib/github.ts src/lib/__tests__/score.test.ts` — passed
- `pytest packages/ghfind-py/tests` — 34 passed, 1 skipped
- full `vitest run` — 256 passed, 2 unrelated existing failures in `src/app/api/scan/route.test.ts` (stale `turnstile_failed` response expectation and missing `rateLimitHeaders` in its Redis mock)
