### PR TITLE
docs: remove unavailable Star History charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,3 @@ Licensed under **[GNU AGPL-3.0](./LICENSE)**.
 - The scoring core is ported from the open-source Claude skill `github-account-value`, kept as the single source of truth.
 
 > **Trademark:** the "ghfind / 毒舌 GitHub 评分" name, logo, and domain are **not covered** by the open-source license; all rights reserved. You may self-host from this code, but please do not use the project's name/brand to impersonate the official site or cause confusion.
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=hikariming%2Fghfind&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
- </picture>
-</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -234,13 +234,3 @@ TURSO_DATABASE_URL=file:./local.db
 - 评分核心移植自开源 Claude 技能 `github-account-value`,保持单一事实来源。
 
 > **商标声明:** 「ghfind / 毒舌 GitHub 评分」名称、Logo 及域名**不在本开源协议授权范围内**,版权保留。你可以基于本代码自部署,但请勿使用本项目的名称/品牌冒充官方或制造混淆。
-
-## 星标历史
-
-<a href="https://www.star-history.com/?repos=hikariming%2Fghfind&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
- </picture>
-</a>


### PR DESCRIPTION
## Summary

Remove the broken Star History embeds from the English and Chinese READMEs. GitHub now restricts the stargazer timeline data required by the third-party chart service; restoring a live public chart would require packaging a repository credential for that service.

This intentionally removes the non-essential chart rather than adding a third-party credential dependency.

## Scope

- `README.md`
- `README.zh.md`

No application code or runtime behavior changes.