### PR TITLE
fix: make profile cards crawlable by social preview bots

### DIFF
--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -140,6 +140,7 @@ export async function generateMetadata({
   // The flex card doubles as the social preview image (resolved absolute via
   // metadataBase in layout.tsx) — so shared /u links render a rich card.
   const image = `/api/card/${d.username}`;
+  const imageAlt = `${d.username} GitHub score card on ghfind`;
   const path = locale === "en" ? `/en/u/${d.username}` : `/u/${d.username}`;
   // Keep low-score profiles out of search results: they name real people, so a
   // "NPC"/"拉完了" page shouldn't rank on someone's handle. Still reachable and
@@ -157,9 +158,14 @@ export async function generateMetadata({
       description,
       url: path,
       type: "website",
-      images: [{ url: image, width: 1200, height: 630 }],
+      images: [{ url: image, width: 1200, height: 630, alt: imageAlt, type: "image/png" }],
     },
-    twitter: { card: "summary_large_image", title, description, images: [image] },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [{ url: image, alt: imageAlt }],
+    },
   };
 }
 

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -17,7 +17,20 @@ export const revalidate = 86400;
  */
 
 // Search / answer / user-triggered fetch crawlers — allowed (this is how we get
-// cited in AI answers; NOT training).
+// cited in AI answers; NOT training). Social preview crawlers get their own
+// explicit group so they never have to interpret the generic `/api/` exception
+// ordering before fetching `/api/card/...` images.
+const ALLOWED_PREVIEW_BOTS = [
+  "Twitterbot",
+  "facebookexternalhit",
+  "Slackbot-LinkExpanding",
+  "LinkedInBot",
+  "Discordbot",
+  "TelegramBot",
+  "WhatsApp",
+  "Line",
+];
+
 const ALLOWED_AI_BOTS = [
   "OAI-SearchBot",
   "ChatGPT-User",
@@ -46,6 +59,13 @@ const BLOCKED_TRAINING_BOTS = [
 
 export function GET() {
   const lines: string[] = [];
+
+  // Explicit allow tier for social preview crawlers. Keep this group fully open:
+  // social scrapers are black boxes, and a later `Disallow: /api/` can make them
+  // skip `/api/card/...` even when the card route is explicitly allowed.
+  for (const bot of ALLOWED_PREVIEW_BOTS) {
+    lines.push(`User-agent: ${bot}`, "Allow: /", "");
+  }
 
   // Explicit allow tier for the search/answer crawlers we welcome.
   for (const bot of ALLOWED_AI_BOTS) {


### PR DESCRIPTION
## Summary
- explicitly allow Twitterbot and other social preview crawlers in robots.txt
- add image MIME type and alt metadata to profile OG/Twitter card images
- keeps budget-burning API routes blocked for generic crawlers

## Verification
- pnpm typecheck
- pnpm build
- local robots route emits a dedicated Twitterbot allow group
- live Twitterbot fetch currently sees complete profile card metadata and a 1200x630 PNG image

## Context
X/Twitter sometimes does not render cards even when the page has the base tags. The most likely ambiguity is the catch-all robots group containing both Allow exceptions and Disallow: /api/, while the shared card image lives under /api/card/.