### PR TITLE
fix(scan): refresh stale scores and drain durable jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,3 @@ Licensed under **[GNU AGPL-3.0](./LICENSE)**.
 - The scoring core is ported from the open-source Claude skill `github-account-value`, kept as the single source of truth.
 
 > **Trademark:** the "ghfind / 毒舌 GitHub 评分" name, logo, and domain are **not covered** by the open-source license; all rights reserved. You may self-host from this code, but please do not use the project's name/brand to impersonate the official site or cause confusion.
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=hikariming%2Fghfind&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
- </picture>
-</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -234,13 +234,3 @@ TURSO_DATABASE_URL=file:./local.db
 - 评分核心移植自开源 Claude 技能 `github-account-value`,保持单一事实来源。
 
 > **商标声明:** 「ghfind / 毒舌 GitHub 评分」名称、Logo 及域名**不在本开源协议授权范围内**,版权保留。你可以基于本代码自部署,但请勿使用本项目的名称/品牌冒充官方或制造混淆。
-
-## 星标历史
-
-<a href="https://www.star-history.com/?repos=hikariming%2Fghfind&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hikariming/ghfind&type=date&legend=top-left" />
- </picture>
-</a>

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -335,11 +335,12 @@ describe("roast API persistence", () => {
     });
     expect(mocks.startPublicScan).toHaveBeenCalledWith("DemoDev", expect.any(Object));
     expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
     expect(mocks.recordScore).not.toHaveBeenCalled();
     expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
   });
 
