### PR TITLE
fix(db): keep legacy score rows visible

### DIFF
--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClient } from "@libsql/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { ROAST_CACHE_VERSION, SCORE_CACHE_VERSION } from "../cache-version";
+import { ROAST_CACHE_VERSION } from "../cache-version";
 import type { ScoreEntry } from "../db";
 import { PUBLIC_SCAN_COLLECTION_VERSION } from "../scan-run-types";
 import type { ScanResult } from "../types";
@@ -125,30 +125,27 @@ describe("score snapshots", () => {
   });
 });
 
-describe("current score version reads", () => {
-  it("hides stale score rows from public current-score surfaces", async () => {
-    const currentUsername = "current-score-row";
-    const staleUsername = "stale-score-row";
-    await db.recordScore({ ...entry, username: currentUsername, final_score: 72 });
-    await db.recordScore({ ...entry, username: staleUsername, final_score: 99 });
+describe("legacy score row compatibility", () => {
+  it("keeps existing scored profiles visible after score-version bumps", async () => {
+    const username = "legacy-visible-row";
+    await db.recordScore({ ...entry, username, final_score: 73 });
 
     const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
     await client.execute({
       sql: `UPDATE scores SET score_version = ? WHERE username = ?`,
-      args: [`${SCORE_CACHE_VERSION}-old`, staleUsername],
+      args: ["legacy-score-version", username],
     });
 
-    await expect(db.getAccountDetail(currentUsername)).resolves.toMatchObject({
-      username: currentUsername,
-      final_score: 72,
+    await expect(db.getAccountDetail(username)).resolves.toMatchObject({
+      username,
+      final_score: 73,
     });
-    await expect(db.getAccountDetail(staleUsername)).resolves.toBeNull();
-    await expect(db.getScoreBrief(staleUsername)).resolves.toBeNull();
-    await expect(db.searchScoredUsers("stale-score")).resolves.toEqual([]);
-
+    await expect(db.getScoreBrief(username)).resolves.toMatchObject({ username });
+    await expect(db.searchScoredUsers("legacy-visible")).resolves.toEqual([
+      expect.objectContaining({ username }),
+    ]);
     const board = await db.getLeaderboard(500, 0);
-    expect(board.some((row) => row.username === currentUsername)).toBe(true);
-    expect(board.some((row) => row.username === staleUsername)).toBe(false);
+    expect(board.some((row) => row.username === username)).toBe(true);
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2896,9 +2896,8 @@ export async function getFacetRank(
                 WHERE f.facet_type = 'language'
                   AND f.facet_value = ?
                   AND s.hidden = 0
-                  AND s.score_version = ?
                   AND s.final_score >= ?`,
-          args: [score, facetValue, SCORE_CACHE_VERSION, FACET_MIN_SCORE],
+          args: [score, facetValue, FACET_MIN_SCORE],
         },
         {
           sql: `SELECT s.username, s.final_score
@@ -2907,11 +2906,10 @@ export async function getFacetRank(
                 WHERE f.facet_type = 'language'
                   AND f.facet_value = ?
                   AND s.hidden = 0
-                  AND s.score_version = ?
                   AND s.final_score > ?
                 ORDER BY s.final_score ASC
                 LIMIT 1`,
-          args: [facetValue, SCORE_CACHE_VERSION, score],
+          args: [facetValue, score],
         },
       ],
       "read",
@@ -3015,9 +3013,9 @@ export async function getTrendingLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.final_score >= ?
             ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}`,
-      args: [recentCutoff, SCORE_CACHE_VERSION, minScore],
+      args: [recentCutoff, minScore],
     });
     return rankTrending(
       res.rows.map((r) => ({
@@ -3053,9 +3051,9 @@ export async function getAllPublicUsernames(minScore = 60): Promise<PublicProfil
     const res = await db.execute({
       sql: `SELECT username, scanned_at
             FROM scores
-            WHERE hidden = 0 AND score_version = ? AND final_score >= ?
+            WHERE hidden = 0 AND final_score >= ?
             ORDER BY final_score DESC`,
-      args: [SCORE_CACHE_VERSION, minScore],
+      args: [minScore],
     });
     return res.rows.map((r) => ({
       username: String(r.username),
@@ -3092,11 +3090,11 @@ export async function getLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.final_score >= ?
             ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}
             ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [recentCutoff, SCORE_CACHE_VERSION, minScore, limit],
+      args: [recentCutoff, minScore, limit],
     });
     const now = Date.now();
     return res.rows.map((r) => toLeaderboardEntry(r as unknown as LeaderboardRow, now));
@@ -3135,10 +3133,10 @@ export async function getCampaignLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE participant.campaign = ? AND s.hidden = 0 AND s.score_version = ?
+            WHERE participant.campaign = ? AND s.hidden = 0
             ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [Date.now() - TRENDING_LOOKUP_WINDOW_MS, campaign, SCORE_CACHE_VERSION, capped],
+      args: [Date.now() - TRENDING_LOOKUP_WINDOW_MS, campaign, capped],
     });
     const now = Date.now();
     return res.rows.map((row) =>
@@ -3178,11 +3176,11 @@ export async function getHeatLeaderboard(
               WHERE last_counted_at >= ?
               GROUP BY username
             ) AS recent ON recent.username = s.username
-            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.final_score >= ?
             ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}
             ORDER BY ${heatOrder}, s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [recentCutoff, SCORE_CACHE_VERSION, minScore, limit],
+      args: [recentCutoff, minScore, limit],
     });
     const now = Date.now();
     return res.rows.map((r) => toLeaderboardEntry(r as unknown as LeaderboardRow, now));
@@ -3218,13 +3216,12 @@ export async function getProgressLeaderboard(
               GROUP BY username
             ) AS recent ON recent.username = s.username
             WHERE s.hidden = 0
-              AND s.score_version = ?
               AND s.prev_score IS NOT NULL
               AND s.final_score > s.prev_score
               ${activeOnly ? "AND recent.recent_lookup_count > 0" : ""}
             ORDER BY (s.final_score - s.prev_score) DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [recentCutoff, SCORE_CACHE_VERSION, limit],
+      args: [recentCutoff, limit],
     });
     const now = Date.now();
     return res.rows.map((r) => {
@@ -3272,17 +3269,11 @@ export async function getFacetCategories(
             JOIN scores AS s ON s.username = f.username
             WHERE f.facet_type = ?
               AND s.hidden = 0
-              AND s.score_version = ?
               AND s.final_score >= ?
             GROUP BY f.facet_value
             ORDER BY count DESC, f.facet_value ASC
             LIMIT ?`,
-      args: [
-        facetType,
-        SCORE_CACHE_VERSION,
-        FACET_MIN_SCORE,
-        Math.max(1, Math.min(500, limit)),
-      ],
+      args: [facetType, FACET_MIN_SCORE, Math.max(1, Math.min(500, limit))],
     });
     return res.rows.map((r) => ({ value: String(r.value), count: Number(r.count) }));
   } catch (e) {
@@ -3321,11 +3312,10 @@ export async function getDevelopersByFacet(
             WHERE f.facet_type = ?
               AND f.facet_value = ?
               AND s.hidden = 0
-              AND s.score_version = ?
               AND s.final_score >= ?
             ORDER BY s.final_score DESC, s.scanned_at DESC
             LIMIT ?`,
-      args: [facetType, facetValue, SCORE_CACHE_VERSION, FACET_MIN_SCORE, capped],
+      args: [facetType, facetValue, FACET_MIN_SCORE, capped],
     });
     const now = Date.now();
     return res.rows.map((r) => toLeaderboardEntry(r as unknown as LeaderboardRow, now));
@@ -3421,9 +3411,9 @@ async function attachTopContributors(
               WHERE repo_key IN (${placeholders})
             ) AS edges
             JOIN scores AS s ON s.username = edges.username
-            WHERE s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
+            WHERE s.hidden = 0 AND s.final_score >= ?
             ORDER BY edges.repo_key ASC, s.final_score DESC, s.username ASC`,
-      args: [...keys, SCORE_CACHE_VERSION, FACET_MIN_SCORE],
+      args: [...keys, FACET_MIN_SCORE],
     });
     for (const row of contributors.rows) {
       const key = String(row.repo_key);
@@ -3498,13 +3488,12 @@ async function queryProjectItems(
             FROM edges
             CROSS JOIN repos AS r ON r.repo_key = edges.repo_key
             CROSS JOIN scores AS s ON s.username = edges.username
-              AND s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
+              AND s.hidden = 0 AND s.final_score >= ?
             ${options.language ? "WHERE lower(r.language) = lower(?)" : ""}
             GROUP BY r.repo_key`,
       args: [
         ...options.repoKeys,
         cutoff,
-        SCORE_CACHE_VERSION,
         FACET_MIN_SCORE,
         ...(options.language ? [options.language] : []),
       ],
@@ -3530,13 +3519,12 @@ async function queryProjectItems(
           FROM repos AS r
           JOIN edges ON edges.repo_key = r.repo_key
           JOIN scores AS s ON s.username = edges.username
-            AND s.hidden = 0 AND s.score_version = ? AND s.final_score >= ?
+            AND s.hidden = 0 AND s.final_score >= ?
           LEFT JOIN recent ON recent.username = edges.username
           ${options.language ? "WHERE lower(r.language) = lower(?)" : ""}
           GROUP BY r.repo_key`,
       args: [
         cutoff,
-        SCORE_CACHE_VERSION,
         FACET_MIN_SCORE,
         ...(options.language ? [options.language] : []),
       ],
@@ -3750,16 +3738,15 @@ export async function getRepoOverview(repoKey: string): Promise<RepoOverview | n
     const [ownerRes, contribRes] = await Promise.all([
       db.execute({
         sql: `SELECT username, display_name, avatar_url, final_score, tier
-              FROM scores
-              WHERE username = ? AND hidden = 0 AND score_version = ?`,
-        args: [repo.owner_login, SCORE_CACHE_VERSION],
+              FROM scores WHERE username = ? AND hidden = 0`,
+        args: [repo.owner_login],
       }),
       db.execute({
         sql: `SELECT s.tier AS tier, s.final_score AS final_score
               FROM repo_developers AS rd
               JOIN scores AS s ON s.username = rd.username
-              WHERE rd.repo_key = ? AND s.hidden = 0 AND s.score_version = ?`,
-        args: [key, SCORE_CACHE_VERSION],
+              WHERE rd.repo_key = ? AND s.hidden = 0`,
+        args: [key],
       }),
     ]);
 
@@ -3874,9 +3861,9 @@ export async function getScoreBrief(username: string): Promise<ScoreBrief | null
     const res = await db.execute({
       sql: `SELECT username, display_name, final_score, tier, prev_score, prev_scanned_at
             FROM scores
-            WHERE username = ? AND hidden = 0 AND score_version = ?
+            WHERE username = ? AND hidden = 0
             LIMIT 1`,
-      args: [username.toLowerCase(), SCORE_CACHE_VERSION],
+      args: [username.toLowerCase()],
     });
     const r = res.rows[0];
     if (!r) return null;
@@ -3924,10 +3911,10 @@ export async function searchScoredUsers(
     const res = await db.execute({
       sql: `SELECT username, display_name, avatar_url, final_score, tier
             FROM scores
-            WHERE hidden = 0 AND score_version = ? AND username LIKE ? ESCAPE '\\'
+            WHERE hidden = 0 AND username LIKE ? ESCAPE '\\'
             ORDER BY final_score DESC
             LIMIT ?`,
-      args: [SCORE_CACHE_VERSION, like, limit],
+      args: [like, limit],
     });
     return res.rows.map((r) => ({
       username: String(r.username),
@@ -4159,9 +4146,9 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
                    tags, roast_line, sub_scores, roast, roast_en, score_version, scanned_at,
                    prev_score, prev_scanned_at
             FROM scores
-            WHERE username = ? AND hidden = 0 AND score_version = ?
+            WHERE username = ? AND hidden = 0
             LIMIT 1`,
-      args: [username.toLowerCase(), SCORE_CACHE_VERSION],
+      args: [username.toLowerCase()],
     });
     const r = res.rows[0];
     if (!r) return null;
@@ -4199,11 +4186,8 @@ export async function getScoreScannedAt(username: string): Promise<number | null
   try {
     await ensureSchema(db);
     const res = await db.execute({
-      sql: `SELECT scanned_at
-            FROM scores
-            WHERE username = ? AND hidden = 0 AND score_version = ?
-            LIMIT 1`,
-      args: [username.toLowerCase(), SCORE_CACHE_VERSION],
+      sql: `SELECT scanned_at FROM scores WHERE username = ? AND hidden = 0 LIMIT 1`,
+      args: [username.toLowerCase()],
     });
     const r = res.rows[0];
     return r ? Number(r.scanned_at) : null;
@@ -4286,13 +4270,11 @@ export async function getSimilarAccounts(
             FROM scores AS s
             LEFT JOIN account_stats AS stats ON stats.username = s.username
             WHERE s.hidden = 0
-              AND s.score_version = ?
               AND s.username != ?
               AND s.final_score BETWEEN ? AND ?
             ORDER BY s.final_score DESC
             LIMIT ?`,
       args: [
-        SCORE_CACHE_VERSION,
         username.toLowerCase(),
         finalScore - SIMILAR_SCORE_BAND,
         finalScore + SIMILAR_SCORE_BAND,
@@ -4789,14 +4771,11 @@ export async function listFollowedAccounts(
                    s.display_name, s.avatar_url, s.final_score, s.tier,
                    s.prev_score, s.prev_scanned_at
             FROM follows f
-            LEFT JOIN scores s
-              ON s.username = f.target_username
-              AND s.hidden = 0
-              AND s.score_version = ?
+            LEFT JOIN scores s ON s.username = f.target_username AND s.hidden = 0
             WHERE f.follower_github_id = ?
             ORDER BY f.created_at DESC
             LIMIT ?`,
-      args: [SCORE_CACHE_VERSION, followerGithubId, MAX_FOLLOWS],
+      args: [followerGithubId, MAX_FOLLOWS],
     });
     const scored = res.rows.filter((r) => r.final_score !== null).map((r) => String(r.username));
     const baselines = await getWeeklyBaselines(scored);

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -741,7 +741,7 @@ const LEADERBOARD_WINDOWS: LeaderboardWindow[] = ["24h", "7d", "30d", "all"];
 // One Redis entry per (view, window) pair — 4 × 4 = 16 keys, each a slow-moving
 // 500-row payload. A hit skips the triple-LEFT-JOIN DB read entirely.
 const leaderboardKey = (view: LeaderboardCacheView, window: LeaderboardWindow) =>
-  `leaderboard:${SCORE_CACHE_VERSION}:${view}:${window}`;
+  `leaderboard:${view}:${window}`;
 const LEADERBOARD_TTL_SECONDS = 300; // 5 min — board moves slowly; fewer DB reads
 
 export async function getCachedLeaderboard(


### PR DESCRIPTION
## Summary

- remove the read-side `score_version = SCORE_CACHE_VERSION` filters introduced in #114 from profile/detail, boards, facets, project, autocomplete, badge, similar, and follow reads
- restore the stable leaderboard Redis key so version bumps do not force a board cache namespace reset
- replace the bad regression test with one that proves legacy `scores.score_version` rows still power public profile/badge/search/leaderboard surfaces

## Why

#114 made current-score reads require the latest `SCORE_CACHE_VERSION`. Existing production `scores` rows were written under older versions, so `getAccountDetail()` returned null and profile pages fell through to `notFound()`.

This keeps old scored profiles visible while newer rescans can overwrite the single `scores` row normally. The durable pending-drain fixes from #114 are intentionally left intact.

## Verification

- `pnpm -s vitest run src/lib/__tests__/db.test.ts src/app/api/scan/route.test.ts 'src/app/api/score/[username]/route.test.ts' 'src/app/api/scan-status/[username]/route.test.ts' src/app/api/roast/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
