### PR TITLE
test(release): add legacy-read deployment guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify release
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CI: "true"
+      NEXT_TELEMETRY_DISABLED: "1"
+      GITHUB_TOKEN: ""
+      GH_TOKEN: ""
+      TURSO_DATABASE_URL: ""
+      TURSO_AUTH_TOKEN: ""
+      UPSTASH_REDIS_REST_URL: ""
+      UPSTASH_REDIS_REST_TOKEN: ""
+      CRON_SECRET: ""
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release versions
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            pnpm versions:check --base-ref "origin/$BASE_REF"
+          else
+            pnpm versions:check
+          fi
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Production build
+        run: pnpm build

--- a/config/release-versions.json
+++ b/config/release-versions.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "previousRelease": {
+    "score": "v8",
+    "roast": "v8",
+    "collection": "v3"
+  },
+  "targetRelease": {
+    "score": "v9",
+    "roast": "v9",
+    "collection": "v4"
+  },
+  "runtimeEnforcement": {
+    "state": "source_changes_only",
+    "trackingIssue": 126
+  },
+  "compatibility": {
+    "publicScoreReadOrder": ["v9", "v8"],
+    "roastReplay": [
+      {
+        "score": "v9",
+        "roast": "v9"
+      }
+    ],
+    "collectionReadOrder": ["v4", "v3"]
+  },
+  "changeControl": {
+    "maxComponentsPerPullRequest": 1,
+    "approvedMultiComponentIssue": null
+  },
+  "aliases": [],
+  "releasePlan": "docs/releases/v9-v9-v4-rollout.md"
+}

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -1,0 +1,29 @@
+# Deployment smoke
+
+`scripts/smoke-deployment.mts` is read-only. It never starts a scan or roast and
+does not print canary handles, run IDs, response bodies, or credentials.
+
+Configure these values privately in the deployment system:
+
+```text
+SMOKE_BASE_URL
+SMOKE_CANARY_HANDLE
+SMOKE_FACET_TYPE
+SMOKE_FACET_VALUE
+SMOKE_COMPLETE_HANDLE
+SMOKE_COMPLETE_RUN_ID
+```
+
+An active pending-run check is optional because a pending run eventually becomes
+complete. To require it for a controlled promotion window, also configure:
+
+```text
+SMOKE_PENDING_HANDLE
+SMOKE_PENDING_RUN_ID
+SMOKE_REQUIRE_PENDING=1
+```
+
+Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
+API, autocomplete, score leaderboard, facet bucket, complete scan status,
+optional pending scan status, and canonical origin. Missing required values,
+`localhost` canonical output, unexpected status, or malformed JSON fails the run.

--- a/docs/releases/v9-v9-v4-rollout.md
+++ b/docs/releases/v9-v9-v4-rollout.md
@@ -1,0 +1,55 @@
+# v9 / v9 / v4 release plan
+
+## Formal lineage
+
+| Component | Previous release | Target release | Read behavior during rollout |
+| --- | --- | --- | --- |
+| Deterministic score | v8 | v9 | Prefer v9; keep the last complete v8 score visible |
+| Roast report | v8 | v9 | Replay only when both score and roast are v9 |
+| Public collection | v3 | v4 | Prefer complete v4; use complete v3 only as an explicit stale fallback |
+
+Unpublished local version values are not release versions. They are not aliases,
+replay inputs, backfill sources, or migration targets.
+
+## Rollout sequence
+
+```mermaid
+flowchart LR
+  A["#121: CI and legacy-read guardrails"] --> B["#126: normalize runtime to v9/v9/v4"]
+  B --> C["#120: bounded version-aware queue"]
+  C --> D["#118: persist deterministic v9 score"]
+  D --> E["#119: v4 atomic switch with v3 stale fallback"]
+  E --> F["Owner: protected staging smoke and promotion"]
+```
+
+The first guardrail phase uses `source_changes_only`: CI permits the untouched
+pre-normalization source, but any pull request that edits a version constant must
+set all edited runtime values directly to the formal target. #126 changes the
+manifest to `canonical`, after which every CI run requires exact runtime equality.
+
+## Capacity and write policy
+
+- A deploy must not enqueue work merely because a stored version is old.
+- Profile, score, search, leaderboard, facet, sitemap, project, similar, and
+  following reads continue serving the last complete stored score.
+- Only an explicit scan or roast flow may request refresh work.
+- New collection work is bounded and version-aware before v4 is enabled.
+- No global rescore, recollection, or roast regeneration runs during promotion.
+
+## Rollback
+
+1. Stop new scan admission with the queue kill switch.
+2. Revert the isolated version-enablement pull request and its manifest state.
+3. Keep public reads on the last complete v8 score and complete v3 collection.
+4. Do not rewrite, alias, or replay unpublished local-version rows.
+5. Promote only after profile, score API, search, leaderboard, facet, scan status,
+   and canonical-origin smoke checks pass against staging.
+
+The scoring formula and the removal of model-authored score deltas are outside
+this release-control change and must remain covered by the existing test suite.
+
+## Owner controls
+
+The owner must use isolated staging Turso, Redis, GitHub quota, and Cron secrets.
+After this workflow lands, configure `Verify release` as a required check on
+`dev` and `main`, and make the private deployment smoke a promotion gate.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "start:prod": "next start",
     "build/start": "next build && next start",
     "lint": "eslint",
