### PR TITLE
feat(home): add ADVX 2026 event banner

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -6,6 +6,7 @@ import { HomeLeaderboard } from "@/components/HomeLeaderboard";
 import { Roaster } from "@/components/Roaster";
 import { HomeFaq, getFaqItems } from "@/components/HomeFaq";
 import { HomeIntro } from "@/components/HomeIntro";
+import { HomeEventBanner } from "@/components/HomeEventBanner";
 import { JsonLd, faqJsonLd } from "@/components/JsonLd";
 import type { TierKey } from "@/lib/tier";
 
@@ -39,8 +40,9 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
   const faqItems = await getFaqItems();
 
   return (
-    <main className="flex flex-1 flex-col items-center px-5 py-14 sm:px-6 sm:py-20">
+    <main className="flex flex-1 flex-col items-center px-5 pb-14 pt-2 sm:px-6 sm:pb-20 sm:pt-3">
       <JsonLd data={faqJsonLd(faqItems)} />
+      <HomeEventBanner locale={locale} />
       <header className="mb-10 flex w-full max-w-4xl flex-col items-center text-center">
         <p className="mb-3 text-sm font-bold tracking-wide text-zinc-400">
           {t("brand")} <span className="text-orange-500">GitHub</span>

--- a/src/components/HomeEventBanner.tsx
+++ b/src/components/HomeEventBanner.tsx
@@ -1,0 +1,27 @@
+import { Link } from "@/i18n/navigation";
+
+const COPY = {
+  zh: "🔥ADVX2026现场一决高下🔥",
+  default: "🔥 Face off live at ADVX 2026 🔥",
+} as const;
+
+export function HomeEventBanner({ locale }: { locale: string }) {
+  const label = locale === "zh" ? COPY.zh : COPY.default;
+
+  return (
+    <Link
+      href="/advx"
+      className="group mb-8 flex min-h-16 w-full max-w-6xl items-center justify-center overflow-hidden rounded-2xl border border-orange-400/30 bg-orange-500/[0.04] px-4 py-3 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition-colors hover:bg-orange-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:mb-10"
+    >
+      <span className="text-base font-black tracking-tight text-orange-200 sm:text-lg">
+        {label}
+      </span>
+      <span
+        aria-hidden="true"
+        className="ms-2 text-orange-400 transition-transform group-hover:translate-x-0.5"
+      >
+        →
+      </span>
+    </Link>
+  );
+}

--- a/src/components/__tests__/HomeEventBanner.test.tsx
+++ b/src/components/__tests__/HomeEventBanner.test.tsx
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../HomeEventBanner.tsx", import.meta.url), "utf8");
+
+describe("HomeEventBanner", () => {
+  it("shows the requested Chinese campaign copy and links to the event page", () => {
+    expect(source).toContain('zh: "🔥ADVX2026现场一决高下🔥"');
+    expect(source).toContain('href="/advx"');
+  });
+
+  it("uses English campaign copy on other locales", () => {
+    expect(source).toContain('default: "🔥 Face off live at ADVX 2026 🔥"');
+    expect(source).toContain('locale === "zh" ? COPY.zh : COPY.default');
+  });
+});


### PR DESCRIPTION
## Summary

- add a prominent ADVX 2026 campaign banner above the homepage hero
- link the banner to the existing `/advx` live leaderboard
- keep the requested Chinese copy and provide an English fallback for other locales
- tighten homepage top spacing so the banner sits directly below the navbar

## Impact

Visitors can discover and enter the ADVX 2026 live competition directly from the homepage. The banner follows the existing orange accent, responsive layout, and light/dark theme system.

## Validation

- `vitest run src/components/__tests__/HomeEventBanner.test.tsx`
- `tsc --noEmit`
- ESLint on the three changed files
- manual browser QA at 1280px and 390px in light, dark, and auto themes
- verified the banner navigates to `/advx`

Repository-wide `eslint .` still reports the pre-existing `no-explicit-any` error in `scripts/langgenius-audit.mts` and an unused-import warning in `scripts/mega-ingest.mts`.

## Change metadata

- Generated files: no
- GraphQL codegen updates: no
- DB baseline updates: no
