### PR TITLE
feat(ops): 同步代理农场 ASN 至 Vercel WAF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ LLM_FALLBACK_API_KEY=
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# ── Vercel WAF ASN denylist sync (manual production operation) ─────────────
+# `pnpm waf:sync` prints the intended rule. Add --apply only after reviewing it;
+# it reads the live firewall config first and refuses to overwrite a drifted rule.
+VERCEL_TOKEN=
+VERCEL_PROJECT_ID=
+VERCEL_TEAM_ID=
+
 # ── Human verification (optional but recommended in prod) ─────────────────
 # Cloudflare Turnstile (free). If absent, the human-check is skipped.
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=

--- a/README.md
+++ b/README.md
@@ -209,6 +209,22 @@ TURSO_DATABASE_URL=file:./local.db
 6. (Optional) set `PUBLIC_SITE_URL` when deploying under a custom domain so metadata, sitemap, cards, and LLM attribution use the right origin.
 7. Deploy.
 
+### WAF proxy-farm ASN denylist
+
+The high-confidence proxy-farm ASN list is versioned in
+[`config/proxy-farm-asns.json`](./config/proxy-farm-asns.json). It is shared by
+the traffic report and the production WAF rule, so analytics classification and
+blocking cannot silently drift apart. General cloud providers, consumer VPNs,
+and residential networks are deliberately excluded.
+
+`pnpm waf:sync` is dry-run only and prints the exact Vercel rule. After review,
+run `pnpm waf:sync -- --apply` from an operator shell with `VERCEL_TOKEN`,
+`VERCEL_PROJECT_ID`, and, when needed, `VERCEL_TEAM_ID`. The script reads the
+current Firewall configuration first, creates the `geo_as_number` deny rule only
+when absent, and refuses to overwrite a changed live rule. Firewall changes take
+effect independently of a deployment; do not add the operator token to runtime
+environment variables.
+
 ## Bring your own model / API key
 
 Click "Use your own model" on the page and enter Base URL + API Key + Model. Compatible with any OpenAI-style API (OpenAI / OpenRouter / Groq / DeepSeek / local). **The key lives only in your own browser's localStorage, is passed directly on call, and is never uploaded to the server or persisted.**

--- a/README.zh.md
+++ b/README.zh.md
@@ -206,6 +206,20 @@ TURSO_DATABASE_URL=file:./local.db
 6. (可选)自定义域名部署时设置 `PUBLIC_SITE_URL`,保证 metadata、sitemap、卡片和 LLM attribution 使用正确域名。
 7. Deploy。
 
+### WAF 代理农场 ASN 拦截
+
+高置信代理农场 ASN 清单维护在
+[`config/proxy-farm-asns.json`](./config/proxy-farm-asns.json),流量报表和生产
+WAF 共用它,不会出现报表识别与实际拦截口径漂移。AWS 等通用云、消费级 VPN 和
+居民网络可能承载真人,刻意不纳入此清单。
+
+`pnpm waf:sync` 默认只 dry-run,打印将要写入的 Vercel 规则。确认后,在运维
+终端提供 `VERCEL_TOKEN`、`VERCEL_PROJECT_ID` 和必要时的 `VERCEL_TEAM_ID`,运行
+`pnpm waf:sync -- --apply`。脚本先读取当前 Firewall 配置,仅在规则不存在时以
+`geo_as_number` + `deny` 创建;若同名线上规则与仓库清单不一致,会停止并要求人工
+在 Vercel 审计后处理,绝不覆盖其他防火墙配置。Firewall 更新不依赖重新部署;运维
+token 不应写进线上运行时环境变量。
+
 ## 自带模型 / API Key
 
 点页面上的「用自己的模型」,填 Base URL + API Key + Model。兼容任意 OpenAI 接口(OpenAI / OpenRouter / Groq / DeepSeek / 本地)。**Key 只存在你自己的浏览器 localStorage,调用时直传,绝不上传到服务器、绝不落库。**