+    "smoke:deployment": "tsx scripts/smoke-deployment.mts",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.release.json",
+    "versions:check": "tsx scripts/check-release-versions.mts"
   },
   "dependencies": {
     "@libsql/client": "^0.17.4",
@@ -61,5 +63,6 @@
   },
   "workspaces": [
     "."
-  ]
+  ],
+  "packageManager": "pnpm@9.12.1"
 }

--- a/scripts/check-release-versions.mts
+++ b/scripts/check-release-versions.mts
@@ -1,0 +1,148 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import ts from "typescript";
+import {
+  RELEASE_VERSION_MANIFEST,
+  RUNTIME_RELEASE_VERSIONS,
+  changedVersionComponents,
+  releaseVersionErrors,
+  type ReleaseVersionManifest,
+} from "../src/lib/release-versions";
+
+const MANIFEST_PATH = "config/release-versions.json";
+const VERSION_SOURCES = {
+  score: { path: "src/lib/cache-version.ts", name: "SCORE_CACHE_VERSION" },
+  roast: { path: "src/lib/cache-version.ts", name: "ROAST_CACHE_VERSION" },
+  collection: {
+    path: "src/lib/scan-run-types.ts",
+    name: "PUBLIC_SCAN_COLLECTION_VERSION",
+  },
+} as const;
+
+function argument(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] ?? null : null;
+}
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function baseManifest(ref: string): ReleaseVersionManifest | null {
+  try {
+    return JSON.parse(git("show", `${ref}:${MANIFEST_PATH}`)) as ReleaseVersionManifest;
+  } catch {
+    return null;
+  }
+}
+
+function exportedStringConstant(source: string, fileName: string, name: string): string {
+  const file = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+  for (const statement of file.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    const exported = statement.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+    );
+    if (!exported) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === name &&
+        declaration.initializer &&
+        ts.isStringLiteral(declaration.initializer)
+      ) {
+        return declaration.initializer.text;
+      }
+    }
+  }
+  throw new Error(`${name} must be an exported string constant in ${fileName}`);
+}
+
+function versionsAt(ref?: string) {
+  const read = (source: (typeof VERSION_SOURCES)[keyof typeof VERSION_SOURCES]) => {
+    const text = ref
+      ? git("show", `${ref}:${source.path}`)
+      : readFileSync(resolve(source.path), "utf8");
+    return exportedStringConstant(text, source.path, source.name);
+  };
+  return {
+    score: read(VERSION_SOURCES.score),
+    roast: read(VERSION_SOURCES.roast),
+    collection: read(VERSION_SOURCES.collection),
+  };
+}
+
+function versionChangeErrors(baseRef: string): string[] {
+  const base = baseManifest(baseRef);
+  if (!base) return [];
+
+  const errors: string[] = [];
+  const targetChanges = changedVersionComponents(
+    base.targetRelease,
+    RELEASE_VERSION_MANIFEST.targetRelease,
+  );
+  const runtimeChanges = changedVersionComponents(versionsAt(baseRef), versionsAt());
+  const approvedIssue = RELEASE_VERSION_MANIFEST.changeControl.approvedMultiComponentIssue;
+  const hasApproval = Number.isInteger(approvedIssue) && Number(approvedIssue) > 0;
+  const isTrackedNormalization =
+    base.runtimeEnforcement.state === "source_changes_only" &&
+    RELEASE_VERSION_MANIFEST.runtimeEnforcement.state === "canonical" &&
+    base.runtimeEnforcement.trackingIssue === 126 &&
+    RELEASE_VERSION_MANIFEST.runtimeEnforcement.trackingIssue === null &&
+    runtimeChanges.length > 0;
+
+  if (runtimeChanges.length > 0 && !sameTarget(versionsAt(), RELEASE_VERSION_MANIFEST.targetRelease)) {
+    errors.push("changed runtime constants must exactly match the formal target release");
+  }
+
+  if (targetChanges.length > 1 && !hasApproval) {
+    errors.push(
+      `formal release changes ${targetChanges.join(", ")}; multi-component bumps require an approved issue`,
+    );
+  }
+  if (targetChanges.length > 0 && runtimeChanges.length === 0) {
+    errors.push("a formal target change must include its isolated runtime version change");
+  }
+  if (runtimeChanges.length > 1 && !hasApproval && !isTrackedNormalization) {
+    errors.push(
+      `runtime changes ${runtimeChanges.join(", ")}; multi-component changes require an approved issue`,
+    );
+  }
+
+  if (targetChanges.length > 0 || runtimeChanges.length > 0) {
+    const changedFiles = git("diff", "--name-only", `${baseRef}...HEAD`).split("\n");
+    if (!changedFiles.includes(RELEASE_VERSION_MANIFEST.releasePlan)) {
+      errors.push("a version change must update its checked-in release and rollback plan");
+    }
+  }
+  return errors;
+}
+
+function sameTarget(
+  actual: typeof RUNTIME_RELEASE_VERSIONS,
+  target: typeof RELEASE_VERSION_MANIFEST.targetRelease,
+): boolean {
+  return changedVersionComponents(actual, target).length === 0;
+}
+
+const errors = releaseVersionErrors();
+const releasePlan = resolve(RELEASE_VERSION_MANIFEST.releasePlan);
+if (!existsSync(releasePlan) || readFileSync(releasePlan, "utf8").trim().length === 0) {
+  errors.push(`release plan is missing: ${RELEASE_VERSION_MANIFEST.releasePlan}`);
+}
+
+const baseRef = argument("--base-ref");
+if (baseRef) errors.push(...versionChangeErrors(baseRef));
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`release-version check failed: ${error}`);
+  process.exitCode = 1;
+} else {
+  console.log(
+    `formal release target verified (${RELEASE_VERSION_MANIFEST.targetRelease.score}/${RELEASE_VERSION_MANIFEST.targetRelease.roast}/${RELEASE_VERSION_MANIFEST.targetRelease.collection}, ${RELEASE_VERSION_MANIFEST.runtimeEnforcement.state})`,
+  );
+}

