### PR TITLE
fix: relax ecosystem impact cap for commit-heavy contributors

### DIFF
--- a/src/lib/__tests__/score.test.ts
+++ b/src/lib/__tests__/score.test.ts
@@ -3,6 +3,7 @@ import {
   bestOriginalRepoQuality,
   computeClosedPrBreakdown,
   computeFloodSignals,
+  computeCommitBasedImpact,
   computeImpactFromContribMap,
   computeImpactQualitySignals,
   computeOrgRepoAttribution,
@@ -918,6 +919,200 @@ describe("impact quality caps", () => {
     expect(signals.verified_impact_pr_count).toBe(0);
     expect(signals.unverified_impact_pr_count).toBe(10);
     expect(signals.impact_quality_cap).toBeUndefined();
+  });
+});
+
+describe("computeCommitBasedImpact", () => {
+  it("returns high strength for many commits in high-star repos", () => {
+    const contribRepos = [
+      contribRepo({ repo: "AstrBotDevs/AstrBot", stars: 36000, commits: 71, prs: 30, owner_login: "AstrBotDevs" }),
+      contribRepo({ repo: "end-4/dots-hyprland", stars: 15000, commits: 5, prs: 2, owner_login: "end-4" }),
+    ];
+    const strength = computeCommitBasedImpact(contribRepos, "alice");
+    expect(strength).toBeGreaterThan(0.8);
+  });
+
+  it("returns low strength for few commits", () => {
+    const contribRepos = [
+      contribRepo({ repo: "org/repo", stars: 5000, commits: 2, prs: 1, owner_login: "org" }),
+    ];
+    const strength = computeCommitBasedImpact(contribRepos, "alice");
+    expect(strength).toBeLessThan(0.4);
+  });
+
+  it("returns 0 for no qualifying repos", () => {
+    const strength = computeCommitBasedImpact([], "alice");
+    expect(strength).toBe(0);
+  });
+
+  it("excludes private and fork repos", () => {
+    const contribRepos = [
+      contribRepo({ repo: "org/private", stars: 50000, commits: 50, prs: 10, owner_login: "org", is_private: true }),
+      contribRepo({ repo: "org/fork", stars: 50000, commits: 50, prs: 10, owner_login: "org", is_fork: true }),
+    ];
+    const strength = computeCommitBasedImpact(contribRepos, "alice");
+    expect(strength).toBe(0);
+  });
+});
+
+describe("computeImpactQualitySignals with commit strength", () => {
+  it("skips cap when commit strength is high (issue #91)", () => {
+    const recentPrs = [
+      pr({ title: "docs: update install guide", repo: "docs-org/framework", repo_stars: 10000 }),
+      pr({ title: "docs: add tutorial", repo: "docs-org/guide", repo_stars: 8000 }),
+      pr({ title: "fix: typo in readme", repo: "big-org/project", repo_stars: 5000 }),
+    ];
+    const contribRepos = [
+      contribRepo({ repo: "AstrBotDevs/AstrBot", stars: 36000, commits: 71, prs: 30, owner_login: "AstrBotDevs" }),
+    ];
+    const signals = computeImpactQualitySignals(recentPrs, 30, "alice", contribRepos);
+    expect(signals.impact_quality_cap).toBeUndefined();
+  });
+
+  it("relaxes cap when commit strength is moderate", () => {
+    const recentPrs = [
+      pr({ title: "docs: update install guide", repo: "docs-org/framework", repo_stars: 10000 }),
+      pr({ title: "docs: add tutorial", repo: "docs-org/guide", repo_stars: 8000 }),
+      pr({ title: "fix: typo in readme", repo: "big-org/project", repo_stars: 5000 }),
+    ];
+    const contribRepos = [
+      contribRepo({ repo: "org/repo", stars: 5000, commits: 8, prs: 3, owner_login: "org" }),
+    ];
+    const signals = computeImpactQualitySignals(recentPrs, 10, "alice", contribRepos);
+    expect(signals.impact_quality_cap).toBe(8);
+  });
+
+  it("applies full cap when commit strength is low", () => {
+    const recentPrs = [
+      pr({ title: "docs: update install guide", repo: "docs-org/framework", repo_stars: 10000 }),
+      pr({ title: "docs: add tutorial", repo: "docs-org/guide", repo_stars: 8000 }),
+      pr({ title: "fix: typo in readme", repo: "big-org/project", repo_stars: 5000 }),
+    ];
+    const signals = computeImpactQualitySignals(recentPrs, 10, "alice", []);
+    expect(signals.impact_quality_cap).toBe(4);
+  });
+});
+
+describe("isDocLikeImpactPr title regex", () => {
+  it("does not match 'guide' in title (issue #91)", () => {
+    expect(
+      isDocLikeImpactPr(
+        pr({ title: "Add deployment guide", repo: "org/project", repo_stars: 5000, files: ["src/deploy.ts", "src/config.ts"] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match 'site' in title", () => {
+    expect(
+      isDocLikeImpactPr(
+        pr({ title: "Update site configuration", repo: "org/project", repo_stars: 5000, files: ["src/site.ts", "src/config.ts"] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still matches 'docs' in title", () => {
+    expect(isDocLikeImpactPr(pr({ title: "docs: update install guide", repo_stars: 5000 }))).toBe(true);
+  });
+
+  it("still matches 'tutorial' in title", () => {
+    expect(isDocLikeImpactPr(pr({ title: "Add tutorial for beginners", repo_stars: 5000 }))).toBe(true);
+  });
+});
+
+describe("computeCommitBasedImpact", () => {
+  it("returns high strength for many commits in high-star repos", () => {
+    const contribRepos = [
+      contribRepo({ repo: "AstrBotDevs/AstrBot", stars: 36000, commits: 71, prs: 30, owner_login: "AstrBotDevs" }),
+      contribRepo({ repo: "end-4/dots-hyprland", stars: 15000, commits: 5, prs: 2, owner_login: "end-4" }),
+    ];
+    const strength = computeCommitBasedImpact(contribRepos, "alice");
+    expect(strength).toBeGreaterThan(0.8);
+  });
+
+  it("returns low strength for few commits", () => {
+    const contribRepos = [
+      contribRepo({ repo: "org/repo", stars: 5000, commits: 2, prs: 1, owner_login: "org" }),
+    ];
+    const strength = computeCommitBasedImpact(contribRepos, "alice");
+    expect(strength).toBeLessThan(0.4);
+  });
+
+  it("returns 0 for no qualifying repos", () => {
+    const strength = computeCommitBasedImpact([], "alice");
+    expect(strength).toBe(0);
+  });
+
+  it("excludes private and fork repos", () => {
+    const contribRepos = [
+      contribRepo({ repo: "org/private", stars: 50000, commits: 50, prs: 10, owner_login: "org", is_private: true }),
+      contribRepo({ repo: "org/fork", stars: 50000, commits: 50, prs: 10, owner_login: "org", is_fork: true }),
+    ];
+    const strength = computeCommitBasedImpact(contribRepos, "alice");
+    expect(strength).toBe(0);
+  });
+});
+
+describe("computeImpactQualitySignals with commit strength", () => {
+  it("skips cap when commit strength is high (issue #91)", () => {
+    const recentPrs = [
+      pr({ title: "docs: update install guide", repo: "docs-org/framework", repo_stars: 10000 }),
+      pr({ title: "docs: add tutorial", repo: "docs-org/guide", repo_stars: 8000 }),
+      pr({ title: "fix: typo in readme", repo: "big-org/project", repo_stars: 5000 }),
+    ];
+    const contribRepos = [
+      contribRepo({ repo: "AstrBotDevs/AstrBot", stars: 36000, commits: 71, prs: 30, owner_login: "AstrBotDevs" }),
+    ];
+    const signals = computeImpactQualitySignals(recentPrs, 30, "alice", contribRepos);
+    expect(signals.impact_quality_cap).toBeUndefined();
+  });
+
+  it("relaxes cap when commit strength is moderate", () => {
+    const recentPrs = [
+      pr({ title: "docs: update install guide", repo: "docs-org/framework", repo_stars: 10000 }),
+      pr({ title: "docs: add tutorial", repo: "docs-org/guide", repo_stars: 8000 }),
+      pr({ title: "fix: typo in readme", repo: "big-org/project", repo_stars: 5000 }),
+    ];
+    const contribRepos = [
+      contribRepo({ repo: "org/repo", stars: 5000, commits: 8, prs: 3, owner_login: "org" }),
+    ];
+    const signals = computeImpactQualitySignals(recentPrs, 10, "alice", contribRepos);
+    expect(signals.impact_quality_cap).toBe(8);
+  });
+
+  it("applies full cap when commit strength is low", () => {
+    const recentPrs = [
+      pr({ title: "docs: update install guide", repo: "docs-org/framework", repo_stars: 10000 }),
+      pr({ title: "docs: add tutorial", repo: "docs-org/guide", repo_stars: 8000 }),
+      pr({ title: "fix: typo in readme", repo: "big-org/project", repo_stars: 5000 }),
+    ];
+    const signals = computeImpactQualitySignals(recentPrs, 10, "alice", []);
+    expect(signals.impact_quality_cap).toBe(4);
+  });
+});
+
+describe("isDocLikeImpactPr title regex", () => {
+  it("does not match 'guide' in title (issue #91)", () => {
+    expect(
+      isDocLikeImpactPr(
+        pr({ title: "Add deployment guide", repo: "org/project", repo_stars: 5000, files: ["src/deploy.ts", "src/config.ts"] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match 'site' in title", () => {
+    expect(
+      isDocLikeImpactPr(
+        pr({ title: "Update site configuration", repo: "org/project", repo_stars: 5000, files: ["src/site.ts", "src/config.ts"] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still matches 'docs' in title", () => {
+    expect(isDocLikeImpactPr(pr({ title: "docs: update install guide", repo_stars: 5000 }))).toBe(true);
+  });
+
+  it("still matches 'tutorial' in title", () => {
+    expect(isDocLikeImpactPr(pr({ title: "Add tutorial for beginners", repo_stars: 5000 }))).toBe(true);
   });
 });
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1120,7 +1120,8 @@ function isCoreCodePath(path: string): boolean {
 export function isDocLikeImpactPr(pr: RecentPr): boolean {
   if (isDocLikeRepo(pr.repo)) return true;
   const title = pr.title ?? "";
-  if (/\b(docs?|readme|typo|translate|translation|i18n|website|site|blog|examples?|templates?|tutorial|guide)\b/i.test(title)) {
+  // Removed "guide" and "site" - too common in code PRs (e.g., "deployment guide", "site configuration")
+  if (/\b(docs?|readme|typo|translate|translation|i18n|website|blog|examples?|templates?|tutorial)\b/i.test(title)) {
     return true;
   }
 
@@ -1139,21 +1140,59 @@ export interface ImpactQualitySignals {
   impact_quality_cap?: number;
 }
 
+/**
+ * Compute commit-based impact strength from all-time contribution aggregates.
+ * Returns 0~1: higher when the user has substantial landed commits in high-star repos.
+ * This signal is more reliable than PR title/file-path heuristics for determining
+ * whether a contribution is substantive.
+ */
+export function computeCommitBasedImpact(
+  contribRepos: ContribRepoAgg[],
+  loginLower: string,
+): number {
+  const qualifying = contribRepos.filter((r) => {
+    if (r.is_private || r.is_fork) return false;
+    const isExternal = r.owner_login.toLowerCase() !== loginLower;
+    const threshold = isExternal ? 200 : 1000;
+    return r.stars >= threshold && r.commits >= IMPACT_COMMIT_MIN;
+  });
+
+  if (qualifying.length === 0) return 0;
+
+  // Weighted sum: more commits in higher-star repos → stronger signal
+  const weighted = qualifying.reduce((sum, r) => {
+    const starSignal = logRatio(r.stars, 50000);
+    const commitSignal = Math.min(r.commits / 20, 1);
+    return sum + starSignal * commitSignal;
+  }, 0);
+
+  // Normalize to 0~1: ≥2.0 is considered strong
+  return Math.min(weighted / 2.0, 1.0);
+}
+
 export function computeImpactQualitySignals(
   recentPrs: RecentPr[],
   impactPrCount: number,
   loginLower: string,
+  contribRepos: ContribRepoAgg[] = [],
 ): ImpactQualitySignals {
   const verifiedImpactPrs = recentPrs.filter((p) => isEcosystemImpactPr(p, loginLower));
   const docLikeCount = verifiedImpactPrs.filter(isDocLikeImpactPr).length;
   const coreCount = verifiedImpactPrs.length - docLikeCount;
   const unverifiedCount = Math.max(0, impactPrCount - verifiedImpactPrs.length);
 
+  // Compute commit-based impact strength to relax cap when there's strong
+  // evidence of substantive contributions (many landed commits in high-star repos)
+  const commitStrength = computeCommitBasedImpact(contribRepos, loginLower);
+
   let impactQualityCap: number | undefined;
-  if (impactPrCount >= 10 && coreCount <= 2 && docLikeCount > coreCount) {
-    impactQualityCap = 4;
+  if (commitStrength >= 0.8) {
+    // Strong commit signal: skip the cap entirely
+    impactQualityCap = undefined;
+  } else if (impactPrCount >= 10 && coreCount <= 2 && docLikeCount > coreCount) {
+    impactQualityCap = commitStrength >= 0.4 ? 8 : 4;
   } else if (impactPrCount >= 10 && docLikeCount > coreCount) {
-    impactQualityCap = 8;
+    impactQualityCap = commitStrength >= 0.4 ? 16 : 8;
   }
 
   return {
@@ -1796,6 +1835,7 @@ export async function collect(username: string): Promise<{
     recentPrWindow,
     impact.impact_pr_count,
     loginLower,
+    contribRepos,
   );
   const verifiedImpactPrs = recentPrWindow
     .filter((p) => isEcosystemImpactPr(p, loginLower))


### PR DESCRIPTION
## Summary
- Add \computeCommitBasedImpact()\ to measure commit-based contribution strength from all-time contribution aggregates
- Modify \computeImpactQualitySignals()\ to accept \contribRepos\ parameter and relax cap based on commit strength
- Skip \impact_quality_cap\ when commit strength >= 0.8 (strong evidence of substantive contributions)
- Relax cap when commit strength >= 0.4 (moderate evidence)
- Tighten \isDocLikeImpactPr\ title regex: remove 'guide' and 'site' keywords that commonly appear in code PRs

## Problem
Issue #91 reports that users with substantial contributions to high-star repos (e.g., 71 commits + 30 PRs to AstrBot with 36k stars) get ecosystem impact score of 0/20. The root cause is that \computeImpactQualitySignals\ applies a cap based on recent PR title/file-path heuristics, which can override the all-time commit-based impact computed by \computeImpactFromContribMap\.

## Solution
The fix introduces a commit-based impact strength signal that relaxes or skips the doc-like PR cap when there's strong evidence of substantive contributions (many landed commits in high-star repos). This ensures that commit-heavy contributors are not incorrectly penalized by PR title heuristics.

## Testing
- Added comprehensive tests for \computeCommitBasedImpact\ (high/low commit scenarios, private/fork exclusion)
- Added tests for \computeImpactQualitySignals\ with commit strength (cap skip/relax/full cap)
- Added tests for \isDocLikeImpactPr\ title regex (no false positives for 'guide'/'site', still matches 'docs'/'tutorial')
- All existing tests pass

Fixes #91