-  it("does not advance an existing durable scan when a roast is retried", async () => {
+  it("advances an existing durable scan when a roast is retried", async () => {
     mocks.getPublicScanStatus.mockResolvedValue({
       status: "pending",
       run: { id: "active-run", username: "DemoDev" },
@@ -355,7 +356,7 @@ describe("roast API persistence", () => {
     );
 
     expect(response.status).toBe(409);
-    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
     expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -727,7 +727,7 @@ export async function POST(req: NextRequest) {
     if (resolution.status === "complete") {
       scan = resolution.scan;
     } else {
-      if (resolution.status === "pending" && resolution.shouldDrain) kickPublicScanDrain();
+      if (resolution.status === "pending") kickPublicScanDrain();
       const retryAfterSeconds = resolution.retryAfterSeconds;
       const busy = resolution.status === "queue_full" || resolution.status === "admission_limited";
       return NextResponse.json(

--- a/src/app/api/scan-status/[username]/route.test.ts
+++ b/src/app/api/scan-status/[username]/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getPublicScanStatus: vi.fn(),
   checkPublicScanStatusRateLimit: vi.fn(),
   rateLimitHeaders: vi.fn(),
+  kickPublicScanDrain: vi.fn(),
 }));
 
 vi.mock("@/lib/public-scan", () => ({
@@ -14,6 +15,10 @@ vi.mock("@/lib/public-scan", () => ({
 vi.mock("@/lib/redis", () => ({
   checkPublicScanStatusRateLimit: mocks.checkPublicScanStatusRateLimit,
   rateLimitHeaders: mocks.rateLimitHeaders,
+}));
+
+vi.mock("@/lib/public-scan-dispatcher", () => ({
+  kickPublicScanDrain: mocks.kickPublicScanDrain,
 }));
 
 import { GET } from "./route";
@@ -90,6 +95,7 @@ describe("durable scan status API", () => {
     expect(pending.headers.get("Retry-After")).toBe("7");
     expect(pending.headers.get("Cache-Control")).toContain("s-maxage=5");
     await expect(pending.json()).resolves.toMatchObject({ status: "pending", run_id: "run-id" });
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
 
     mocks.getPublicScanStatus.mockResolvedValueOnce({
       status: "failed",
@@ -99,5 +105,6 @@ describe("durable scan status API", () => {
     const failed = await request("durable-status-case");
     expect(failed.status).toBe(503);
     await expect(failed.json()).resolves.toMatchObject({ error: "durable_scan_failed" });
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/api/scan-status/[username]/route.ts
+++ b/src/app/api/scan-status/[username]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPublicScanStatus } from "@/lib/public-scan";
+import { kickPublicScanDrain } from "@/lib/public-scan-dispatcher";
 import { checkPublicScanStatusRateLimit, rateLimitHeaders } from "@/lib/redis";
 import { normalizeUsername } from "@/lib/username";
 
@@ -48,6 +49,9 @@ export async function GET(
       { status: "complete_public", username: status.run.username, run_id: status.run.id, scan: status.scan },
       { headers: { ...headers, "Cache-Control": COMPLETE_CACHE } },
     );
+  }
+  if (status.status === "pending") {
+    kickPublicScanDrain();
   }
   return NextResponse.json(
     {

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -216,7 +216,7 @@ describe("scan route machine auth", () => {
     });
     expect(mocks.collect).not.toHaveBeenCalled();
     expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
-    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
   });
 
   it("starts one response-side step only when this request created the durable job", async () => {

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -62,6 +62,7 @@ function durableStatusResponse(input: {
   headers: Record<string, string>;
 }) {
   if (input.resolution.status === "pending") {
+    kickPublicScanDrain();
     return NextResponse.json(
       {
         error: "scan_enrichment_pending",
@@ -110,9 +111,6 @@ async function durableResponse(input: {
     input.scan,
     input.admission,
   );
-  if (resolution.status === "pending" && resolution.shouldDrain) {
-    kickPublicScanDrain();
-  }
   if (resolution.status === "complete") {
     return NextResponse.json(
       { ...resolution.scan, cached: true, coverage: "complete_public" },

--- a/src/app/api/score/[username]/route.test.ts
+++ b/src/app/api/score/[username]/route.test.ts
@@ -105,7 +105,7 @@ describe("score durable scan guardrails", () => {
 
     expect(response.status).toBe(202);
     expect(await response.json()).toMatchObject({ run_id: "active-run" });
-    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
     expect(mocks.getCachedScan).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/score/[username]/route.ts
+++ b/src/app/api/score/[username]/route.ts
@@ -75,6 +75,7 @@ function durableResponse(
   headers: Record<string, string>,
 ) {
   if (resolution.status === "pending") {
+    kickPublicScanDrain();
     return json(
       {
         error: "scan_enrichment_pending",
@@ -83,7 +84,7 @@ function durableResponse(
         retry_after: resolution.retryAfterSeconds,
       },
       202,
-      MISS_CACHE,
+      "no-store",
       { ...headers, "Retry-After": String(resolution.retryAfterSeconds) },
     );
   }
@@ -250,9 +251,6 @@ export async function GET(
     if (durable.status === "complete") {
       result = durable.scan;
     } else {
-      if (durable.status === "pending" && durable.shouldDrain) {
-        kickPublicScanDrain();
-      }
       return durableResponse(result.metrics.username, durable, { ...statusHeaders, ...rlHeaders });
     }
   }

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -61,6 +61,17 @@ function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+const PENDING_SCAN_MAX_WAIT_MS = 15 * 60 * 1_000;
+const PENDING_SCAN_MIN_RETRY_SECONDS = 5;
+const PENDING_SCAN_MAX_RETRY_SECONDS = 30;
+
+function pendingRetrySeconds(value: unknown): number {
+  return Math.max(
+    PENDING_SCAN_MIN_RETRY_SECONDS,
+    Math.min(PENDING_SCAN_MAX_RETRY_SECONDS, Number(value) || 10),
+  );
+}
+
 export function Roaster({
   campaign,
   analyticsSource = "home",
@@ -256,19 +267,20 @@ export function Roaster({
         const data = await res.json();
         if (res.status === 202 && data?.error === "scan_enrichment_pending") {
           setError(t("errScanPending"));
-          const retrySeconds = Math.max(10, Math.min(30, Number(data.retry_after) || 10));
+          let retrySeconds = pendingRetrySeconds(data.retry_after);
           const runId = typeof data.run_id === "string" ? data.run_id : "";
           if (!runId) {
             setError(t("errScanFailed"));
             setScanning(false);
             return;
           }
-          const deadline = Date.now() + 2 * 60 * 1_000;
+          const deadline = Date.now() + PENDING_SCAN_MAX_WAIT_MS;
           const controller = new AbortController();
           pollAbortRef.current?.abort();
           pollAbortRef.current = controller;
           const poll = async () => {
             let completed = false;
+            let terminalError = false;
             try {
               while (Date.now() < deadline) {
                 await abortableDelay(retrySeconds * 1_000, controller.signal);
@@ -285,14 +297,29 @@ export function Roaster({
                     presentScan(status.scan as ScanResult);
                     return;
                   }
-                  if (statusRes.status >= 500 || status?.status === "failed") break;
+                  if (statusRes.status === 202 && status?.retry_after) {
+                    retrySeconds = pendingRetrySeconds(status.retry_after);
+                    continue;
+                  }
+                  if (statusRes.status === 429 && status?.retry_after) {
+                    retrySeconds = pendingRetrySeconds(status.retry_after);
+                    continue;
+                  }
+                  if (statusRes.status >= 500 || status?.status === "failed") {
+                    terminalError = true;
+                    setError(t("errScanFailed"));
+                    break;
+                  }
                 } catch {
                   if (controller.signal.aborted) return;
                   break;
                 }
               }
             } finally {
-              if (!controller.signal.aborted && !completed) setScanning(false);
+              if (!controller.signal.aborted && !completed) {
+                if (!terminalError) setError(t("errScanPending"));
+                setScanning(false);
+              }
               if (pollAbortRef.current === controller) pollAbortRef.current = null;
             }
           };

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClient } from "@libsql/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { ROAST_CACHE_VERSION } from "../cache-version";
+import { ROAST_CACHE_VERSION, SCORE_CACHE_VERSION } from "../cache-version";
 import type { ScoreEntry } from "../db";
 import { PUBLIC_SCAN_COLLECTION_VERSION } from "../scan-run-types";
 import type { ScanResult } from "../types";
@@ -122,6 +122,33 @@ describe("score snapshots", () => {
     expect(Number(res.rows[0]?.first_generated_at)).toBeGreaterThanOrEqual(before);
     expect(Number(res.rows[0]?.last_generated_at)).toBeLessThanOrEqual(after);
     expect(String(res.rows[0]?.langs).split(",").sort()).toEqual(["en", "zh"]);
+  });
+});
+
+describe("current score version reads", () => {
+  it("hides stale score rows from public current-score surfaces", async () => {
+    const currentUsername = "current-score-row";
+    const staleUsername = "stale-score-row";
+    await db.recordScore({ ...entry, username: currentUsername, final_score: 72 });
+    await db.recordScore({ ...entry, username: staleUsername, final_score: 99 });
+
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: `UPDATE scores SET score_version = ? WHERE username = ?`,
+      args: [`${SCORE_CACHE_VERSION}-old`, staleUsername],
+    });
+
+    await expect(db.getAccountDetail(currentUsername)).resolves.toMatchObject({
+      username: currentUsername,
+      final_score: 72,
+    });
+    await expect(db.getAccountDetail(staleUsername)).resolves.toBeNull();
+    await expect(db.getScoreBrief(staleUsername)).resolves.toBeNull();
+    await expect(db.searchScoredUsers("stale-score")).resolves.toEqual([]);
+
+    const board = await db.getLeaderboard(500, 0);
+    expect(board.some((row) => row.username === currentUsername)).toBe(true);
+    expect(board.some((row) => row.username === staleUsername)).toBe(false);
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2896,8 +2896,9 @@ export async function getFacetRank(
                 WHERE f.facet_type = 'language'
                   AND f.facet_value = ?
                   AND s.hidden = 0
+                  AND s.score_version = ?
                   AND s.final_score >= ?`,
-          args: [score, facetValue, FACET_MIN_SCORE],
+          args: [score, facetValue, SCORE_CACHE_VERSION, FACET_MIN_SCORE],
         },
         {
           sql: `SELECT s.username, s.final_score
@@ -2906,10 +2907,11 @@ export async function getFacetRank(
                 WHERE f.facet_type = 'language'
                   AND f.facet_value = ?
                   AND s.hidden = 0
+                  AND s.score_version = ?
                   AND s.final_score > ?
                 ORDER BY s.final_score ASC
                 LIMIT 1`,
-          args: [facetValue, score],
+          args: [facetValue, SCORE_CACHE_VERSION, score],
         },
       ],
       "read",
@@ -3013,9 +3015,9 @@ export async function getTrendingLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE s.hidden = 0 AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
             ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}`,
-      args: [recentCutoff, minScore],
+      args: [recentCutoff, SCORE_CACHE_VERSION, minScore],
     });
     return rankTrending(
       res.rows.map((r) => ({
@@ -3051,9 +3053,9 @@ export async function getAllPublicUsernames(minScore = 60): Promise<PublicProfil
     const res = await db.execute({
       sql: `SELECT username, scanned_at
             FROM scores
-            WHERE hidden = 0 AND final_score >= ?
+            WHERE hidden = 0 AND score_version = ? AND final_score >= ?
             ORDER BY final_score DESC`,
-      args: [minScore],
+      args: [SCORE_CACHE_VERSION, minScore],
     });
     return res.rows.map((r) => ({
       username: String(r.username),
@@ -3090,11 +3092,11 @@ export async function getLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE s.hidden = 0 AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
             ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}
             ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [recentCutoff, minScore, limit],
+      args: [recentCutoff, SCORE_CACHE_VERSION, minScore, limit],
     });
     const now = Date.now();
     return res.rows.map((r) => toLeaderboardEntry(r as unknown as LeaderboardRow, now));
@@ -3133,10 +3135,10 @@ export async function getCampaignLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE participant.campaign = ? AND s.hidden = 0
+            WHERE participant.campaign = ? AND s.hidden = 0 AND s.score_version = ?
             ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [Date.now() - TRENDING_LOOKUP_WINDOW_MS, campaign, capped],
+      args: [Date.now() - TRENDING_LOOKUP_WINDOW_MS, campaign, SCORE_CACHE_VERSION, capped],
     });
     const now = Date.now();
     return res.rows.map((row) =>
@@ -3176,11 +3178,11 @@ export async function getHeatLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE s.hidden = 0 AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
             ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}
             ORDER BY ${heatOrder}, s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [recentCutoff, minScore, limit],
+      args: [recentCutoff, SCORE_CACHE_VERSION, minScore, limit],
     });
     const now = Date.now();
     return res.rows.map((r) => toLeaderboardEntry(r as unknown as LeaderboardRow, now));
@@ -3216,12 +3218,13 @@ export async function getProgressLeaderboard(
               GROUP BY username
             ) AS recent ON recent.username = s.username
             WHERE s.hidden = 0
+              AND s.score_version = ?
               AND s.prev_score IS NOT NULL
               AND s.final_score > s.prev_score
               ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}
             ORDER BY (s.final_score - s.prev_score) DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [recentCutoff, limit],
+      args: [recentCutoff, SCORE_CACHE_VERSION, limit],
     });
     const now = Date.now();
     return res.rows.map((r) => {
@@ -3269,11 +3272,17 @@ export async function getFacetCategories(
             JOIN scores AS s ON s.username = f.username
             WHERE f.facet_type = ?
               AND s.hidden = 0
+              AND s.score_version = ?
               AND s.final_score >= ?
             GROUP BY f.facet_value
             ORDER BY count DESC, f.facet_value ASC
             LIMIT ?`,
-      args: [facetType, FACET_MIN_SCORE, Math.max(1, Math.min(500, limit))],
+      args: [
+        facetType,
+        SCORE_CACHE_VERSION,
+        FACET_MIN_SCORE,
+        Math.max(1, Math.min(500, limit)),
+      ],
     });
     return res.rows.map((r) => ({ value: String(r.value), count: Number(r.count) }));
   } catch (e) {
@@ -3312,10 +3321,11 @@ export async function getDevelopersByFacet(
             WHERE f.facet_type = ?
               AND f.facet_value = ?
               AND s.hidden = 0
+              AND s.score_version = ?
               AND s.final_score >= ?
             ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [facetType, facetValue, FACET_MIN_SCORE, capped],
+      args: [facetType, facetValue, SCORE_CACHE_VERSION, FACET_MIN_SCORE, capped],
     });
     const now = Date.now();
     return res.rows.map((r) => toLeaderboardEntry(r as unknown as LeaderboardRow, now));
@@ -3411,9 +3421,9 @@ async function attachTopContributors(
               WHERE repo_key IN (${placeholders})
             ) AS edges
             JOIN scores AS s ON s.username = edges.username
-            WHERE s.hidden = 0 AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
             ORDER BY edges.repo_key ASC, s.final_score DESC, s.username ASC`,
-      args: [...keys, FACET_MIN_SCORE],
+      args: [...keys, SCORE_CACHE_VERSION, FACET_MIN_SCORE],
     });
     for (const row of contributors.rows) {
       const key = String(row.repo_key);
@@ -3488,12 +3498,13 @@ async function queryProjectItems(
             FROM edges
             CROSS JOIN repos AS r ON r.repo_key = edges.repo_key
             CROSS JOIN scores AS s ON s.username = edges.username
-              AND s.hidden = 0 AND s.final_score >= ?
+              AND s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
             ${options.language ? "WHERE lower(r.language) = lower(?)" : ""}
             GROUP BY r.repo_key`,
       args: [
         ...options.repoKeys,
         cutoff,
+        SCORE_CACHE_VERSION,
         FACET_MIN_SCORE,
         ...(options.language ? [options.language] : []),
       ],
@@ -3519,12 +3530,13 @@ async function queryProjectItems(
           FROM repos AS r
           JOIN edges ON edges.repo_key = r.repo_key
           JOIN scores AS s ON s.username = edges.username
-            AND s.hidden = 0 AND s.final_score >= ?
+            AND s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
           LEFT JOIN recent ON recent.username = edges.username
           ${options.language ? "WHERE lower(r.language) = lower(?)" : ""}
           GROUP BY r.repo_key`,
       args: [
         cutoff,
+        SCORE_CACHE_VERSION,
         FACET_MIN_SCORE,
         ...(options.language ? [options.language] : []),
       ],
@@ -3738,15 +3750,16 @@ export async function getRepoOverview(repoKey: string): Promise<RepoOverview | n
     const [ownerRes, contribRes] = await Promise.all([
       db.execute({
         sql: `SELECT username, display_name, avatar_url, final_score, tier
-              FROM scores WHERE username = ? AND hidden = 0`,
-        args: [repo.owner_login],
+              FROM scores
+              WHERE username = ? AND hidden = 0 AND score_version = ?`,
+        args: [repo.owner_login, SCORE_CACHE_VERSION],
       }),
       db.execute({
         sql: `SELECT s.tier AS tier, s.final_score AS final_score
               FROM repo_developers AS rd
               JOIN scores AS s ON s.username = rd.username
-              WHERE rd.repo_key = ? AND s.hidden = 0`,
-        args: [key],
+              WHERE rd.repo_key = ? AND s.hidden = 0 AND s.score_version = ?`,
+        args: [key, SCORE_CACHE_VERSION],
       }),
     ]);
 
@@ -3861,9 +3874,9 @@ export async function getScoreBrief(username: string): Promise<ScoreBrief | null
     const res = await db.execute({
       sql: `SELECT username, display_name, final_score, tier, prev_score, prev_scanned_at
             FROM scores
-            WHERE username = ? AND hidden = 0
+            WHERE username = ? AND hidden = 0 AND score_version = ?
             LIMIT 1`,
-      args: [username.toLowerCase()],
+      args: [username.toLowerCase(), SCORE_CACHE_VERSION],
     });
     const r = res.rows[0];
     if (!r) return null;
@@ -3911,10 +3924,10 @@ export async function searchScoredUsers(
     const res = await db.execute({
       sql: `SELECT username, display_name, avatar_url, final_score, tier
             FROM scores
-            WHERE hidden = 0 AND username LIKE ? ESCAPE '\\'
+            WHERE hidden = 0 AND score_version = ? AND username LIKE ? ESCAPE '\\'
             ORDER BY final_score DESC
             LIMIT ?`,
-      args: [like, limit],
+      args: [SCORE_CACHE_VERSION, like, limit],
     });
     return res.rows.map((r) => ({
       username: String(r.username),
@@ -4146,9 +4159,9 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
                    tags, roast_line, sub_scores, roast, roast_en, score_version, scanned_at,
                    prev_score, prev_scanned_at
             FROM scores
-            WHERE username = ? AND hidden = 0
+            WHERE username = ? AND hidden = 0 AND score_version = ?
             LIMIT 1`,
-      args: [username.toLowerCase()],
+      args: [username.toLowerCase(), SCORE_CACHE_VERSION],
     });
     const r = res.rows[0];
     if (!r) return null;
@@ -4186,8 +4199,11 @@ export async function getScoreScannedAt(username: string): Promise<number | null
   try {
     await ensureSchema(db);
     const res = await db.execute({
-      sql: `SELECT scanned_at FROM scores WHERE username = ? AND hidden = 0 LIMIT 1`,
-      args: [username.toLowerCase()],
+      sql: `SELECT scanned_at
+            FROM scores
+            WHERE username = ? AND hidden = 0 AND score_version = ?
+            LIMIT 1`,
+      args: [username.toLowerCase(), SCORE_CACHE_VERSION],
     });
     const r = res.rows[0];
     return r ? Number(r.scanned_at) : null;
@@ -4270,11 +4286,13 @@ export async function getSimilarAccounts(
             FROM scores AS s
             LEFT JOIN account_stats AS stats ON stats.username = s.username
             WHERE s.hidden = 0
+              AND s.score_version = ?
               AND s.username != ?
               AND s.final_score BETWEEN ? AND ?
             ORDER BY s.final_score DESC
             LIMIT ?`,
       args: [
+        SCORE_CACHE_VERSION,
         username.toLowerCase(),
         finalScore - SIMILAR_SCORE_BAND,
         finalScore + SIMILAR_SCORE_BAND,
@@ -4771,11 +4789,14 @@ export async function listFollowedAccounts(
                    s.display_name, s.avatar_url, s.final_score, s.tier,
                    s.prev_score, s.prev_scanned_at
             FROM follows f
-            LEFT JOIN scores s ON s.username = f.target_username AND s.hidden = 0
+            LEFT JOIN scores s
+              ON s.username = f.target_username
+              AND s.hidden = 0
+              AND s.score_version = ?
             WHERE f.follower_github_id = ?
             ORDER BY f.created_at DESC
             LIMIT ?`,
-      args: [followerGithubId, MAX_FOLLOWS],
+      args: [SCORE_CACHE_VERSION, followerGithubId, MAX_FOLLOWS],
     });
     const scored = res.rows.filter((r) => r.final_score !== null).map((r) => String(r.username));
     const baselines = await getWeeklyBaselines(scored);

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -681,7 +681,7 @@ const LEADERBOARD_WINDOWS: LeaderboardWindow[] = ["24h", "7d", "30d", "all"];
 // One Redis entry per (view, window) pair — 4 × 4 = 16 keys, each a slow-moving
 // 500-row payload. A hit skips the triple-LEFT-JOIN DB read entirely.
 const leaderboardKey = (view: LeaderboardCacheView, window: LeaderboardWindow) =>
-  `leaderboard:${view}:${window}`;
+  `leaderboard:${SCORE_CACHE_VERSION}:${view}:${window}`;
 const LEADERBOARD_TTL_SECONDS = 300; // 5 min — board moves slowly; fewer DB reads
 
 export async function getCachedLeaderboard(


### PR DESCRIPTION
## Summary

- filter public current-score reads by `SCORE_CACHE_VERSION` so stale `scores` rows no longer drive profile pages, badges, cards, boards, autocomplete, facets, or project/follow surfaces
- make pending durable public-history scans actively kick one leased worker step from scan, score, scan-status, and roast paths instead of relying only on cron after the first request
- extend the home scanner's pending poll window and honor `retry_after` while keeping terminal failures explicit

## Why

Production showed two separate symptoms after the latest deploy:

- `/api/score/lofisu` returned the current lower score, but `/u/lofisu` still rendered the old persisted score from `scores`.
- high-history accounts such as `asperformias` could stay in `scan_enrichment_pending` because existing durable jobs were passive and only Vercel Cron could advance them.

## Verification

- `pnpm -s vitest run src/lib/__tests__/db.test.ts src/app/api/scan/route.test.ts 'src/app/api/score/[username]/route.test.ts' 'src/app/api/scan-status/[username]/route.test.ts' src/app/api/roast/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