--- a/config/proxy-farm-asns.json
+++ b/config/proxy-farm-asns.json
@@ -1,0 +1,31 @@
+{
+  "ruleName": "ghfind-deny-known-proxy-farm-asns",
+  "description": "Deny high-confidence rotating-proxy and scraper-farm networks observed against ghfind. Deliberately excludes general cloud, VPN, and consumer networks that can carry legitimate users.",
+  "asns": [
+    "212238",
+    "9009",
+    "3257",
+    "203020",
+    "210906",
+    "62874",
+    "7979",
+    "396356",
+    "46635",
+    "11798",
+    "396319",
+    "59253",
+    "55286",
+    "401152",
+    "212286",
+    "134450",
+    "132817",
+    "209709",
+    "201341",
+    "393886"
+  ],
+  "excludedNetworks": [
+    "AWS and other general-purpose cloud providers",
+    "consumer VPN and accelerator networks",
+    "residential ISP networks"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cli:build": "make cli-build",
     "cli:build-all": "make cli-build-all",
     "cli:test": "make cli-test",
+    "waf:sync": "tsx scripts/sync-waf-asn-denylist.mts",
     "start": "next build && next start",
     "start:prod": "next start",
     "build/start": "next build && next start",

--- a/scripts/sync-waf-asn-denylist.mts
+++ b/scripts/sync-waf-asn-denylist.mts
@@ -1,0 +1,24 @@
+import "./_env.mjs";
+import { syncProxyFarmWafRule } from "../src/lib/waf-asn-sync";
+
+const apply = process.argv.includes("--apply");
+
+try {
+  const result = await syncProxyFarmWafRule({
+    apply,
+    apiBase: process.env.VERCEL_API_BASE_URL ?? "https://api.vercel.com",
+    token: process.env.VERCEL_TOKEN,
+    projectId: process.env.VERCEL_PROJECT_ID,
+    teamId: process.env.VERCEL_TEAM_ID,
+  });
+  console.log(JSON.stringify(result, null, 2));
+  if (result.status === "drift") {
+    console.error(
+      "The deployed rule has the same name but a different definition. Review it in Vercel Firewall before changing it; this script will not overwrite a live WAF rule.",
+    );
+    process.exitCode = 2;
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/traffic-report.sh
+++ b/scripts/traffic-report.sh
@@ -11,12 +11,14 @@
 set -euo pipefail
 
 SINCE="${1:-24h}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ASN_DENYLIST="$SCRIPT_DIR/../config/proxy-farm-asns.json"
 
 # 高置信代理/爬虫农场 ASN(2026-07 实测:Oxylabs、Datacamp、M247 等,真人几乎不会从这些网络来)
 # 2026-07-06 增补:农场开始伪造 referrer=www.google.com,借伪造流量暴露了一批新 ASN —
 #   401152/11798 Ace Data Centers、212286 LonConnect、134450 HostRoyale二号段、
 #   132817 DZCRD、209709 code200、201341 trafficforce、393886 Leaseweb、210906 Bite(代理转售段)
-PROXY_ASNS='["212238","9009","3257","203020","210906","62874","7979","396356","46635","11798","396319","59253","55286","401152","212286","134450","132817","209709","201341","393886"]'
+PROXY_ASNS="$(jq -c '.asns' "$ASN_DENYLIST")"
 # 注意:机场/VPN 出口(Eons 138997、DMIT、Akari、Bunny、GSL 等)有真实中国用户,刻意不算进农场层。
 AWS_ASNS='["14618","16509"]'
 

--- a/src/lib/__tests__/waf-asn-sync.test.ts
+++ b/src/lib/__tests__/waf-asn-sync.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { once } from "node:events";
+import { syncProxyFarmWafRule } from "@/lib/waf-asn-sync";
+import { PROXY_FARM_ASNS, WAF_ASN_RULE_NAME } from "@/lib/waf-asn";
+
+type RecordedRequest = { method: string; url: string; body: unknown };
+
+let server: Server | undefined;
+
+afterEach(async () => {
+  if (!server) return;
+  server.close();
+  await once(server, "close");
+  server = undefined;
+});
+
+async function withMockFirewall(rules: unknown[] = []) {
+  const requests: RecordedRequest[] = [];
+  server = createServer(async (req, res) => {
+    const body = await new Promise<string>((resolve) => {
+      let value = "";
+      req.on("data", (chunk) => {
+        value += chunk;
+      });
+      req.on("end", () => resolve(value));
+    });
+    requests.push({ method: req.method ?? "", url: req.url ?? "", body: body ? JSON.parse(body) : null });
+
+    if (req.method === "GET" && req.url?.startsWith("/v1/security/firewall/config/active")) {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ rules }));
+      return;
+    }
+    if (req.method === "PATCH" && req.url?.startsWith("/v1/security/firewall/config?")) {
+      res.setHeader("content-type", "application/json");
+      res.end("{}");
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("mock firewall did not bind a TCP port");
+  return { apiBase: `http://127.0.0.1:${address.port}`, requests };
+}
+
+describe("syncProxyFarmWafRule", () => {
+  it("is inert without --apply", async () => {
+    const result = await syncProxyFarmWafRule({ apply: false, apiBase: "https://example.test" });
+    expect(result.status).toBe("dry-run");
+    expect(result.rule.conditionGroup[0]?.conditions[0]?.value).toEqual(PROXY_FARM_ASNS);
+  });
+
+  it("creates the exact ASN deny rule through the Vercel Firewall control plane", async () => {
+    const mock = await withMockFirewall();
+    const result = await syncProxyFarmWafRule({
+      apply: true,
+      apiBase: mock.apiBase,
+      token: "test-token",
+      projectId: "project_test",
+      teamId: "team_test",
+    });
+
+    expect(result.status).toBe("created");
+    expect(mock.requests).toHaveLength(2);
+    expect(mock.requests[0]).toMatchObject({ method: "GET" });
+    expect(mock.requests[1]).toMatchObject({ method: "PATCH" });
+    expect(mock.requests[1]?.url).toContain("projectId=project_test");
+    expect(mock.requests[1]?.body).toEqual({
+      action: "rules.insert",
+      id: null,
+      value: {
+        active: true,
+        name: WAF_ASN_RULE_NAME,
+        description: expect.any(String),
+        conditionGroup: [
+          {
+            conditions: [
+              {
+                type: "geo_as_number",
+                op: "inc",
+                value: PROXY_FARM_ASNS,
+              },
+            ],
+          },
+        ],
+        action: { mitigate: { action: "deny" } },
+      },
+    });
+  });
+
+  it("does not duplicate an already-current live rule", async () => {
+    const mock = await withMockFirewall([
+      {
+        id: "rule_1",
+        name: WAF_ASN_RULE_NAME,
+        active: true,
+        conditionGroup: [
+          { conditions: [{ type: "geo_as_number", op: "inc", value: [...PROXY_FARM_ASNS].reverse() }] },
+        ],
+        action: { mitigate: { action: "deny" } },
+      },
+    ]);
+    const result = await syncProxyFarmWafRule({
+      apply: true,
+      apiBase: mock.apiBase,
+      token: "test-token",
+      projectId: "project_test",
+    });
+
+    expect(result.status).toBe("up-to-date");
+    expect(mock.requests).toHaveLength(1);
+  });
+
+  it("reports drift rather than overwriting a live rule", async () => {
+    const mock = await withMockFirewall([
+      {
+        id: "rule_1",
+        name: WAF_ASN_RULE_NAME,
+        active: true,
+        conditionGroup: [{ conditions: [{ type: "geo_as_number", op: "inc", value: ["123"] }] }],
+        action: { mitigate: { action: "deny" } },
+      },
+    ]);
+    const result = await syncProxyFarmWafRule({
+      apply: true,
+      apiBase: mock.apiBase,
+      token: "test-token",
+      projectId: "project_test",
+    });
+
+    expect(result.status).toBe("drift");
+    expect(mock.requests).toHaveLength(1);
+  });
+});

--- a/src/lib/waf-asn-sync.ts
+++ b/src/lib/waf-asn-sync.ts
@@ -1,0 +1,75 @@
+import {
+  buildProxyFarmWafRule,
+  extractWafRules,
+  isCurrentProxyFarmWafRule,
+  WAF_ASN_RULE_NAME,
+  type WafRule,
+} from "./waf-asn";
+
+export type WafSyncStatus = "dry-run" | "created" | "up-to-date" | "drift";
+
+export type WafSyncResult = {
+  status: WafSyncStatus;
+  rule: WafRule;
+};
+
+type WafSyncOptions = {
+  apply: boolean;
+  apiBase: string;
+  token?: string;
+  projectId?: string;
+  teamId?: string;
+  fetchImpl?: typeof fetch;
+};
+
+function endpoint(options: WafSyncOptions, suffix: string): string {
+  const url = new URL(`${options.apiBase.replace(/\/$/, "")}${suffix}`);
+  if (options.projectId) url.searchParams.set("projectId", options.projectId);
+  if (options.teamId) url.searchParams.set("teamId", options.teamId);
+  return url.toString();
+}
+
+function authHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * Synchronize the source-controlled ASN denylist to Vercel's control plane.
+ * A changed existing rule deliberately reports `drift` rather than overwrite:
+ * the Firewall API's update operations can also alter unrelated configuration,
+ * so an operator must review that change in the Vercel audit log first.
+ */
+export async function syncProxyFarmWafRule(options: WafSyncOptions): Promise<WafSyncResult> {
+  const rule = buildProxyFarmWafRule();
+  if (!options.apply) return { status: "dry-run", rule };
+
+  if (!options.token || !options.projectId) {
+    throw new Error("--apply requires VERCEL_TOKEN and VERCEL_PROJECT_ID");
+  }
+
+  const request = options.fetchImpl ?? fetch;
+  const current = await request(endpoint(options, "/v1/security/firewall/config/active"), {
+    headers: authHeaders(options.token),
+  });
+  if (!current.ok) {
+    throw new Error(`could not read Vercel Firewall configuration (${current.status})`);
+  }
+
+  const existing = extractWafRules(await current.json()).find((item) => item.name === WAF_ASN_RULE_NAME);
+  if (existing) {
+    return { status: isCurrentProxyFarmWafRule(existing) ? "up-to-date" : "drift", rule };
+  }
+
+  const response = await request(endpoint(options, "/v1/security/firewall/config"), {
+    method: "PATCH",
+    headers: authHeaders(options.token),
+    body: JSON.stringify({ action: "rules.insert", id: null, value: rule }),
+  });
+  if (!response.ok) {
+    throw new Error(`could not create Vercel Firewall rule (${response.status})`);
+  }
+  return { status: "created", rule };
+}

--- a/src/lib/waf-asn.ts
+++ b/src/lib/waf-asn.ts
@@ -1,0 +1,99 @@
+import proxyFarmAsns from "../../config/proxy-farm-asns.json";
+
+export type WafCondition = {
+  type: "geo_as_number";
+  op: "inc";
+  value: string[];
+};
+
+export type WafRule = {
+  active: boolean;
+  name: string;
+  description: string;
+  conditionGroup: Array<{ conditions: WafCondition[] }>;
+  action: { mitigate: { action: "deny" } };
+};
+
+type RemoteWafRule = {
+  id?: string;
+  name?: string;
+  active?: boolean;
+  conditionGroup?: unknown;
+  action?: unknown;
+};
+
+export const WAF_ASN_RULE_NAME = proxyFarmAsns.ruleName;
+export const PROXY_FARM_ASNS = Object.freeze([...proxyFarmAsns.asns]);
+
+function normalizedAsns(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => /^\d+$/.test(value)))].sort(
+    (a, b) => Number(a) - Number(b),
+  );
+}
+
+/** The canonical Vercel WAF custom rule. `geo_as_number` is evaluated by Vercel
+ * before a request reaches the deployment, unlike a Next.js middleware check. */
+export function buildProxyFarmWafRule(): WafRule {
+  return {
+    active: true,
+    name: WAF_ASN_RULE_NAME,
+    description: proxyFarmAsns.description,
+    conditionGroup: [
+      {
+        conditions: [
+          {
+            type: "geo_as_number",
+            op: "inc",
+            value: [...PROXY_FARM_ASNS],
+          },
+        ],
+      },
+    ],
+    action: { mitigate: { action: "deny" } },
+  };
+}
+
+/** Accept the two documented Firewall response envelopes (`rules` and
+ * `active.rules`) without assuming a particular API version. */
+export function extractWafRules(payload: unknown): RemoteWafRule[] {
+  if (!payload || typeof payload !== "object") return [];
+  const root = payload as Record<string, unknown>;
+  if (Array.isArray(root.rules)) return root.rules.filter(isRemoteWafRule);
+  if (root.active && typeof root.active === "object") {
+    const active = root.active as Record<string, unknown>;
+    if (Array.isArray(active.rules)) return active.rules.filter(isRemoteWafRule);
+  }
+  return [];
+}
+
+function isRemoteWafRule(value: unknown): value is RemoteWafRule {
+  return !!value && typeof value === "object";
+}
+
+function asnValues(rule: RemoteWafRule): string[] {
+  if (!Array.isArray(rule.conditionGroup)) return [];
+  for (const group of rule.conditionGroup) {
+    if (!group || typeof group !== "object") continue;
+    const conditions = (group as { conditions?: unknown }).conditions;
+    if (!Array.isArray(conditions)) continue;
+    for (const condition of conditions) {
+      if (!condition || typeof condition !== "object") continue;
+      const item = condition as { type?: unknown; op?: unknown; value?: unknown };
+      if (item.type !== "geo_as_number" || item.op !== "inc" || !Array.isArray(item.value)) continue;
+      return item.value.filter((value): value is string => typeof value === "string");
+    }
+  }
+  return [];
+}
+
+/** A matching name alone is not enough: a stale WAF rule is reported as drift
+ * so the sync command never silently claims a changed denylist is deployed. */
+export function isCurrentProxyFarmWafRule(rule: RemoteWafRule): boolean {
+  const action = rule.action as { mitigate?: { action?: unknown } } | undefined;
+  return (
+    rule.name === WAF_ASN_RULE_NAME &&
+    rule.active === true &&
+    action?.mitigate?.action === "deny" &&
+    JSON.stringify(normalizedAsns(asnValues(rule))) === JSON.stringify(normalizedAsns(PROXY_FARM_ASNS))
+  );
+}


### PR DESCRIPTION
## 改动

- 将已用于流量归因的高置信代理农场 ASN 收敛到 `config/proxy-farm-asns.json`，作为报表与 WAF 的唯一来源。
- 新增 `pnpm waf:sync`：默认 dry-run；显式 `--apply` 时先读取 Vercel Firewall，再以 `geo_as_number` + `deny` 创建规则。
- 已存在同名规则且内容一致时无操作；内容不一致时返回 drift 并停止，避免脚本覆盖其他线上 WAF 配置。
- 明确排除 AWS 等通用云、消费级 VPN/加速器、居民网络，避免把可能的真人流量纳入农场封禁。
- 更新中英文部署说明和 `.env.example`，声明 Vercel token 仅用于运维终端，不能写入线上运行时环境。

## 验证

- 本地 HTTP mock 控制面 E2E：验证 GET 当前 Firewall、PATCH 精确规则、幂等重复执行与 drift fail-closed。
- `pnpm typecheck` 通过。
- `pnpm build` 通过。
- 定向 ESLint、`bash -n scripts/traffic-report.sh`、JSON 校验、dry-run 和无凭据 `--apply` fail-closed 均通过。
- 全仓 `pnpm lint` 仍被上游已有脚本的显式 `any` 与未使用导入阻断，和本 PR 无关。