### PR TITLE
fix: preserve cost protection during Redis limiter outages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,14 @@ LLM_FALLBACK_API_KEY=
 # LLM_FALLBACK_BASE_URL=https://api.deepseek.com       # default; override for another provider
 # LLM_FALLBACK_MODEL=deepseek-v4-flash                  # default
 
-# ── Cache + rate limiting (optional but recommended) ──────────────────────
+# ── Cache + rate limiting (required for production cost protection) ────────
 # Upstash Redis (free tier). Caches scans 24h by username and rate-limits per IP.
-# If absent, both silently no-op (fine for local dev).
+# It is optional in local development. In production, protected uncached routes
+# return 503 when Redis is unavailable instead of silently spending GitHub/Turso/LLM budget.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+# Emergency operator override only. Leave unset in normal production operation.
+# RATE_LIMIT_FAIL_OPEN=1
 
 # ── Human verification (optional but recommended in prod) ─────────────────
 # Cloudflare Turnstile (free). If absent, the human-check is skipped.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ facts.
 
 ## Environment variables
 
-See [`.env.example`](./.env.example). The minimum to run the GitHub roast flow is `GITHUB_TOKEN` + `LLM_API_KEY` (defaults to StepFun, OpenAI-compatible; swap in any OpenAI-compatible service). Cache, rate limiting, human verification, GitHub login, profile comments/reactions, and the leaderboard **degrade silently** when unconfigured (fine for local). Configure everything for production.
+See [`.env.example`](./.env.example). The minimum to run the GitHub roast flow is `GITHUB_TOKEN` + `LLM_API_KEY` (defaults to StepFun, OpenAI-compatible; swap in any OpenAI-compatible service). Cache, rate limiting, human verification, GitHub login, profile comments/reactions, and the leaderboard **degrade silently** when unconfigured in local development. Production requires `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`: when the limiter is unavailable, only protected uncached cost-bearing routes return `503` with `Retry-After`; edge-cached responses and ordinary browsing continue. `RATE_LIMIT_FAIL_OPEN=1` is an emergency operator override and should not be set during normal operation.
 
 ## Leaderboard + percentile (Turso, optional)
 

--- a/src/app/api/campaigns/[campaign]/leaderboard/route.test.ts
+++ b/src/app/api/campaigns/[campaign]/leaderboard/route.test.ts
@@ -44,6 +44,21 @@ describe("campaign leaderboard public guardrails", () => {
     expect(mocks.getCampaignLeaderboard).not.toHaveBeenCalled();
   });
 