--- a/scripts/smoke-deployment.mts
+++ b/scripts/smoke-deployment.mts
@@ -1,0 +1,178 @@
+const REQUEST_TIMEOUT_MS = 15_000;
+
+type Check = {
+  label: string;
+  path: string;
+  status: number;
+  validate?: (body: unknown, response: Response) => void;
+};
+
+function usage(): void {
+  console.log("Run with private SMOKE_* environment variables; see docs/releases/deployment-smoke.md");
+}
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function optionalPair(left: string, right: string): [string, string] | null {
+  const a = process.env[left]?.trim();
+  const b = process.env[right]?.trim();
+  if (Boolean(a) !== Boolean(b)) throw new Error(`${left} and ${right} must be configured together`);
+  return a && b ? [a, b] : null;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("response must be a JSON object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function handle(value: string, variable: string): string {
+  if (!/^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(value)) {
+    throw new Error(`${variable} is not a valid handle`);
+  }
+  return value;
+}
+
+function baseUrl(): URL {
+  const url = new URL(required("SMOKE_BASE_URL"));
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("SMOKE_BASE_URL must contain only an origin");
+  }
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+    if (process.env.SMOKE_ALLOW_HTTP !== "1") {
+      throw new Error("localhost smoke requires SMOKE_ALLOW_HTTP=1");
+    }
+  } else if (url.protocol !== "https:") {
+    throw new Error("remote deployment smoke requires HTTPS");
+  }
+  url.pathname = "/";
+  return url;
+}
+
+async function runCheck(base: URL, check: Check): Promise<void> {
+  const response = await fetch(new URL(check.path, base), {
+    redirect: "follow",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: { Accept: "application/json, text/html;q=0.9" },
+  });
+  if (response.status !== check.status) {
+    throw new Error(`${check.label} returned ${response.status}; expected ${check.status}`);
+  }
+  if (response.url.includes("localhost") || response.url.includes("127.0.0.1")) {
+    throw new Error(`${check.label} resolved to a local origin`);
+  }
+  if (check.validate) {
+    const body = await response.json();
+    check.validate(body, response);
+  }
+  console.log(`PASS ${check.label}`);
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes("--help")) {
+    usage();
+    return;
+  }
+
+  const base = baseUrl();
+  const canary = handle(required("SMOKE_CANARY_HANDLE"), "SMOKE_CANARY_HANDLE");
+  const facetType = required("SMOKE_FACET_TYPE");
+  if (!new Set(["language", "org", "repo"]).has(facetType)) {
+    throw new Error("SMOKE_FACET_TYPE must be language, org, or repo");
+  }
+  const facetValue = required("SMOKE_FACET_VALUE");
+  const completeHandle = handle(
+    required("SMOKE_COMPLETE_HANDLE"),
+    "SMOKE_COMPLETE_HANDLE",
+  );
+  const completeRun = required("SMOKE_COMPLETE_RUN_ID");
+  const pending = optionalPair("SMOKE_PENDING_HANDLE", "SMOKE_PENDING_RUN_ID");
+  if (!pending && process.env.SMOKE_REQUIRE_PENDING === "1") {
+    throw new Error("pending scan canary is required for this promotion");
+  }
+
+  const expectedOrigin = base.origin;
+  const checks: Check[] = [
+    {
+      label: "profile",
+      path: `/u/${encodeURIComponent(canary)}`,
+      status: 200,
+    },
+    {
+      label: "score API and canonical origin",
+      path: `/api/score/${encodeURIComponent(canary)}`,
+      status: 200,
+      validate(body) {
+        const payload = record(body);
+        if (String(payload.username).toLowerCase() !== canary.toLowerCase()) {
+          throw new Error("score API returned the wrong canary");
+        }
+        const profile = new URL(String(payload.profile));
+        if (profile.origin !== expectedOrigin) {
+          throw new Error("score API canonical profile origin does not match deployment origin");
+        }
+      },
+    },
+    {
+      label: "autocomplete",
+      path: `/api/search-users?q=${encodeURIComponent(canary.slice(0, 6))}`,
+      status: 200,
+      validate(body) {
+        if (!Array.isArray(record(body).users)) throw new Error("autocomplete users are missing");
+      },
+    },
+    {
+      label: "score leaderboard",
+      path: "/api/leaderboard?view=score&limit=1",
+      status: 200,
+      validate(body) {
+        if (!Array.isArray(record(body).entries)) throw new Error("leaderboard entries are missing");
+      },
+    },
+    {
+      label: "facet bucket",
+      path: `/api/developers?type=${encodeURIComponent(facetType)}&value=${encodeURIComponent(facetValue)}&limit=1`,
+      status: 200,
+      validate(body) {
+        if (!Array.isArray(record(body).entries)) throw new Error("facet entries are missing");
+      },
+    },
+    {
+      label: "complete scan status",
+      path: `/api/scan-status/${encodeURIComponent(completeHandle)}?run_id=${encodeURIComponent(completeRun)}`,
+      status: 200,
+      validate(body) {
+        if (record(body).status !== "complete_public") {
+          throw new Error("complete scan canary is not complete_public");
+        }
+      },
+    },
+  ];
+
+  if (pending) {
+    const [pendingHandle, pendingRun] = pending;
+    checks.push({
+      label: "pending scan status",
+      path: `/api/scan-status/${encodeURIComponent(handle(pendingHandle, "SMOKE_PENDING_HANDLE"))}?run_id=${encodeURIComponent(pendingRun)}`,
+      status: 202,
+      validate(body) {
+        if (record(body).status !== "pending") {
+          throw new Error("pending scan canary is not pending");
+        }
+      },
+    });
+  }
+
+  for (const check of checks) await runCheck(base, check);
+  console.log(`PASS deployment smoke (${checks.length} checks)`);
+}
+
+main().catch((error: unknown) => {
+  console.error(`FAIL deployment smoke: ${error instanceof Error ? error.message : "unknown error"}`);
+  process.exitCode = 1;
+});

