### PR TITLE
fix(scan): use public events for activity recency

### DIFF
--- a/src/lib/__tests__/github.test.ts
+++ b/src/lib/__tests__/github.test.ts
@@ -53,6 +53,7 @@ describe("collect", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (originalToken === undefined) delete process.env.GITHUB_TOKEN;
     else process.env.GITHUB_TOKEN = originalToken;
     vi.unstubAllGlobals();
@@ -98,6 +99,131 @@ describe("collect", () => {
     );
 
     await expect(collect("alice")).rejects.toBeInstanceOf(GitHubDataUnavailableError);
+  });
+
+  it("uses public events for activity recency when owned repo pushes are stale", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-18T12:00:00Z"));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url === "https://api.github.com/users/active") {
+          return jsonResponse({
+            login: "active",
+            id: 3,
+            html_url: "https://github.com/active",
+            avatar_url: null,
+            name: null,
+            bio: null,
+            company: null,
+            created_at: "2020-01-01T00:00:00Z",
+            followers: 0,
+            following: 0,
+            public_repos: 1,
+          });
+        }
+
+        if (url.includes("/users/active/repos")) {
+          return jsonResponse([
+            {
+              name: "old-fork",
+              full_name: "active/old-fork",
+              private: false,
+              fork: true,
+              size: 1,
+              stargazers_count: 0,
+              forks_count: 0,
+              open_issues_count: 0,
+              language: null,
+              description: null,
+              pushed_at: "2023-09-01T00:00:00Z",
+              owner: { login: "active" },
+              topics: [],
+            },
+          ]);
+        }
+
+        if (url === "https://api.github.com/users/active/events/public?per_page=30") {
+          return jsonResponse([
+            {
+              type: "IssueCommentEvent",
+              created_at: "2026-07-18T10:30:00Z",
+              repo: { name: "upstream/project" },
+            },
+          ]);
+        }
+
+        if (url === "https://api.github.com/graphql") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { query?: string };
+          const query = body.query ?? "";
+
+          if (query.includes("organizations(first: 20)")) {
+            return jsonResponse({ data: { user: { organizations: { nodes: [] } } } });
+          }
+
+          if (query.includes("pullRequests(first: $count, states: MERGED")) {
+            return jsonResponse({
+              data: {
+                user: {
+                  pullRequests: {
+                    nodes: [],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              },
+            });
+          }
+
+          if (
+            query.includes("pullRequests(first: $count, orderBy: {field: CREATED_AT, direction: DESC})")
+          ) {
+            return jsonResponse({ data: { user: { pullRequests: { nodes: [] } } } });
+          }
+
+          if (
+            query.includes("mergedPRs: pullRequests") &&
+            query.includes("pinnedItems(first: 6, types: REPOSITORY)")
+          ) {
+            return jsonResponse({
+              data: {
+                user: {
+                  pinnedItems: { nodes: [] },
+                  mergedPRs: { totalCount: 0 },
+                  allPRs: { totalCount: 0 },
+                  closedPRs: { totalCount: 0, nodes: [] },
+                  issues: { totalCount: 0 },
+                  contributionsCollection: {
+                    totalCommitContributions: 0,
+                    totalPullRequestContributions: 0,
+                    totalIssueContributions: 1,
+                    totalPullRequestReviewContributions: 0,
+                    restrictedContributionsCount: 0,
+                    contributionCalendar: { totalContributions: 1 },
+                  },
+                  contributionYears: { contributionYears: [] },
+                },
+              },
+            });
+          }
+
+          return jsonResponse({ data: { user: null } });
+        }
+
+        return jsonResponse({}, 404);
+      }),
+    );
+
+    const result = await collect("active");
+
+    expect(result.metrics.days_since_last_activity).toBe(0);
   });
 
   it("splits the contribution query when GitHub reports RESOURCE_LIMITS_EXCEEDED", async () => {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -206,6 +206,10 @@ interface RestUser {
   public_repos: number;
 }
 
+interface RestPublicEvent {
+  created_at?: string | null;
+}
+
 async function restGet<T>(path: string): Promise<T | null> {
   let res: Response;
   try {
@@ -536,6 +540,23 @@ function parseTs(value: string | null | undefined): Date | null {
   if (!value) return null;
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+async function fetchLatestPublicEvent(username: string): Promise<Date | null> {
+  try {
+    const events = await restGet<RestPublicEvent[]>(
+      `users/${encodeURIComponent(username)}/events/public?per_page=30`,
+    );
+    if (!events) return null;
+    let latest: Date | null = null;
+    for (const event of events) {
+      const ts = parseTs(event.created_at);
+      if (ts && (latest === null || ts > latest)) latest = ts;
+    }
+    return latest;
+  } catch {
+    return null;
+  }
 }
 
 export function boundedContributionYearsActive(
@@ -2388,7 +2409,8 @@ export async function collect(username: string): Promise<{
   const empty = repos.filter((r) => (r.size ?? 0) === 0 && !r.fork);
   const nonemptyOriginal = original.filter((r) => (r.size ?? 0) > 0);
 
-  const { overview, statTotals, lastYearContributions } = await fetchContribOverview(username);
+  const [{ overview, statTotals, lastYearContributions }, latestPublicEvent] =
+    await Promise.all([fetchContribOverview(username), fetchLatestPublicEvent(username)]);
   const contributionYears = overview.contributionYears?.contributionYears ?? [];
   const pinnedRepos = (overview.pinnedItems?.nodes ?? [])
     .map((n) => n?.nameWithOwner)
@@ -2452,14 +2474,15 @@ export async function collect(username: string): Promise<{
     ? Math.round(((now.getTime() - created.getTime()) / dayMs / 365.25) * 100) / 100
     : 0.0;
 
-  // Most recent push across repos
-  let lastPush: Date | null = null;
+  // Most recent public activity. Repository pushes cover owned repos, while
+  // public events cover org/external contributions and issue/comment activity.
+  let lastActivity: Date | null = latestPublicEvent;
   for (const r of repos) {
     const ts = parseTs(r.pushed_at);
-    if (ts && (lastPush === null || ts > lastPush)) lastPush = ts;
+    if (ts && (lastActivity === null || ts > lastActivity)) lastActivity = ts;
   }
-  const daysSinceActive = lastPush
-    ? Math.floor((now.getTime() - lastPush.getTime()) / dayMs)
+  const daysSinceActive = lastActivity
+    ? Math.max(0, Math.floor((now.getTime() - lastActivity.getTime()) / dayMs))
     : null;
 
   const followers = user.followers ?? 0;


### PR DESCRIPTION
## Summary
- include GitHub public events when computing activity recency
- keep stale repo pushed_at as a fallback instead of the only source
- add a regression test for stale owned-repo pushes with recent public activity

Fixes #92

## Validation
- pnpm vitest run src/lib/__tests__/github.test.ts
- pnpm typecheck
- pnpm test
- local /api/scan rprx returns days_since_last_activity: 0

Note: pnpm lint still fails on pre-existing script lint debt in scripts/langgenius-audit.mts and scripts/mega-ingest.mts.