+  it("fails closed before the leaderboard database query when request protection is unavailable", async () => {
+    mocks.checkRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await GET(
+      new NextRequest("https://example.test/api/campaigns/advx/leaderboard"),
+      context,
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toEqual({ error: "rate_limit_unavailable" });
+    expect(mocks.getCampaignLeaderboard).not.toHaveBeenCalled();
+  });
+
   it("canonicalizes cache-busting query strings before Turso", async () => {
     const response = await GET(
       new NextRequest("https://example.test/api/campaigns/advx/leaderboard?limit=0100&utm=x"),

--- a/src/app/api/campaigns/[campaign]/leaderboard/route.ts
+++ b/src/app/api/campaigns/[campaign]/leaderboard/route.ts
@@ -42,9 +42,9 @@ export async function GET(
   const limit = await checkRateLimit(clientIp(req));
   if (!limit.success) {
     return NextResponse.json(
-      { error: "rate_limited" },
+      { error: limit.unavailable ? "rate_limit_unavailable" : "rate_limited" },
       {
-        status: 429,
+        status: limit.unavailable ? 503 : 429,
         headers: { ...rateLimitHeaders(limit), "Cache-Control": "no-store" },
       },
     );

--- a/src/app/api/facet-rank/[username]/route.test.ts
+++ b/src/app/api/facet-rank/[username]/route.test.ts
@@ -46,6 +46,19 @@ describe("facet-rank public guardrails", () => {
     expect(mocks.getFacetRank).not.toHaveBeenCalled();
   });
 
+  it("fails closed before both database reads when request protection is unavailable", async () => {
+    mocks.checkRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await GET(new NextRequest("https://example.test/api/facet-rank/DemoDev"), context);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toEqual({ error: "rate_limit_unavailable" });
+    expect(mocks.getScoreBrief).not.toHaveBeenCalled();
+    expect(mocks.getFacetRank).not.toHaveBeenCalled();
+  });
+
   it("CDN-caches null ranks after the limiter passes", async () => {
     mocks.getScoreBrief.mockResolvedValue(null);
 

--- a/src/app/api/facet-rank/[username]/route.ts
+++ b/src/app/api/facet-rank/[username]/route.ts
@@ -28,9 +28,9 @@ export async function GET(
   const limit = await checkRateLimit(clientIp(req));
   if (!limit.success) {
     return NextResponse.json(
-      { error: "rate_limited" },
+      { error: limit.unavailable ? "rate_limit_unavailable" : "rate_limited" },
       {
-        status: 429,
+        status: limit.unavailable ? 503 : 429,
         headers: { ...rateLimitHeaders(limit), "Cache-Control": "no-store" },
       },
     );

--- a/src/app/api/profile/backfill/route.test.ts
+++ b/src/app/api/profile/backfill/route.test.ts
@@ -72,4 +72,22 @@ describe("profile backfill rate-limit ordering", () => {
     expect(mocks.getCachedScan).not.toHaveBeenCalled();
     expect(mocks.collect).not.toHaveBeenCalled();
   });
+
+  it("fails closed before any database read when request protection is unavailable", async () => {
+    mocks.checkRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/profile/backfill", {
+        method: "POST",
+        body: JSON.stringify({ username: "DemoDev" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toEqual({ error: "rate_limit_unavailable" });
+    expect(mocks.getScoreBrief).not.toHaveBeenCalled();
+    expect(mocks.hasProfileSnapshot).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/profile/backfill/route.ts
+++ b/src/app/api/profile/backfill/route.ts
@@ -64,9 +64,9 @@ export async function POST(req: NextRequest) {
   const limit = await checkRateLimit(ip);
   if (!limit.success) {
     return NextResponse.json(
-      { error: "rate_limited" },
+      { error: limit.unavailable ? "rate_limit_unavailable" : "rate_limited" },
       {
-        status: 429,
+        status: limit.unavailable ? 503 : 429,
         headers: { ...rateLimitHeaders(limit), "Cache-Control": "no-store" },
       },
     );

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -313,6 +313,28 @@ describe("roast API persistence", () => {
     expect(mocks.getCachedScan).not.toHaveBeenCalled();
   });
 
+  it("fails closed for BYO roast requests before durable-status and scan-cache reads", async () => {
+    mocks.checkRoastRequestRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({
+          scan,
+          lang: "zh",
+          byoKey: { baseURL: "https://llm.example.test/v1", apiKey: "user-key", model: "test" },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toMatchObject({ error: "rate_limit_unavailable", useByoKey: true });
+    expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
+    expect(mocks.getCachedScan).not.toHaveBeenCalled();
+  });
+
   it("never seeds a durable scan from an untrusted roast request body", async () => {
     mocks.requiresDurablePublicScan.mockReturnValue(true);
     mocks.startPublicScan.mockResolvedValue({

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -652,9 +652,9 @@ export async function POST(req: NextRequest) {
   const requestLimit = await checkRoastRequestRateLimit(clientIp(req));
   if (!requestLimit.success) {
     return NextResponse.json(
-      { error: "rate_limited", useByoKey: true },
+      { error: requestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
       {
-        status: 429,
+        status: requestLimit.unavailable ? 503 : 429,
         headers: { ...rateLimitHeaders(requestLimit), "Cache-Control": "no-store" },
       },
     );
@@ -810,11 +810,14 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const { success } = await checkRoastRateLimit(clientIp(req));
-    if (!success) {
+    const generationLimit = await checkRoastRateLimit(clientIp(req));
+    if (!generationLimit.success) {
       return NextResponse.json(
-        { error: "rate_limited", useByoKey: true },
-        { status: 429 },
+        { error: generationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
+        {
+          status: generationLimit.unavailable ? 503 : 429,
+          headers: { ...rateLimitHeaders(generationLimit), "Cache-Control": "no-store" },
+        },
       );
     }
     // Single-flight: become the lone generator, or wait for whoever already is.

--- a/src/app/api/scan-status/[username]/route.test.ts
+++ b/src/app/api/scan-status/[username]/route.test.ts
@@ -60,6 +60,18 @@ describe("durable scan status API", () => {
     expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
   });
 
+  it("returns a retryable 503 before Turso when request protection is unavailable", async () => {
+    mocks.checkPublicScanStatusRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await request("durable-status-case");
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toEqual({ error: "rate_limit_unavailable", retry_after: 15 });
+    expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
+  });
+
   it("returns a complete snapshot only after public collection finishes", async () => {
     mocks.getPublicScanStatus.mockResolvedValue({
       status: "complete",

--- a/src/app/api/scan-status/[username]/route.ts
+++ b/src/app/api/scan-status/[username]/route.ts
@@ -34,8 +34,11 @@ export async function GET(
   const headers = rateLimitHeaders(limit);
   if (!limit.success) {
     return NextResponse.json(
-      { error: "rate_limited", retry_after: Number(headers["Retry-After"] ?? 1) },
-      { status: 429, headers: { ...headers, "Cache-Control": "no-store" } },
+      {
+        error: limit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+        retry_after: Number(headers["Retry-After"] ?? 1),
+      },
+      { status: limit.unavailable ? 503 : 429, headers: { ...headers, "Cache-Control": "no-store" } },
     );
   }
 

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -186,6 +186,19 @@ describe("scan route machine auth", () => {
     expect(mocks.recordAccountLookup).not.toHaveBeenCalled();
   });
 
+  it("fails closed before cache and lookup work when production rate limiting is unavailable", async () => {
+    mocks.checkRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toMatchObject({ error: "rate_limit_unavailable" });
+    expect(mocks.getCachedScan).not.toHaveBeenCalled();
+    expect(mocks.recordAccountLookup).not.toHaveBeenCalled();
+  });
+
   it("serves cache hits with RateLimit headers once the limiter passes", async () => {
     mocks.rateLimitHeaders.mockReturnValue({ "RateLimit-Remaining": "9" });
     mocks.getCachedScan.mockResolvedValue({ metrics, scoring });

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -173,7 +173,10 @@ export async function POST(req: NextRequest) {
   const limit = await checkRateLimit(ip);
   const rlHeaders = rateLimitHeaders(limit);
   if (!limit.success) {
-    return apiError("rate_limited", { status: 429, headers: { ...idem, ...rlHeaders } });
+    return apiError(limit.unavailable ? "rate_limit_unavailable" : "rate_limited", {
+      status: limit.unavailable ? 503 : 429,
+      headers: { ...idem, ...rlHeaders, "Cache-Control": "no-store" },
+    });
   }
 
   // Cache hit short-circuits both GitHub and (later) the LLM. The leaderboard

--- a/src/app/api/score/[username]/route.test.ts
+++ b/src/app/api/score/[username]/route.test.ts
@@ -119,6 +119,18 @@ describe("score durable scan guardrails", () => {
     expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
   });
 
+  it("fails closed before a durable status lookup when request protection is unavailable", async () => {
+    mocks.checkPublicScanStatusRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await request();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toMatchObject({ error: "rate_limit_unavailable" });
+    expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
+  });
+
   it("starts one response-side step only for a newly created durable job", async () => {
     mocks.getCachedScan.mockResolvedValue(quickScan);
     mocks.requiresDurablePublicScan.mockReturnValue(true);

--- a/src/app/api/score/[username]/route.ts
+++ b/src/app/api/score/[username]/route.ts
@@ -168,8 +168,12 @@ export async function GET(
   const statusHeaders = rateLimitHeaders(statusLimit);
   if (!statusLimit.success) {
     return json(
-      { error: "rate_limited", message: "too many status requests", hint: "retry after the Retry-After interval" },
-      429,
+      {
+        error: statusLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+        message: statusLimit.unavailable ? "request protection temporarily unavailable" : "too many status requests",
+        hint: "retry after the Retry-After interval",
+      },
+      statusLimit.unavailable ? 503 : 429,
       "no-store",
       statusHeaders,
     );
@@ -215,9 +219,13 @@ export async function GET(
     rlHeaders = rateLimitHeaders(limit);
     if (!limit.success) {
       return json(
-        { error: "rate_limited", message: "too many requests", hint: "retry after the Retry-After interval" },
-        429,
-        MISS_CACHE,
+        {
+          error: limit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+          message: limit.unavailable ? "request protection temporarily unavailable" : "too many requests",
+          hint: "retry after the Retry-After interval",
+        },
+        limit.unavailable ? 503 : 429,
+        "no-store",
         rlHeaders,
       );
     }

--- a/src/app/api/vs-verdict/route.test.ts
+++ b/src/app/api/vs-verdict/route.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   checkBotId: vi.fn(),
   checkVerdictRateLimit: vi.fn(),
+  rateLimitHeaders: vi.fn(),
   getAccountDetail: vi.fn(),
   recordMatchup: vi.fn(),
   bumpMatchupView: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("@/lib/db", () => ({
 
 vi.mock("@/lib/redis", () => ({
   checkVerdictRateLimit: mocks.checkVerdictRateLimit,
+  rateLimitHeaders: mocks.rateLimitHeaders,
   acquireVerdictLock: vi.fn(),
   getCachedVerdict: vi.fn(),
   releaseVerdictLock: vi.fn(),
@@ -32,6 +34,7 @@ describe("vs verdict cost guardrail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.checkVerdictRateLimit.mockResolvedValue({ success: false });
+    mocks.rateLimitHeaders.mockReturnValue({});
   });
 
   it("rate-limits before BotID and all Turso reads or writes", async () => {
@@ -48,5 +51,23 @@ describe("vs verdict cost guardrail", () => {
     expect(mocks.getAccountDetail).not.toHaveBeenCalled();
     expect(mocks.recordMatchup).not.toHaveBeenCalled();
     expect(mocks.bumpMatchupView).not.toHaveBeenCalled();
+  });
+
+  it("returns a retryable 503 before BotID and all Turso reads when protection is unavailable", async () => {
+    mocks.checkVerdictRateLimit.mockResolvedValue({ success: false, unavailable: true, retryAfter: 15 });
+    mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "15" });
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/vs-verdict", {
+        method: "POST",
+        body: JSON.stringify({ a: "alice", b: "bob" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("15");
+    await expect(response.json()).resolves.toEqual({ verdict: null, reason: "rate_limit_unavailable" });
+    expect(mocks.checkBotId).not.toHaveBeenCalled();
+    expect(mocks.getAccountDetail).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/vs-verdict/route.ts
+++ b/src/app/api/vs-verdict/route.ts
@@ -11,6 +11,7 @@ import {
   acquireVerdictLock,
   checkVerdictRateLimit,
   getCachedVerdict,
+  rateLimitHeaders,
   releaseVerdictLock,
   setCachedVerdict,
   waitForCachedVerdict,
@@ -60,11 +61,14 @@ export async function POST(req: NextRequest) {
   // Enforce the request budget before BotID and every Turso read/write. The
   // cached verdict is already present in the SSR page, so a retry that exceeds
   // the budget can safely keep rendering the deterministic fallback.
-  const { success } = await checkVerdictRateLimit(clientIp(req));
-  if (!success) {
+  const limit = await checkVerdictRateLimit(clientIp(req));
+  if (!limit.success) {
     return NextResponse.json(
-      { verdict: null, reason: "rate_limited" },
-      { status: 429, headers: { "Cache-Control": "no-store" } },
+      { verdict: null, reason: limit.unavailable ? "rate_limit_unavailable" : "rate_limited" },
+      {
+        status: limit.unavailable ? 503 : 429,
+        headers: { ...rateLimitHeaders(limit), "Cache-Control": "no-store" },
+      },
     );
   }
 

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -48,8 +48,13 @@ async function guarded(
   extra: Extra,
   run: () => Promise<unknown>,
 ): Promise<ReturnType<typeof jsonResult>> {
-  const { success } = await checkMcpRateLimit(ipFrom(extra));
-  if (!success) {
+  const limit = await checkMcpRateLimit(ipFrom(extra));
+  if (!limit.success) {
+    if (limit.unavailable) {
+      return errorResult(
+        `rate_limit_unavailable: request protection is temporarily unavailable; retry in ${limit.retryAfter ?? 15} seconds`,
+      );
+    }
     return errorResult("rate_limited: too many requests, slow down and retry in a minute");
   }
   return jsonResult(await run());

--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -27,7 +27,7 @@ export function GET() {
         "stable machine code, `message`/`hint` are human-readable. See the `Error` schema.\n\n" +
         "## Rate limits\n" +
         "Responses carry `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers; a " +
-        "`429` also carries `Retry-After`. Write calls accept an `Idempotency-Key` request header " +
+        "`429` and temporary request-protection `503` responses carry `Retry-After`. Write calls accept an `Idempotency-Key` request header " +
         "(scans are idempotent per username).\n\n" +
         "## Versioning & stability\n" +
         "The API is unversioned (`/api/*`) and evolves additively: new fields may be added, but " +
@@ -90,7 +90,7 @@ export function GET() {
               headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } },
               content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
             },
-            "503": { description: "GitHub temporarily unavailable", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+            "503": { description: "GitHub or request protection temporarily unavailable", headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } }, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
           },
         },
       },
@@ -148,7 +148,7 @@ export function GET() {
               headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } },
               content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
             },
-            "503": { description: "GitHub temporarily unavailable", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+            "503": { description: "GitHub or request protection temporarily unavailable", headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } }, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
           },
         },
       },
@@ -186,8 +186,9 @@ export function GET() {
               },
             },
             "202": { description: "Collection remains in progress", headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } }, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+            "429": { description: "Status polling rate limited", headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } }, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
             "404": { description: "No durable scan has been requested", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
-            "503": { description: "Durable run failed or its queue is unavailable", headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } }, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+            "503": { description: "Durable run or request protection unavailable", headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } }, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
           },
         },
       },
@@ -236,6 +237,11 @@ export function GET() {
               headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } },
               content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
             },
+            "503": {
+              description: "Request protection temporarily unavailable",
+              headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } },
+              content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+            },
           },
         },
       },
@@ -272,6 +278,16 @@ export function GET() {
             "404": {
               description: "One or both accounts not scored",
               content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+            },
+            "429": {
+              description: "Verdict generation rate limited",
+              headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } },
+              content: { "application/json": { schema: { $ref: "#/components/schemas/VsVerdictResponse" } } },
+            },
+            "503": {
+              description: "Request protection temporarily unavailable",
+              headers: { "Retry-After": { $ref: "#/components/headers/Retry-After" } },
+              content: { "application/json": { schema: { $ref: "#/components/schemas/VsVerdictResponse" } } },
             },
           },
         },
@@ -398,7 +414,7 @@ export function GET() {
         "RateLimit-Limit": { description: "Request quota for the window", schema: { type: "integer" } },
         "RateLimit-Remaining": { description: "Requests remaining in the window", schema: { type: "integer" } },
         "RateLimit-Reset": { description: "Seconds until the window resets", schema: { type: "integer" } },
-        "Retry-After": { description: "Seconds to wait before retrying (on 429)", schema: { type: "integer" } },
+        "Retry-After": { description: "Seconds to wait before retrying (on retryable 429/503 responses)", schema: { type: "integer" } },
       },
       schemas: {
         Error: {
@@ -414,6 +430,7 @@ export function GET() {
                 "invalid_username",
                 "turnstile_failed",
                 "rate_limited",
+                "rate_limit_unavailable",
                 "account_not_found",
                 "github_rate_limited",
                 "github_unavailable",

--- a/src/lib/__tests__/redis-rate-limit.test.ts
+++ b/src/lib/__tests__/redis-rate-limit.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadRedis() {
+  vi.resetModules();
+  return import("../redis");
+}
+
+function unsetRedisEnv() {
+  vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
+  vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("production rate-limit availability", () => {
+  it("keeps local development usable without Redis", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VERCEL_ENV", "development");
+    unsetRedisEnv();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkRateLimit } = await loadRedis();
+
+    await expect(checkRateLimit("198.51.100.10")).resolves.toEqual({ success: true });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("keeps Vercel preview deployments usable without production Redis", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    unsetRedisEnv();
+    const { checkRateLimit } = await loadRedis();
+
+    await expect(checkRateLimit("198.51.100.10")).resolves.toEqual({ success: true });
+  });
+
+  it("fails closed with a retry hint when production Redis is unconfigured", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "production");
+    unsetRedisEnv();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkRateLimit, rateLimitHeaders } = await loadRedis();
+
+    const result = await checkRateLimit("198.51.100.10");
+
+    expect(result).toMatchObject({ success: false, unavailable: true, retryAfter: 15 });
+    expect(rateLimitHeaders(result)).toEqual({ "Retry-After": "15" });
+    expect(error).toHaveBeenCalledWith(
+      "rate_limit_unavailable",
+      expect.objectContaining({ limiter: "scan", reason: "missing_redis_config" }),
+    );
+  });
+
+  it("fails closed when a configured Redis limiter request errors", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://redis.example.test");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token");
+    const fetch = vi.fn().mockRejectedValue(new Error("redis unavailable"));
+    vi.stubGlobal("fetch", fetch);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkRateLimit } = await loadRedis();
+
+    await expect(checkRateLimit("198.51.100.10")).resolves.toMatchObject({
+      success: false,
+      unavailable: true,
+      retryAfter: 15,
+    });
+    expect(fetch).toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      "rate_limit_unavailable",
+      expect.objectContaining({ limiter: "scan", reason: "Error" }),
+    );
+  });
+
+  it("allows an explicit emergency operator override", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("RATE_LIMIT_FAIL_OPEN", "1");
+    unsetRedisEnv();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkRateLimit } = await loadRedis();
+
+    await expect(checkRateLimit("198.51.100.10")).resolves.toEqual({ success: true });
+    expect(error).toHaveBeenCalledWith(
+      "rate_limit_unavailable",
+      expect.objectContaining({ limiter: "scan", reason: "operator_fail_open_override" }),
+    );
+  });
+});

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -12,6 +12,7 @@ export type ApiErrorCode =
   | "invalid_username"
   | "turnstile_failed"
   | "rate_limited"
+  | "rate_limit_unavailable"
   | "account_not_found"
   | "github_rate_limited"
   | "github_unavailable"
@@ -29,6 +30,7 @@ const HINTS: Partial<Record<ApiErrorCode, string>> = {
   invalid_username: "Pass a valid GitHub login (letters, digits, single hyphens).",
   turnstile_failed: "Complete the browser verification, or call with a Bearer API key.",
   rate_limited: "Slow down and retry after the Retry-After interval.",
+  rate_limit_unavailable: "Request protection is temporarily unavailable — retry after the Retry-After interval.",
   account_not_found: "That GitHub login does not exist.",
   github_rate_limited: "GitHub's API is rate limited right now — retry shortly.",
   github_unavailable: "GitHub is temporarily unavailable — retry later.",

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,11 +1,11 @@
 /**
  * Upstash Redis cache + rate limiting.
  *
- * Both are optional: if the env vars are absent (e.g. local dev), caching and
- * rate limiting silently no-op so the app still runs. Caching scan results by
- * username is the primary cost lever — popular accounts get scanned repeatedly
- * when a report is shared, and a cache hit avoids both GitHub API calls and an
- * LLM call.
+ * Cache reads are always best-effort. Rate limiting also no-ops locally, but a
+ * production deployment fails closed for protected cost-bearing routes when its
+ * Redis limiter is unavailable. Caching scan results by username is the primary
+ * cost lever — popular accounts get scanned repeatedly when a report is shared,
+ * and a cache hit avoids both GitHub API calls and an LLM call.
  */
 
 import { Ratelimit } from "@upstash/ratelimit";
@@ -36,6 +36,39 @@ let roastMinuteLimiter: Ratelimit | null = null;
 let roastDayLimiter: Ratelimit | null = null;
 let verdictMinuteLimiter: Ratelimit | null = null;
 let verdictDayLimiter: Ratelimit | null = null;
+
+export const RATE_LIMIT_UNAVAILABLE_RETRY_AFTER_SECONDS = 15;
+const LIMITER_UNAVAILABLE_LOG_INTERVAL_MS = 60_000;
+const limiterUnavailableLogAt = new Map<string, number>();
+
+function isProductionDeployment(): boolean {
+  return (
+    process.env.VERCEL_ENV === "production" ||
+    (process.env.NODE_ENV === "production" && process.env.VERCEL_ENV !== "preview")
+  );
+}
+
+function logRateLimitUnavailable(limiter: string, reason: string): void {
+  const now = Date.now();
+  const last = limiterUnavailableLogAt.get(limiter) ?? 0;
+  if (now - last < LIMITER_UNAVAILABLE_LOG_INTERVAL_MS) return;
+  limiterUnavailableLogAt.set(limiter, now);
+  console.error("rate_limit_unavailable", { limiter, reason });
+}
+
+function unavailableRateLimitResult(limiter: string, reason: string): RateLimitResult {
+  if (!isProductionDeployment()) return { success: true };
+  if (process.env.RATE_LIMIT_FAIL_OPEN === "1") {
+    logRateLimitUnavailable(limiter, "operator_fail_open_override");
+    return { success: true };
+  }
+  logRateLimitUnavailable(limiter, reason);
+  return {
+    success: false,
+    unavailable: true,
+    retryAfter: RATE_LIMIT_UNAVAILABLE_RETRY_AFTER_SECONDS,
+  };
+}
 
 function getRedis(): Redis | null {
   if (redis) return redis;
@@ -181,6 +214,10 @@ export interface RateLimitResult {
   limit?: number;
   remaining?: number;
   reset?: number;
+  /** The limiter infrastructure could not be used, distinct from a spent budget. */
+  unavailable?: boolean;
+  /** A short retry interval for an unavailable limiter. */
+  retryAfter?: number;
 }
 
 /**
@@ -189,6 +226,11 @@ export interface RateLimitResult {
  * limiter no-op'd (no Redis), so it's safe to always spread into headers.
  */
 export function rateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  if (result.unavailable) {
+    return {
+      "Retry-After": String(result.retryAfter ?? RATE_LIMIT_UNAVAILABLE_RETRY_AFTER_SECONDS),
+    };
+  }
   if (result.limit === undefined || result.reset === undefined) return {};
   const resetSeconds = Math.max(0, Math.ceil((result.reset - Date.now()) / 1000));
   const headers: Record<string, string> = {
@@ -200,10 +242,10 @@ export function rateLimitHeaders(result: RateLimitResult): Record<string, string
   return headers;
 }
 
-/** Per-IP sliding-window limiter for scans. No-ops when Redis is unconfigured. */
+/** Per-IP sliding-window limiter for scan and bounded public-read routes. */
 export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
   const r = getRedis();
-  if (!r) return { success: true };
+  if (!r) return unavailableRateLimitResult("scan", "missing_redis_config");
   if (!scanLimiter) {
     scanLimiter = new Ratelimit({
       redis: r,
@@ -215,8 +257,11 @@ export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
   try {
     const { success, limit, remaining, reset } = await scanLimiter.limit(ip);
     return { success, limit, remaining, reset };
-  } catch {
-    return { success: true };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "scan",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
   }
 }
 
@@ -228,7 +273,7 @@ export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
  */
 export async function checkPublicScanStatusRateLimit(ip: string): Promise<RateLimitResult> {
   const r = getRedis();
-  if (!r) return { success: true };
+  if (!r) return unavailableRateLimitResult("public_scan_status", "missing_redis_config");
   if (!publicScanStatusLimiter) {
     publicScanStatusLimiter = new Ratelimit({
       redis: r,
@@ -240,8 +285,11 @@ export async function checkPublicScanStatusRateLimit(ip: string): Promise<RateLi
   try {
     const { success, limit, remaining, reset } = await publicScanStatusLimiter.limit(ip);
     return { success, limit, remaining, reset };
-  } catch {
-    return { success: true };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "public_scan_status",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
   }
 }
 
@@ -252,7 +300,7 @@ export async function checkPublicScanStatusRateLimit(ip: string): Promise<RateLi
  */
 export async function checkRoastRequestRateLimit(ip: string): Promise<RateLimitResult> {
   const r = getRedis();
-  if (!r) return { success: true };
+  if (!r) return unavailableRateLimitResult("roast_request", "missing_redis_config");
   if (!roastRequestLimiter) {
     roastRequestLimiter = new Ratelimit({
       redis: r,
@@ -264,19 +312,22 @@ export async function checkRoastRequestRateLimit(ip: string): Promise<RateLimitR
   try {
     const { success, limit, remaining, reset } = await roastRequestLimiter.limit(ip);
     return { success, limit, remaining, reset };
-  } catch {
-    return { success: true };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "roast_request",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
   }
 }
 
 /**
  * Per-IP limiter for the MCP server. Tighter than the web scan limiter — the
  * tools are unauthenticated and callable in a loop by an autonomous agent, so we
- * cap harder to protect the GitHub token and DB. No-ops when Redis is absent.
+ * cap harder to protect the GitHub token and DB.
  */
-export async function checkMcpRateLimit(ip: string): Promise<{ success: boolean }> {
+export async function checkMcpRateLimit(ip: string): Promise<RateLimitResult> {
   const r = getRedis();
-  if (!r) return { success: true };
+  if (!r) return unavailableRateLimitResult("mcp", "missing_redis_config");
   if (!mcpLimiter) {
     mcpLimiter = new Ratelimit({
       redis: r,
@@ -288,8 +339,11 @@ export async function checkMcpRateLimit(ip: string): Promise<{ success: boolean 
   try {
     const { success } = await mcpLimiter.limit(ip);
     return { success };
-  } catch {
-    return { success: true };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "mcp",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
   }
 }
 
@@ -298,9 +352,9 @@ export async function checkMcpRateLimit(ip: string): Promise<{ success: boolean 
  * operator's credit, so it's limited tighter than scans: a burst window and a
  * daily cap. Only gates the default model; BYO keys are not limited.
  */
-export async function checkRoastRateLimit(ip: string): Promise<{ success: boolean }> {
+export async function checkRoastRateLimit(ip: string): Promise<RateLimitResult> {
   const r = getRedis();
-  if (!r) return { success: true };
+  if (!r) return unavailableRateLimitResult("roast_generation", "missing_redis_config");
   if (!roastMinuteLimiter) {
     roastMinuteLimiter = new Ratelimit({
       redis: r,
@@ -323,8 +377,11 @@ export async function checkRoastRateLimit(ip: string): Promise<{ success: boolea
       roastDayLimiter.limit(ip),
     ]);
     return { success: minute.success && day.success };
-  } catch {
-    return { success: true };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "roast_generation",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
   }
 }
 
@@ -593,9 +650,9 @@ export async function waitForCachedVerdict(
 }
 
 /** Per-IP limiter for the PK verdict LLM call (operator credit). Burst + daily. */
-export async function checkVerdictRateLimit(ip: string): Promise<{ success: boolean }> {
+export async function checkVerdictRateLimit(ip: string): Promise<RateLimitResult> {
   const r = getRedis();
-  if (!r) return { success: true };
+  if (!r) return unavailableRateLimitResult("vs_verdict", "missing_redis_config");
   if (!verdictMinuteLimiter) {
     verdictMinuteLimiter = new Ratelimit({
       redis: r,
@@ -618,8 +675,11 @@ export async function checkVerdictRateLimit(ip: string): Promise<{ success: bool
       verdictDayLimiter.limit(ip),
     ]);
     return { success: minute.success && day.success };
-  } catch {
-    return { success: true };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "vs_verdict",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
   }
 }
 


### PR DESCRIPTION
Closes #109

## Problem

The public cost-protection routes introduced by #106 rely on Upstash Redis. Before this change, a missing Redis configuration or an Upstash request failure was treated as a successful rate-limit check. In production that silently re-opened the same request-amplification path: public traffic could again reach Turso, GitHub, and model-backed work without a functioning limiter.

## Production behavior

When a protected limiter is unavailable in a production deployment, stop the request before its downstream work and return:

- `503 Service Unavailable`
- `rate_limit_unavailable`
- `Retry-After: 15`

A real quota exhaustion remains `429`; this change does not conflate an overloaded user with unavailable limiter infrastructure. Local development and Vercel Preview retain the existing no-op limiter behavior so they do not require an Upstash instance.

## Covered paths

The policy applies before expensive work on public scan creation/status, score reads, roast requests including BYO-key requests, VS verdicts, MCP, profile backfill, facet rank, and campaign leaderboard routes. Cache and ordinary non-cost-protection reads remain best-effort; this is not a site-wide Redis outage policy.

The server emits throttled structured `rate_limit_unavailable` logs for operator visibility. `RATE_LIMIT_FAIL_OPEN=1` is documented as a temporary, explicit emergency override only.

## Verification

- `pnpm test` - 445 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Production-mode local smoke with Redis credentials intentionally absent: `GET /api/score/octocat`, `GET /api/scan-status/octocat?run_id=run-id`, and `POST /api/vs-verdict` each returned `503` with `Retry-After: 15` and did not reach downstream work.

## Deployment note

Production already has the required Upstash variables according to the project owner. The current Vercel check is blocked only because the project GitHub deployment integration needs owner reauthorization; it is not a test or build failure.