--- a/src/app/api/score/[username]/route.test.ts
+++ b/src/app/api/score/[username]/route.test.ts
@@ -93,6 +93,47 @@ describe("score durable scan guardrails", () => {
     mocks.requiresDurablePublicScan.mockReturnValue(false);
   });
 
+  it("serves a stored stale score without touching GitHub or the durable queue", async () => {
+    mocks.getAccountDetail.mockResolvedValue({
+      username: "stored-fixture",
+      display_name: "Stored Fixture",
+      avatar_url: null,
+      profile_url: "https://profiles.example.invalid/stored-fixture",
+      final_score: 84,
+      tier: "人上人",
+      tags: { zh: [], en: [] },
+      roast_line: { zh: "", en: "" },
+      sub_scores: {},
+      roast: null,
+      roast_en: null,
+      score_version: "v8",
+      scanned_at: 1_800_000_000_000,
+      prev_score: null,
+      prev_scanned_at: null,
+    });
+    mocks.getPercentileCached.mockResolvedValue({ below: 8, total: 10 });
+    mocks.getRankCached.mockResolvedValue({ rank: 2, total: 10, below: 8 });
+
+    const response = await GET(
+      new NextRequest("https://example.test/api/score/stored-fixture"),
+      { params: Promise.resolve({ username: "stored-fixture" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toContain("s-maxage=600");
+    await expect(response.json()).resolves.toMatchObject({
+      source: "indexed",
+      stale: true,
+      username: "stored-fixture",
+      final_score: 84,
+    });
+    expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
+    expect(mocks.getCachedScan).not.toHaveBeenCalled();
+    expect(mocks.buildScanResult).not.toHaveBeenCalled();
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+  });
+
   it("keeps an existing durable job passive when the public score is read", async () => {
     mocks.getPublicScanStatus.mockResolvedValue({
       status: "pending",

--- a/src/app/api/score/[username]/route.ts
+++ b/src/app/api/score/[username]/route.ts
@@ -140,10 +140,11 @@ export async function GET(
 
   // 1) Indexed (already roasted / scored) — richest payload, cheapest path.
   const detail = await getAccountDetail(handle);
-  if (detail?.score_version === SCORE_CACHE_VERSION) {
+  if (detail) {
     return json(
       {
         source: "indexed",
+        stale: detail.score_version !== SCORE_CACHE_VERSION,
         username: detail.username,
         display_name: detail.display_name,
         avatar_url: detail.avatar_url,
@@ -159,11 +160,11 @@ export async function GET(
         profile: `${SITE_URL}/u/${detail.username}`,
       },
       200,
-      RATED_CACHE,
+      detail.score_version === SCORE_CACHE_VERSION ? RATED_CACHE : LIVE_CACHE,
     );
   }
 
-  // 2) Not indexed → score it live, deterministically (NO LLM).
+  // 2) Not indexed at all → score it live, deterministically (NO LLM).
   const statusLimit = await checkPublicScanStatusRateLimit(clientIp(req));
   const statusHeaders = rateLimitHeaders(statusLimit);
   if (!statusLimit.success) {

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -13,10 +13,10 @@ let db: typeof import("../db");
 let tmpDir: string;
 
 const entry: ScoreEntry = {
-  username: "RockChinQ",
-  display_name: "Rock",
+  username: "archive-fixture",
+  display_name: "Archive Fixture",
   avatar_url: null,
-  profile_url: "https://github.com/RockChinQ",
+  profile_url: "https://profiles.example.invalid/archive-fixture",
   final_score: 95.2,
   tier: "夯",
   tags: { zh: ["开源狠人"], en: ["oss beast"] },
@@ -48,17 +48,17 @@ afterAll(() => {
 describe("getArchivedRoast", () => {
   it("replays archived reports by username and language", async () => {
     await db.recordScore(entry);
-    await db.updateRoast("RockChinQ", "## 中文报告", "zh");
-    await db.updateRoast("RockChinQ", "## English report", "en");
+    await db.updateRoast("archive-fixture", "## 中文报告", "zh");
+    await db.updateRoast("archive-fixture", "## English report", "en");
 
-    await expect(db.getArchivedRoast("rockchinq", "zh")).resolves.toMatchObject({
-      username: "rockchinq",
+    await expect(db.getArchivedRoast("ARCHIVE-FIXTURE", "zh")).resolves.toMatchObject({
+      username: "archive-fixture",
       final_score: 95.2,
       tier: "夯",
       tags: entry.tags,
       report: "## 中文报告",
     });
-    await expect(db.getArchivedRoast("RockChinQ", "en")).resolves.toMatchObject({
+    await expect(db.getArchivedRoast("archive-fixture", "en")).resolves.toMatchObject({
       report: "## English report",
     });
   });
@@ -89,6 +89,22 @@ describe("getArchivedRoast", () => {
     });
 
     await expect(db.getArchivedRoast("legacy-roast", "zh")).resolves.toBeNull();
+  });
+
+  it("does not attach a previous-release roast to a target-release score", async () => {
+    const username = "mixed-version-roast-fixture";
+    await db.recordScore({ ...entry, username });
+    await db.updateRoast(username, "## previous release report", "zh");
+
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: `UPDATE scores
+            SET score_version = 'v9', roast_version = 'v8'
+            WHERE username = ?`,
+      args: [username],
+    });
+
+    await expect(db.getArchivedRoast(username, "zh")).resolves.toBeNull();
   });
 });
 
@@ -246,6 +262,51 @@ describe("durable public scan jobs", () => {
         error: "test complete",
       }),
     ).resolves.toBe(true);
+  });
+
+  it("stores a complete v3 snapshot as historical data without aliasing it as current", async () => {
+    const username = "previous-collection-fixture";
+    const queued = await db.enqueuePublicScan(username, {
+      scoreVersion: "v8",
+      collectionVersion: "v3",
+    });
+    if (!queued || "rejection" in queued) throw new Error("expected a synthetic v3 job");
+    const lease = await db.claimPublicScanJob(queued.job.id);
+    const snapshot = '{"fixture":"complete-v3"}';
+    const sourceStatus = {
+      quick: "complete",
+      original_repos: "complete",
+      native_prs: "complete",
+      workflow_landings: "complete",
+      commit_recovery: "complete",
+    } as const;
+
+    await expect(
+      db.completePublicScanRun({
+        jobId: queued.job.id,
+        runId: queued.run.id,
+        leaseToken: lease!.leaseToken,
+        coverage: "complete_public",
+        sourceStatus,
+        snapshot,
+        snapshotHash: createHash("sha256").update(snapshot).digest("hex"),
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      db.getLatestPublicScanRun(username, {
+        scoreVersion: "v8",
+        collectionVersion: "v3",
+      }),
+    ).resolves.toMatchObject({
+      state: "complete_public",
+      collectionVersion: "v3",
+    });
+    await expect(
+      db.getLatestPublicScanRun(username, {
+        scoreVersion: "v8",
+        collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+      }),
+    ).resolves.toBeNull();
   });
 
   it("admits new durable work atomically without charging an existing job", async () => {
@@ -916,6 +977,122 @@ describe("getRepoOverview + filterExistingRepoKeys", () => {
     const found = await db.filterExistingRepoKeys(["Acme/Widget", "ghost/missing"]);
     expect(found.has("acme/widget")).toBe(true);
     expect(found.has("ghost/missing")).toBe(false);
+  });
+});
+
+describe("legacy public score release guardrail", () => {
+  it("keeps a synthetic v8 row on every passive public surface without creating work", async () => {
+    const username = "legacy-public-fixture";
+    const peer = "legacy-peer-fixture";
+    const repoKey = `${username}/public-fixture`;
+    const followerId = 9_100_001;
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+
+    await db.recordScore({ ...entry, username, final_score: 86 });
+    await db.recordScore({ ...entry, username: peer, final_score: 84 });
+    await client.execute({
+      sql: `UPDATE scores
+            SET score_version = 'v8', roast = 'legacy report', roast_version = 'v8'
+            WHERE username IN (?, ?)`,
+      args: [username, peer],
+    });
+    await db.recordDeveloperFacets(username, [
+      { type: "language", value: "FixtureLang", weight: 1 },
+    ]);
+    await db.recordRepoGraph(username, {
+      repos: [
+        {
+          repo_key: repoKey,
+          name_with_owner: `${username}/PublicFixture`,
+          owner_login: username,
+          name: "PublicFixture",
+          description: "Synthetic release fixture",
+          stars: 100,
+          forks: 5,
+          language: "FixtureLang",
+          topics: ["release-fixture"],
+        },
+      ],
+      links: [
+        {
+          repo_key: repoKey,
+          relation: "owner",
+          commits: null,
+          prs: null,
+          weight: 100,
+        },
+      ],
+    });
+    await expect(db.setFollow(followerId, username)).resolves.toBe("ok");
+
+    const jobsBefore = await client.execute(
+      "SELECT COUNT(*) AS count FROM public_scan_jobs",
+    );
+    const runsBefore = await client.execute(
+      "SELECT COUNT(*) AS count FROM public_scan_runs",
+    );
+
+    const [
+      detail,
+      brief,
+      suggestions,
+      leaderboard,
+      trending,
+      heat,
+      facets,
+      facetDevelopers,
+      sitemapProfiles,
+      repo,
+      similar,
+      following,
+      archivedRoast,
+    ] = await Promise.all([
+      db.getAccountDetail(username),
+      db.getScoreBrief(username),
+      db.searchScoredUsers("legacy-public"),
+      db.getLeaderboard(500, 0),
+      db.getTrendingLeaderboard(500, 0),
+      db.getHeatLeaderboard(500, 0),
+      db.getFacetCategories("language"),
+      db.getDevelopersByFacet("language", "FixtureLang"),
+      db.getAllPublicUsernames(0),
+      db.getRepoOverview(repoKey),
+      db.getSimilarAccounts(username, 86, entry.sub_scores, 100),
+      db.listFollowedAccounts(followerId),
+      db.getArchivedRoast(username, "zh"),
+    ]);
+
+    expect(detail).toMatchObject({ username, final_score: 86, score_version: "v8" });
+    expect(brief).toMatchObject({ username, final_score: 86 });
+    expect(suggestions).toEqual(expect.arrayContaining([expect.objectContaining({ username })]));
+    for (const entries of [leaderboard, trending, heat]) {
+      expect(entries.some((item) => item.username === username)).toBe(true);
+    }
+    expect(facets).toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: "FixtureLang" })]),
+    );
+    expect(facetDevelopers).toEqual(
+      expect.arrayContaining([expect.objectContaining({ username })]),
+    );
+    expect(sitemapProfiles).toEqual(
+      expect.arrayContaining([expect.objectContaining({ username })]),
+    );
+    expect(repo).toMatchObject({ owner: { username }, summary: { count: 1 } });
+    expect(similar.some((item) => item.username === peer)).toBe(true);
+    expect(following).toEqual(
+      expect.arrayContaining([expect.objectContaining({ username, final_score: 86 })]),
+    );
+    expect(archivedRoast).toBeNull();
+
+    const jobsAfter = await client.execute("SELECT COUNT(*) AS count FROM public_scan_jobs");
+    const runsAfter = await client.execute("SELECT COUNT(*) AS count FROM public_scan_runs");
+    const persisted = await client.execute({
+      sql: "SELECT score_version FROM scores WHERE username = ?",
+      args: [username],
+    });
+    expect(Number(jobsAfter.rows[0]?.count)).toBe(Number(jobsBefore.rows[0]?.count));
+    expect(Number(runsAfter.rows[0]?.count)).toBe(Number(runsBefore.rows[0]?.count));
+    expect(persisted.rows[0]?.score_version).toBe("v8");
   });
 });
 

--- a/src/lib/__tests__/mcp-tools.test.ts
+++ b/src/lib/__tests__/mcp-tools.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAccountDetail: vi.fn(),
+  searchScoredUsers: vi.fn(),
+  getPercentileCached: vi.fn(),
+  getRankCached: vi.fn(),
+  getLeaderboardCached: vi.fn(),
+  coalesceScan: vi.fn(),
+  getCachedScan: vi.fn(),
+  buildScanResult: vi.fn(),
+  scanErrorResponse: vi.fn(),
+  getPublicScanStatus: vi.fn(),
+  publicScanAdmission: vi.fn(),
+  requiresDurablePublicScan: vi.fn(),
+  resolvePublicScanFromTrustedQuickScan: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getAccountDetail: mocks.getAccountDetail,
+  searchScoredUsers: mocks.searchScoredUsers,
+}));
+
+vi.mock("@/lib/rank", () => ({
+  getPercentileCached: mocks.getPercentileCached,
+  getRankCached: mocks.getRankCached,
+}));
+
+vi.mock("@/lib/leaderboard", () => ({
+  getLeaderboardCached: mocks.getLeaderboardCached,
+}));
+
+vi.mock("@/lib/redis", () => ({
+  coalesceScan: mocks.coalesceScan,
+  getCachedScan: mocks.getCachedScan,
+}));
+
+vi.mock("@/lib/scan-core", () => ({
+  buildScanResult: mocks.buildScanResult,
+  scanErrorResponse: mocks.scanErrorResponse,
+}));
+
+vi.mock("@/lib/public-scan", () => ({
+  getPublicScanStatus: mocks.getPublicScanStatus,
+  publicScanAdmission: mocks.publicScanAdmission,
+  requiresDurablePublicScan: mocks.requiresDurablePublicScan,
+  resolvePublicScanFromTrustedQuickScan: mocks.resolvePublicScanFromTrustedQuickScan,
+}));
+
+import { scoreUser } from "../mcp-tools";
+
+describe("MCP stored score guardrail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAccountDetail.mockResolvedValue({
+      username: "mcp-stored-fixture",
+      display_name: "MCP Stored Fixture",
+      final_score: 82,
+      tier: "人上人",
+      sub_scores: {},
+      score_version: "v8",
+      scanned_at: 1_800_000_000_000,
+    });
+    mocks.getPercentileCached.mockResolvedValue({ below: 8, total: 10 });
+    mocks.getRankCached.mockResolvedValue({ rank: 2, total: 10, below: 8 });
+  });
+
+  it("returns a stale stored score without entering any scan path", async () => {
+    await expect(scoreUser("mcp-stored-fixture")).resolves.toMatchObject({
+      source: "indexed",
+      stale: true,
+      username: "mcp-stored-fixture",
+      final_score: 82,
+    });
+
+    expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
+    expect(mocks.getCachedScan).not.toHaveBeenCalled();
+    expect(mocks.buildScanResult).not.toHaveBeenCalled();
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/release-versions.test.ts
+++ b/src/lib/__tests__/release-versions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  RELEASE_VERSION_MANIFEST,
+  changedVersionComponents,
+  releaseVersionErrors,
+  type ReleaseVersionManifest,
+} from "../release-versions";
+
+function manifestCopy(): ReleaseVersionManifest {
+  return structuredClone(RELEASE_VERSION_MANIFEST);
+}
+
+describe("release version contract", () => {
+  it("records only the formal v8/v8/v3 to v9/v9/v4 lineage", () => {
+    expect(RELEASE_VERSION_MANIFEST.previousRelease).toEqual({
+      score: "v8",
+      roast: "v8",
+      collection: "v3",
+    });
+    expect(RELEASE_VERSION_MANIFEST.targetRelease).toEqual({
+      score: "v9",
+      roast: "v9",
+      collection: "v4",
+    });
+    expect(RELEASE_VERSION_MANIFEST.aliases).toEqual([]);
+  });
+
+  it("keeps runtime enforcement scoped to version-file changes until normalization", () => {
+    expect(releaseVersionErrors()).toEqual([]);
+    expect(RELEASE_VERSION_MANIFEST.runtimeEnforcement).toEqual({
+      state: "source_changes_only",
+      trackingIssue: 126,
+    });
+  });
+
+  it("requires canonical runtime constants to equal the formal target", () => {
+    const manifest = manifestCopy();
+    manifest.runtimeEnforcement = {
+      state: "canonical",
+      trackingIssue: null,
+    };
+
+    expect(releaseVersionErrors(manifest, manifest.targetRelease)).toEqual([]);
+  });
+
+  it("rejects aliases and accidental-version replay paths", () => {
+    const aliasManifest = manifestCopy();
+    aliasManifest.aliases = [{ from: "local", to: "formal" }];
+    expect(releaseVersionErrors(aliasManifest)).toContain("version aliases are forbidden");
+
+    const replayManifest = manifestCopy();
+    replayManifest.compatibility.roastReplay = [{ score: "local", roast: "local" }];
+    expect(releaseVersionErrors(replayManifest)).toContain(
+      "roast replay must require the canonical score and roast pair",
+    );
+  });
+
+  it("detects multi-component changes for CI change control", () => {
+    expect(
+      changedVersionComponents(
+        { score: "v9", roast: "v9", collection: "v4" },
+        { score: "v10", roast: "v10", collection: "v4" },
+      ),
+    ).toEqual(["score", "roast"]);
+  });
+});

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -47,9 +47,10 @@ export async function scoreUser(
   }
 
   const detail = await getAccountDetail(handle);
-  if (detail?.score_version === SCORE_CACHE_VERSION) {
+  if (detail) {
     return {
       source: "indexed",
+      stale: detail.score_version !== SCORE_CACHE_VERSION,
       username: detail.username,
       display_name: detail.display_name,
       final_score: detail.final_score,

--- a/src/lib/release-versions.ts
+++ b/src/lib/release-versions.ts
@@ -1,0 +1,166 @@
+import manifestJson from "../../config/release-versions.json";
+import { ROAST_CACHE_VERSION, SCORE_CACHE_VERSION } from "./cache-version";
+import { PUBLIC_SCAN_COLLECTION_VERSION } from "./scan-run-types";
+
+export const RELEASE_COMPONENTS = ["score", "roast", "collection"] as const;
+export type ReleaseComponent = (typeof RELEASE_COMPONENTS)[number];
+
+export interface ReleaseVersionSet {
+  score: string;
+  roast: string;
+  collection: string;
+}
+
+export interface ReleaseVersionManifest {
+  schemaVersion: number;
+  previousRelease: ReleaseVersionSet;
+  targetRelease: ReleaseVersionSet;
+  runtimeEnforcement: {
+    state: "source_changes_only" | "canonical";
+    trackingIssue: number | null;
+  };
+  compatibility: {
+    publicScoreReadOrder: string[];
+    roastReplay: { score: string; roast: string }[];
+    collectionReadOrder: string[];
+  };
+  changeControl: {
+    maxComponentsPerPullRequest: number;
+    approvedMultiComponentIssue: number | null;
+  };
+  aliases: unknown[];
+  releasePlan: string;
+}
+
+export const RELEASE_VERSION_MANIFEST = manifestJson as ReleaseVersionManifest;
+
+export const RUNTIME_RELEASE_VERSIONS: ReleaseVersionSet = {
+  score: SCORE_CACHE_VERSION,
+  roast: ROAST_CACHE_VERSION,
+  collection: PUBLIC_SCAN_COLLECTION_VERSION,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isVersion(value: unknown): value is string {
+  return typeof value === "string" && /^v[1-9]\d*$/.test(value);
+}
+
+function isVersionSet(value: unknown): value is ReleaseVersionSet {
+  return (
+    isRecord(value) &&
+    RELEASE_COMPONENTS.every((component) => isVersion(value[component]))
+  );
+}
+
+function sameVersions(a: ReleaseVersionSet, b: ReleaseVersionSet): boolean {
+  return RELEASE_COMPONENTS.every((component) => a[component] === b[component]);
+}
+
+function exactList(actual: unknown, expected: string[]): boolean {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    actual.every((value, index) => value === expected[index])
+  );
+}
+
+export function changedVersionComponents(
+  before: ReleaseVersionSet,
+  after: ReleaseVersionSet,
+): ReleaseComponent[] {
+  return RELEASE_COMPONENTS.filter((component) => before[component] !== after[component]);
+}
+
+/**
+ * Validate the checked-in release contract against the actual runtime constants.
+ * Public reads use the compatibility matrix; rejected local values are never
+ * aliases or migration sources.
+ */
+export function releaseVersionErrors(
+  manifest: unknown = RELEASE_VERSION_MANIFEST,
+  runtime: ReleaseVersionSet = RUNTIME_RELEASE_VERSIONS,
+): string[] {
+  const errors: string[] = [];
+  if (!isRecord(manifest)) return ["release manifest must be an object"];
+
+  if (manifest.schemaVersion !== 1) errors.push("schemaVersion must be 1");
+  if (!isVersionSet(manifest.previousRelease)) errors.push("previousRelease is invalid");
+  if (!isVersionSet(manifest.targetRelease)) errors.push("targetRelease is invalid");
+  if (errors.length > 0) return errors;
+
+  const typed = manifest as unknown as ReleaseVersionManifest;
+  const { previousRelease, targetRelease } = typed;
+
+  for (const component of RELEASE_COMPONENTS) {
+    const previous = Number(previousRelease[component].slice(1));
+    const target = Number(targetRelease[component].slice(1));
+    if (target < previous || target - previous > 1) {
+      errors.push(`${component} target must stay put or advance by exactly one formal version`);
+    }
+  }
+
+  if (!isRecord(typed.runtimeEnforcement)) {
+    errors.push("runtimeEnforcement is missing");
+  } else if (typed.runtimeEnforcement.state === "source_changes_only") {
+    if (
+      !Number.isInteger(typed.runtimeEnforcement.trackingIssue) ||
+      Number(typed.runtimeEnforcement.trackingIssue) < 1
+    ) {
+      errors.push("source_changes_only requires a normalization tracking issue");
+    }
+  } else if (typed.runtimeEnforcement.state === "canonical") {
+    if (!sameVersions(runtime, targetRelease)) {
+      errors.push("canonical runtime must exactly match targetRelease");
+    }
+    if (typed.runtimeEnforcement.trackingIssue !== null) {
+      errors.push("canonical runtime must not retain a normalization issue");
+    }
+  } else {
+    errors.push("runtimeEnforcement.state must be source_changes_only or canonical");
+  }
+
+  if (!isRecord(typed.compatibility)) {
+    errors.push("compatibility matrix is missing");
+  } else {
+    if (
+      !exactList(typed.compatibility.publicScoreReadOrder, [
+        targetRelease.score,
+        previousRelease.score,
+      ])
+    ) {
+      errors.push("public score reads must prefer target and fall back to the previous release");
+    }
+    if (
+      !exactList(typed.compatibility.collectionReadOrder, [
+        targetRelease.collection,
+        previousRelease.collection,
+      ])
+    ) {
+      errors.push("collection reads must prefer target and fall back to the previous release");
+    }
+    const roastReplay = typed.compatibility.roastReplay;
+    if (
+      !Array.isArray(roastReplay) ||
+      roastReplay.length !== 1 ||
+      roastReplay[0]?.score !== targetRelease.score ||
+      roastReplay[0]?.roast !== targetRelease.roast
+    ) {
+      errors.push("roast replay must require the canonical score and roast pair");
+    }
+  }
+
+  if (!Array.isArray(typed.aliases) || typed.aliases.length !== 0) {
+    errors.push("version aliases are forbidden");
+  }
+  if (typed.changeControl?.maxComponentsPerPullRequest !== 1) {
+    errors.push("version changes must default to one component per pull request");
+  }
+  if (!/^docs\/releases\/[a-z0-9][a-z0-9-]*\.md$/.test(typed.releasePlan)) {
+    errors.push("releasePlan must point to a versioned document under docs/releases");
+  }
+
+  return errors;
+}

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "plugins": [],
+    "target": "ES2022"
+  },
+  "include": [
+    "scripts/check-release-versions.mts",
+    "scripts/smoke-deployment.mts",
+    "src/lib/release-versions.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Why

#123 restored public reads after the production rollback. This PR adds the first release-safety gate from #121 before any runtime version normalization.

## Behavior

- Stored scores remain readable from REST and MCP even when their score version is stale.
- A stale stored score returns `stale: true` and never enters GitHub collection, scan status, or durable queue paths.
- Synthetic v8 fixtures cover detail, autocomplete, leaderboard, facet, sitemap, project, similar, following, and roast replay boundaries.
- CI runs the release guard, typecheck, lint, all tests, and a production build without production credentials.
- A read-only deployment smoke checks profile, score, search, leaderboard, facet, scan status, and canonical origin using privately configured canaries.

## Request flow

```mermaid
flowchart LR
  R["REST / MCP score read"] --> D{"Stored score exists?"}
  D -- Yes --> S["Return indexed score"]
  S --> T{"Current formal version?"}
  T -- No --> F["Mark stale; short edge cache"]
  T -- Yes --> C["Normal indexed cache"]
  D -- No --> L["Existing explicit live-score path"]
  F -. "No GitHub / no job" .-> X["No side effect"]
```

## Version boundary

The checked-in formal lineage is v8/v8/v3 to v9/v9/v4. Runtime constants are intentionally unchanged in this PR. The manifest starts in `source_changes_only` mode: any later PR touching a version source must land directly on the formal target, update the rollout plan, and satisfy multi-component change control. #126 will switch enforcement to `canonical`.

No local-development version value is added to the manifest, compatibility matrix, aliases, fixtures, or migration plan.

## Verification

- `pnpm versions:check --base-ref upstream/dev`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (62 files, 455 tests)
- `pnpm build` (177 pages)
- `pnpm smoke:deployment --help`
- staged diff, secret-pattern, account-name, email, and accidental-version scans

## Deployment boundary

The workflow receives no Turso, Redis, GitHub, or Cron credentials. The owner still needs to make `Verify release` required and run the private smoke against an isolated staging deployment before promotion.

Refs #121. Follow-up behavior remains split across #126, #120, #118, and #119.