### PR TITLE
fix(queue): target durable scan head starts

### DIFF
--- a/docs/operations/public-scan-monitoring.md
+++ b/docs/operations/public-scan-monitoring.md
@@ -1,0 +1,114 @@
+# Public scan monitoring
+
+This runbook covers the canonical durable public-scan queue. It does not permit
+global recollection, version aliases, or request-side queue draining.
+
+## Processing model
+
+```mermaid
+flowchart LR
+  A["Explicit request creates one job"] --> B["Request head start: that job ID, one step"]
+  B --> C["Turso queue and lease"]
+  D["Vercel Cron every five minutes"] --> C
+  C --> E["Canonical worker step"]
+  E --> F["Aggregate metrics and structured log"]
+  F --> G["Authenticated operations endpoint"]
+  F --> H["Vercel Runtime Logs / Log Drain"]
+```
+
+Cron remains the primary consumer. The request head start is optional and can
+only address the job atomically created by that request. A busy execution slot
+returns the claim to the ready queue without changing its attempt count or
+schedule. Durable-storage and metrics-write failures are distinct from an empty
+queue or a busy slot: the Cron endpoint returns `503` and never emits a healthy
+`status: "ok"` response for those failures.
+
+## Aggregate endpoint
+
+Use an operator credential only in a private shell. Do not paste its value into
+issues, pull requests, logs, or screenshots.
+
+```bash
+curl -fsS -H "x-admin-secret: $ADMIN_SECRET" \
+  "$BASE_URL/api/admin/public-scan-jobs"
+```
+
+The response contains no account names, IP addresses, payloads, lease tokens,
+or error text. Its `metrics` object includes:
+
+| Field | Meaning |
+| --- | --- |
+| `queue.depth` | Canonical queued plus running jobs |
+| `queue.ready` / `queue.deferred` | Ready now versus scheduled for later |
+| `queue.oldestAgeMs` | Age of the oldest active canonical job |
+| `queue.byPhase` | Queued/running counts for each bounded phase |
+| `failures.*` | Current failed jobs and cumulative retry/terminal steps |
+| `execution.*` | Active slot, fixed capacity, and cumulative contention |
+| `obsoleteActiveJobs` | Active jobs outside the canonical collection |
+| `steps[]` | Per-phase/outcome count, average duration, and maximum duration |
+| `cron.lastSuccessAt` | Last successfully completed Cron invocation |
+| `cron.consecutiveFailures` | Consecutive dispatcher-level Cron failures |
+
+Step counters are cumulative. Alerting systems must compare successive samples
+to derive rates.
+
+## Structured logs
+
+The worker emits `public_scan.step` and `public_scan.cron` records. Step records
+contain only source, status, opaque job/run IDs, phase, duration, and retry state.
+They never contain account names, IP addresses, request headers, credentials, or
+raw upstream errors. Roast request summaries use an opaque request ID instead of
+an account name.
+
+Vercel documents Runtime Log filtering and structured application logs at:
+
+- <https://vercel.com/docs/logs/runtime>
+- <https://vercel.com/kb/guide/add-structured-application-logs-to-vercel-functions>
+- <https://vercel.com/docs/cron-jobs/manage-cron-jobs>
+
+## Owner configuration
+
+Production configuration requires project-owner access:
+
+1. Deploy the reviewed `dev` commit with the production-equivalent Cron secret.
+2. In **Settings > Cron Jobs**, open **View Logs** for
+   `/api/internal/public-scan` and verify recurring HTTP 200 responses plus
+   `public_scan.cron` records with `status: "ok"`.
+3. In **Observability > Alerts**, configure a route-level error anomaly for the
+   Cron endpoint and deliver it to at least two destinations. Vercel's built-in
+   alerts require a supported paid plan; see <https://vercel.com/docs/alerts>.
+4. For application thresholds below, configure a Log Drain or an external
+   monitor that samples the aggregate endpoint. Vercel Drains are documented at
+   <https://vercel.com/docs/drains>.
+5. Trigger one synthetic durable scan on `dev`; confirm its request log advances
+   only its opaque job ID and a later Cron can resume it.
+
+## Initial alert thresholds
+
+With the checked-in five-minute schedule:
+
+| Signal | Warning | Critical |
+| --- | --- | --- |
+| Time since `cron.lastSuccessAt` | 11 minutes | 20 minutes |
+| `queue.oldestAgeMs` | 15 minutes | 30 minutes |
+| `queue.depth` | 18 | 24 |
+| New `failed_terminal` steps | any | 3 within 15 minutes |
+| New `slot_busy` steps | 3 within 15 minutes | 6 within 15 minutes |
+| `cron.consecutiveFailures` | 1 | 2 |
+| `obsoleteActiveJobs` after quarantine | any | increasing across two samples |
+
+These are launch thresholds, not permanent capacity targets. Tighten them after
+observing the isolated `dev` deployment. Do not increase worker concurrency to
+silence an alert; investigate GitHub quota, step duration, and queue admission.
+
+## Verification and rollback
+
+- Polling `GET /api/scan-status/:username` must not change queue state or invoke
+  GitHub.
+- Repeating a request for an existing pending job must not start after-work.
+- Slot contention must leave `attempt_count` and `next_run_at` unchanged.
+- A missing or unavailable durable store must make the Cron endpoint return
+  `503 public_scan_unavailable`, never an empty-queue `200`.
+- Disabling Vercel Cron stops scheduled consumption but does not delete jobs.
+- Never quarantine a valid running lease; use the existing dry-run inventory and
+  bounded operator switch from the release runbook.

--- a/docs/releases/v9-v9-v4-rollout.md
+++ b/docs/releases/v9-v9-v4-rollout.md
@@ -54,6 +54,10 @@ multi-component bump, and release history cannot be rewritten in place.
   collection, score, and roast contracts together.
 - No global rescore, recollection, or roast regeneration runs during promotion.
 
+Queue metrics, privacy-safe structured logs, alert thresholds, and owner-only
+Vercel steps are documented in
+[`docs/operations/public-scan-monitoring.md`](../operations/public-scan-monitoring.md).
+
 ## #126 normalization boundary
 
 This normalization does not persist a score when a durable scan completes. #118

--- a/src/app/api/admin/public-scan-jobs/route.test.ts
+++ b/src/app/api/admin/public-scan-jobs/route.test.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getPublicScanJobVersionSummary: vi.fn(),
+  getPublicScanOperationalMetrics: vi.fn(),
   quarantineObsoletePublicScanJobs: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
   getPublicScanJobVersionSummary: mocks.getPublicScanJobVersionSummary,
+  getPublicScanOperationalMetrics: mocks.getPublicScanOperationalMetrics,
   quarantineObsoletePublicScanJobs: mocks.quarantineObsoletePublicScanJobs,
 }));
 
@@ -15,6 +17,32 @@ import { GET, POST } from "./route";
 
 const originalAdminSecret = process.env.ADMIN_SECRET;
 const originalQuarantineSwitch = process.env.PUBLIC_SCAN_QUARANTINE_ENABLED;
+const aggregateMetrics = {
+  generatedAt: 1_800_000_000_000,
+  canonicalCollectionVersion: "v4",
+  queue: {
+    depth: 2,
+    queued: 1,
+    running: 1,
+    ready: 1,
+    deferred: 0,
+    retrying: 0,
+    oldestAgeMs: 30_000,
+    byPhase: [{ phase: "merged_prs", queued: 1, running: 1 }],
+  },
+  failures: { currentFailedJobs: 0, retryingSteps: 1, terminalSteps: 0 },
+  execution: { activeSlots: 1, capacity: 1, contentionSteps: 2 },
+  obsoleteActiveJobs: 1,
+  steps: [],
+  cron: {
+    lastStartedAt: 1_799_999_999_000,
+    lastSuccessAt: 1_800_000_000_000,
+    lastDurationMs: 250,
+    lastProcessed: 2,
+    lastFailedSteps: 0,
+    consecutiveFailures: 0,
+  },
+};
 
 function request(method: "GET" | "POST", body?: unknown, authorized = true) {
   return new NextRequest("https://example.test/api/admin/public-scan-jobs", {
@@ -32,6 +60,7 @@ describe("public scan job release operations", () => {
     process.env.ADMIN_SECRET = "synthetic-admin-secret";
     delete process.env.PUBLIC_SCAN_QUARANTINE_ENABLED;
     mocks.getPublicScanJobVersionSummary.mockResolvedValue([]);
+    mocks.getPublicScanOperationalMetrics.mockResolvedValue(aggregateMetrics);
     mocks.quarantineObsoletePublicScanJobs.mockResolvedValue({
       dryRun: true,
       selected: 2,
@@ -65,7 +94,11 @@ describe("public scan job release operations", () => {
     await expect(response.json()).resolves.toEqual({
       canonicalCollectionVersion: "v4",
       versions: [],
+      metrics: aggregateMetrics,
     });
+    expect(mocks.getPublicScanOperationalMetrics).toHaveBeenCalledWith("v4");
+    const serialized = JSON.stringify(await (await GET(request("GET"))).json());
+    expect(serialized).not.toMatch(/username|payload|leaseToken|secret|error/i);
   });
 
   it("defaults to a bounded dry-run", async () => {

--- a/src/app/api/admin/public-scan-jobs/route.ts
+++ b/src/app/api/admin/public-scan-jobs/route.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import {
   getPublicScanJobVersionSummary,
+  getPublicScanOperationalMetrics,
   quarantineObsoletePublicScanJobs,
 } from "@/lib/db";
 import { PUBLIC_SCAN_COLLECTION_VERSION } from "@/lib/scan-run-types";
@@ -40,11 +41,15 @@ function boundedLimit(value: unknown): number {
 /** Aggregate inventory only; no account or job identifiers leave this endpoint. */
 export async function GET(req: NextRequest) {
   if (!authorized(req)) return json({ error: "forbidden" }, 403);
-  const versions = await getPublicScanJobVersionSummary();
-  if (!versions) return json({ error: "storage_unavailable" }, 503);
+  const [versions, metrics] = await Promise.all([
+    getPublicScanJobVersionSummary(),
+    getPublicScanOperationalMetrics(PUBLIC_SCAN_COLLECTION_VERSION),
+  ]);
+  if (!versions || !metrics) return json({ error: "storage_unavailable" }, 503);
   return json({
     canonicalCollectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
     versions,
+    metrics,
   });
 }
 

--- a/src/app/api/internal/public-scan/route.test.ts
+++ b/src/app/api/internal/public-scan/route.test.ts
@@ -20,7 +20,14 @@ describe("durable scan Cron worker", () => {
     mocks.drainPublicScanJobsFromCron.mockResolvedValue({
       processed: 2,
       exhaustedBudget: false,
-      results: [{ status: "continued", jobId: "job-id", phase: "merged_prs" }],
+      results: [
+        {
+          status: "continued",
+          jobId: "job-id",
+          runId: "run-id",
+          phase: "merged_prs",
+        },
+      ],
     });
   });
 
@@ -35,11 +42,30 @@ describe("durable scan Cron worker", () => {
 
     const accepted = await GET(
       new NextRequest("https://example.test/api/internal/public-scan", {
-        headers: { authorization: "Bearer cron-test-secret" },
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
       }),
     );
     expect(accepted.status).toBe(200);
     await expect(accepted.json()).resolves.toMatchObject({ status: "ok", processed: 2 });
     expect(mocks.drainPublicScanJobsFromCron).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 instead of a healthy response when durable storage fails", async () => {
+    mocks.drainPublicScanJobsFromCron.mockRejectedValue(
+      new Error("synthetic-sensitive-storage-marker"),
+    );
+
+    const response = await GET(
+      new NextRequest("https://example.test/api/internal/public-scan", {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      status: "error",
+      error: "public_scan_unavailable",
+    });
   });
 });

--- a/src/app/api/internal/public-scan/route.ts
+++ b/src/app/api/internal/public-scan/route.ts
@@ -30,8 +30,18 @@ async function run(req: NextRequest) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  const result = await drainPublicScanJobsFromCron();
-  return NextResponse.json({ status: "ok", ...result }, { headers: { "Cache-Control": "no-store" } });
+  try {
+    const result = await drainPublicScanJobsFromCron();
+    return NextResponse.json(
+      { status: "ok", ...result },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch {
+    return NextResponse.json(
+      { status: "error", error: "public_scan_unavailable" },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
 }
 
 // Vercel Cron issues a GET request with Authorization: Bearer $CRON_SECRET.

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -74,6 +74,7 @@ vi.mock("@/lib/lang", () => ({
 }));
 
 vi.mock("@/lib/llm", () => {
+  class LlmTimeoutError extends Error {}
   class LlmQuotaError extends Error {
     constructor(
       message: string,
@@ -83,6 +84,7 @@ vi.mock("@/lib/llm", () => {
     }
   }
   return {
+    LlmTimeoutError,
     LlmQuotaError,
     // The route calls the fallback wrapper; delegate to the per-call stream mock
     // using the primary config.
@@ -184,6 +186,14 @@ async function* streamText(text: string): AsyncGenerator<{ type: "content"; text
 
 async function* streamChunks(chunks: string[]): AsyncGenerator<{ type: "content"; text: string }> {
   for (const text of chunks) yield { type: "content", text };
+}
+
+async function* streamThenFail(
+  text: string,
+  error: Error,
+): AsyncGenerator<{ type: "content"; text: string }> {
+  yield { type: "content", text };
+  throw error;
 }
 
 const scan: ScanResult = {
@@ -413,7 +423,7 @@ describe("roast API persistence", () => {
       status: "pending",
       run: { id: "active-run", username: "DemoDev" },
       retryAfterSeconds: 5,
-      shouldDrain: false,
+      headStartJobId: null,
     });
 
     const response = await POST(
@@ -425,6 +435,28 @@ describe("roast API persistence", () => {
 
     expect(response.status).toBe(409);
     expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+    expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
+  });
+
+  it("head-starts only the durable job created by this roast request", async () => {
+    mocks.requiresDurablePublicScan.mockReturnValue(true);
+    mocks.resolvePublicScanFromTrustedQuickScan.mockResolvedValue({
+      status: "pending",
+      run: { id: "new-run-id", username: "DemoDev" },
+      retryAfterSeconds: 5,
+      headStartJobId: "new-job-id",
+    });
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ scan, lang: "zh" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledOnce();
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("new-job-id");
     expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
   });
 
@@ -447,7 +479,10 @@ describe("roast API persistence", () => {
         source: "generate",
         generationPath: "leader",
         lockWaitMs: 0,
+        requestId: expect.any(String),
       });
+      expect(summary.u).toBeUndefined();
+      expect(JSON.stringify(summary)).not.toContain("DemoDev");
       expect(summary.requestTotalMs).toEqual(expect.any(Number));
       expect(summary.streamMs).toEqual(expect.any(Number));
       expect(summary.firstEventMs).toEqual(expect.any(Number));
@@ -459,6 +494,33 @@ describe("roast API persistence", () => {
         "first_content",
         "success",
       ]);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("does not log partial model text, account names, or raw generation errors", async () => {
+    const rawMarker = "sensitive-upstream-marker";
+    mocks.chatStreamEvents.mockReset();
+    mocks.chatStreamEvents.mockReturnValue(
+      streamThenFail(`partial output for ${scan.metrics.username}`, new Error(rawMarker)),
+    );
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const response = await POST(
+        new NextRequest("https://example.test/api/roast", {
+          method: "POST",
+          body: JSON.stringify({ scan, lang: "zh" }),
+        }),
+      );
+      await response.text();
+
+      const summaryCall = log.mock.calls.find(([name]) => name === "roast.summary");
+      expect(summaryCall).toBeDefined();
+      const serialized = String(summaryCall![1]);
+      expect(serialized).not.toContain(scan.metrics.username);
+      expect(serialized).not.toContain(rawMarker);
+      expect(JSON.parse(serialized)).not.toHaveProperty("head");
     } finally {
       log.mockRestore();
     }

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { checkBotId } from "botid/server";
 import { TIER_LABEL_EN } from "@/lib/badge";
@@ -627,6 +628,7 @@ export async function POST(req: NextRequest) {
   // computed from stream start would let wait + generation overrun the 240s
   // function ceiling — the platform then kills the stream mid-roast.
   const reqT0 = Date.now();
+  const requestId = randomUUID();
   let body: RoastBody;
   try {
     body = await req.json();
@@ -732,7 +734,9 @@ export async function POST(req: NextRequest) {
     if (resolution.status === "complete") {
       scan = resolution.scan;
     } else {
-      if (resolution.status === "pending" && resolution.shouldDrain) kickPublicScanDrain();
+      if (resolution.status === "pending" && resolution.headStartJobId) {
+        kickPublicScanDrain(resolution.headStartJobId);
+      }
       const retryAfterSeconds = resolution.retryAfterSeconds;
       const busy = resolution.status === "queue_full" || resolution.status === "admission_limited";
       return NextResponse.json(
@@ -779,7 +783,7 @@ export async function POST(req: NextRequest) {
               )
             : (await computeMeta(scan, cachedRoast.delta, tags, roastLine, false, lang)).meta;
         logRoastSummary({
-          u: username, lang, path, ok: true, source: "redis_cache",
+          requestId, lang, path, ok: true, source: "redis_cache",
           requestTotalMs: Date.now() - reqT0,
         });
         return roastResponse(cachedRoast.report, meta);
@@ -804,7 +808,7 @@ export async function POST(req: NextRequest) {
           archivedRoast.tier,
         );
         logRoastSummary({
-          u: username, lang, path, ok: true, source: "archive",
+          requestId, lang, path, ok: true, source: "archive",
           requestTotalMs: Date.now() - reqT0,
         });
         return roastResponse(archivedRoast.report, meta);
@@ -846,7 +850,7 @@ export async function POST(req: NextRequest) {
               )
             : (await computeMeta(scan, shared.delta, tags, roastLine, false, lang)).meta;
         logRoastSummary({
-          u: username, lang, path, ok: true, source: "singleflight_shared",
+          requestId, lang, path, ok: true, source: "singleflight_shared",
           lockWaitMs, requestTotalMs: Date.now() - reqT0,
         });
         return roastResponse(shared.report, meta);
@@ -905,7 +909,7 @@ export async function POST(req: NextRequest) {
       };
       const generating = lang === "en" ? "Writing roast…" : "正在撰写锐评…";
       const summaryFields = () => ({
-        u: username,
+        requestId,
         lang,
         path,
         source: "generate",
@@ -954,13 +958,12 @@ export async function POST(req: NextRequest) {
         if (e instanceof LlmQuotaError) {
           return failAndClose(
             { error: "llm_quota", useByoKey: true, status: e.status },
-            { stage: "generation", kind: "quota", head: head.slice(0, 200) },
+            { stage: "generation", kind: "quota" },
           );
         }
-        console.error("roast failed:", e);
         return failAndClose(
           { error: "roast_failed" },
-          { stage: "generation", kind: classifyLlmError(e), head: head.slice(0, 200) },
+          { stage: "generation", kind: classifyLlmError(e) },
         );
       }
 
@@ -989,7 +992,6 @@ export async function POST(req: NextRequest) {
         scoreWrite = computed.scoreWrite;
         metaMs = Date.now() - reqT0;
       } catch (e) {
-        console.error("roast meta failed:", e);
         return failAndClose(
           { error: "roast_failed" },
           { stage: "meta", kind: classifyLlmError(e) },
@@ -1058,7 +1060,6 @@ export async function POST(req: NextRequest) {
           ...summaryFields(), ok: false, stage: "stream",
           kind: classifyLlmError(e), chars: full.length,
         });
-        console.error("roast stream error:", e);
         push(errorFrame(enc, { error: "roast_failed" }));
       } finally {
         if (isLeader) await releaseRoastLock(username, lang);

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -238,12 +238,13 @@ describe("scan route machine auth", () => {
       status: "pending",
       run: { id: "new-run" },
       retryAfterSeconds: 5,
-      shouldDrain: true,
+      headStartJobId: "new-job-id",
     });
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
     expect(response.status).toBe(202);
     expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("new-job-id");
   });
 });

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -110,8 +110,8 @@ async function durableResponse(input: {
     input.scan,
     input.admission,
   );
-  if (resolution.status === "pending" && resolution.shouldDrain) {
-    kickPublicScanDrain();
+  if (resolution.status === "pending" && resolution.headStartJobId) {
+    kickPublicScanDrain(resolution.headStartJobId);
   }
   if (resolution.status === "complete") {
     return NextResponse.json(

--- a/src/app/api/score/[username]/route.test.ts
+++ b/src/app/api/score/[username]/route.test.ts
@@ -139,7 +139,7 @@ describe("score durable scan guardrails", () => {
       status: "pending",
       run: { id: "active-run", username: "DemoDev" },
       retryAfterSeconds: 5,
-      shouldDrain: false,
+      headStartJobId: null,
     });
 
     const response = await request();
@@ -179,12 +179,13 @@ describe("score durable scan guardrails", () => {
       status: "pending",
       run: { id: "new-run", username: "DemoDev" },
       retryAfterSeconds: 5,
-      shouldDrain: true,
+      headStartJobId: "new-job-id",
     });
 
     const response = await request();
 
     expect(response.status).toBe(202);
     expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("new-job-id");
   });
 });

--- a/src/app/api/score/[username]/route.ts
+++ b/src/app/api/score/[username]/route.ts
@@ -259,8 +259,8 @@ export async function GET(
     if (durable.status === "complete") {
       result = durable.scan;
     } else {
-      if (durable.status === "pending" && durable.shouldDrain) {
-        kickPublicScanDrain();
+      if (durable.status === "pending" && durable.headStartJobId) {
+        kickPublicScanDrain(durable.headStartJobId);
       }
       return durableResponse(result.metrics.username, durable, { ...statusHeaders, ...rlHeaders });
     }

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -508,6 +508,149 @@ describe("durable public scan jobs", () => {
     ).resolves.toBe(true);
   });
 
+  it("releases a slot-blocked claim without changing attempt or schedule", async () => {
+    const queued = await enqueue("slot-release-fixture");
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    const before = await client.execute({
+      sql: `SELECT attempt_count, next_run_at FROM public_scan_jobs WHERE id = ?`,
+      args: [queued.job.id],
+    });
+    const firstLease = await claim(queued.job.id);
+
+    await expect(
+      db.releasePublicScanJobClaim({
+        jobId: queued.job.id,
+        runId: queued.run.id,
+        leaseToken: firstLease!.leaseToken,
+      }),
+    ).resolves.toBe(true);
+    const released = await client.execute({
+      sql: `SELECT state, attempt_count, next_run_at, lease_token, lease_expires_at
+            FROM public_scan_jobs WHERE id = ?`,
+      args: [queued.job.id],
+    });
+    expect(released.rows[0]).toMatchObject({
+      state: "queued",
+      attempt_count: before.rows[0]?.attempt_count,
+      next_run_at: before.rows[0]?.next_run_at,
+      lease_token: null,
+      lease_expires_at: null,
+    });
+    await expect(db.getPublicScanRun(queued.run.id)).resolves.toMatchObject({ state: "queued" });
+
+    const secondLease = await claim(queued.job.id);
+    expect(secondLease?.leaseToken).not.toBe(firstLease?.leaseToken);
+    await expect(
+      db.releasePublicScanJobClaim({
+        jobId: queued.job.id,
+        runId: queued.run.id,
+        leaseToken: firstLease!.leaseToken,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      db.failPublicScanJob({
+        jobId: queued.job.id,
+        runId: queued.run.id,
+        leaseToken: secondLease!.leaseToken,
+        error: "synthetic cleanup",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns aggregate queue, step, slot, obsolete, and Cron metrics only", async () => {
+    const canonical = await enqueue("metrics-canonical-fixture");
+    const obsoleteCollection = "obsolete-metrics-collection";
+    const obsolete = await db.enqueuePublicScan("metrics-obsolete-fixture", {
+      scoreVersion: "obsolete-score-fixture",
+      collectionVersion: obsoleteCollection,
+    });
+    if (!obsolete || "rejection" in obsolete) throw new Error("expected obsolete metrics fixture");
+
+    await expect(
+      db.recordPublicScanStepMetrics({
+        collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+        observations: [
+          { phase: "merged_prs", outcome: "continued", durationMs: 10 },
+          { phase: "merged_prs", outcome: "continued", durationMs: 30 },
+          { phase: "merged_prs", outcome: "failed_retrying", durationMs: 40 },
+          { phase: "quick", outcome: "slot_busy", durationMs: 5 },
+        ],
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      db.recordPublicScanCronMetrics({
+        startedAt: 1_000,
+        completedAt: 1_050,
+        processed: 2,
+        failedSteps: 1,
+        success: true,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      db.recordPublicScanCronMetrics({
+        startedAt: 2_000,
+        completedAt: 2_025,
+        processed: 0,
+        failedSteps: 0,
+        success: false,
+      }),
+    ).resolves.toBe(true);
+
+    const metrics = await db.getPublicScanOperationalMetrics(PUBLIC_SCAN_COLLECTION_VERSION);
+    expect(metrics).toMatchObject({
+      canonicalCollectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+      queue: {
+        depth: expect.any(Number),
+        queued: expect.any(Number),
+        running: expect.any(Number),
+        oldestAgeMs: expect.any(Number),
+      },
+      failures: { retryingSteps: 1, terminalSteps: 0 },
+      execution: { capacity: 1, contentionSteps: 1 },
+      obsoleteActiveJobs: expect.any(Number),
+      cron: {
+        lastStartedAt: 2_000,
+        lastSuccessAt: 1_050,
+        lastDurationMs: 25,
+        lastProcessed: 0,
+        consecutiveFailures: 1,
+      },
+    });
+    expect(metrics!.queue.depth).toBeGreaterThanOrEqual(1);
+    expect(metrics!.obsoleteActiveJobs).toBeGreaterThanOrEqual(1);
+    expect(metrics!.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "merged_prs",
+          outcome: "continued",
+          count: 2,
+          averageDurationMs: 20,
+          maxDurationMs: 30,
+        }),
+      ]),
+    );
+    const serialized = JSON.stringify(metrics);
+    expect(serialized).not.toContain("metrics-canonical-fixture");
+    expect(serialized).not.toContain("metrics-obsolete-fixture");
+    expect(serialized).not.toContain(canonical.job.id);
+    expect(serialized).not.toContain(obsolete.job.id);
+
+    const canonicalLease = await claim(canonical.job.id);
+    await db.failPublicScanJob({
+      jobId: canonical.job.id,
+      runId: canonical.run.id,
+      leaseToken: canonicalLease!.leaseToken,
+      error: "synthetic cleanup",
+    });
+    const obsoleteLease = await claim(obsolete.job.id, obsoleteCollection);
+    await db.failPublicScanJob({
+      jobId: obsolete.job.id,
+      runId: obsolete.run.id,
+      leaseToken: obsoleteLease!.leaseToken,
+      error: "synthetic cleanup",
+    });
+  });
+
   it("stores a complete v3 snapshot as historical data without aliasing it as current", async () => {
     const username = "previous-collection-fixture";
     const queued = await db.enqueuePublicScan(username, {
@@ -619,12 +762,16 @@ describe("durable public scan jobs", () => {
       jobId: one!.job.id,
       leaseToken: leaseOne!.leaseToken,
     });
-    await expect(
-      db.acquirePublicScanExecutionLease({
-        jobId: two!.job.id,
-        leaseToken: leaseTwo!.leaseToken,
-      }),
-    ).resolves.toBe(1);
+    const reacquiredSlot = await db.acquirePublicScanExecutionLease({
+      jobId: two!.job.id,
+      leaseToken: leaseTwo!.leaseToken,
+    });
+    expect(reacquiredSlot).toBe(1);
+    await db.releasePublicScanExecutionLease({
+      slot: reacquiredSlot!,
+      jobId: two!.job.id,
+      leaseToken: leaseTwo!.leaseToken,
+    });
 
     await expect(
       db.acquirePublicScanRateWindow({ bucket: "commit-search-test", limit: 2, windowMs: 60_000 }),
@@ -635,6 +782,57 @@ describe("durable public scan jobs", () => {
     await expect(
       db.acquirePublicScanRateWindow({ bucket: "commit-search-test", limit: 2, windowMs: 60_000 }),
     ).resolves.toMatchObject({ granted: false });
+  });
+
+  it("fails closed when a queued job has lost its durable run", async () => {
+    const queued = await enqueue("orphaned-job-fixture");
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: `DELETE FROM public_scan_runs WHERE id = ?`,
+      args: [queued.run.id],
+    });
+
+    try {
+      await expect(claim(queued.job.id)).rejects.toMatchObject({
+        name: "PublicScanStorageError",
+        operation: "claim_job",
+      });
+    } finally {
+      await client.execute({
+        sql: `DELETE FROM public_scan_jobs WHERE id = ?`,
+        args: [queued.job.id],
+      });
+    }
+  });
+
+  it("fails closed when the execution-slot singleton is missing", async () => {
+    const queued = await enqueue("missing-slot-fixture");
+    const lease = await claim(queued.job.id);
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute(`DELETE FROM public_scan_execution_leases WHERE slot = 1`);
+
+    try {
+      await expect(
+        db.acquirePublicScanExecutionLease({
+          jobId: queued.job.id,
+          leaseToken: lease!.leaseToken,
+        }),
+      ).rejects.toMatchObject({
+        name: "PublicScanStorageError",
+        operation: "acquire_execution_slot",
+      });
+    } finally {
+      await client.execute(
+        `INSERT OR IGNORE INTO public_scan_execution_leases (slot, lease_expires_at)
+         VALUES (1, 0)`,
+      );
+      await db.failPublicScanJob({
+        jobId: queued.job.id,
+        runId: queued.run.id,
+        leaseToken: lease!.leaseToken,
+        error: "synthetic cleanup",
+      });
+    }
   });
 
   it("carries commit-candidate fork metadata through verification and aggregation", async () => {

--- a/src/lib/__tests__/public-scan-dispatcher.test.ts
+++ b/src/lib/__tests__/public-scan-dispatcher.test.ts
@@ -2,47 +2,173 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   processPublicScanJob: vi.fn(),
+  recordPublicScanCronMetrics: vi.fn(),
+  recordPublicScanStepMetrics: vi.fn(),
 }));
 
 vi.mock("@/lib/public-scan-worker", () => ({
   processPublicScanJob: mocks.processPublicScanJob,
 }));
 
-import { drainPublicScanJobs } from "../public-scan-dispatcher";
+vi.mock("@/lib/db", () => ({
+  recordPublicScanCronMetrics: mocks.recordPublicScanCronMetrics,
+  recordPublicScanStepMetrics: mocks.recordPublicScanStepMetrics,
+}));
+
+import {
+  drainPublicScanJobs,
+  drainPublicScanJobsFromCron,
+} from "../public-scan-dispatcher";
 
 describe("public scan dispatcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.recordPublicScanCronMetrics.mockResolvedValue(true);
+    mocks.recordPublicScanStepMetrics.mockResolvedValue(true);
   });
 
-  it("drains server-side work until the durable queue is idle", async () => {
+  it("drains canonical Cron work until the durable queue is idle", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
     mocks.processPublicScanJob
-      .mockResolvedValueOnce({ status: "continued", jobId: "job-id", phase: "merged_prs" })
-      .mockResolvedValueOnce({ status: "complete", runId: "run-id" })
+      .mockResolvedValueOnce({
+        status: "continued",
+        jobId: "job-id",
+        runId: "run-id",
+        phase: "merged_prs",
+      })
+      .mockResolvedValueOnce({
+        status: "complete",
+        jobId: "job-id",
+        runId: "run-id",
+        phase: "publish",
+      })
       .mockResolvedValueOnce({ status: "idle" });
 
-    await expect(drainPublicScanJobs({ maxSteps: 8, maxDurationMs: 10_000 })).resolves.toEqual({
+    await expect(
+      drainPublicScanJobs({
+        maxSteps: 8,
+        maxDurationMs: 10_000,
+        source: "cron",
+      }),
+    ).resolves.toEqual({
       processed: 2,
       results: [
-        { status: "continued", jobId: "job-id", phase: "merged_prs" },
-        { status: "complete", runId: "run-id" },
+        { status: "continued", jobId: "job-id", runId: "run-id", phase: "merged_prs" },
+        { status: "complete", jobId: "job-id", runId: "run-id", phase: "publish" },
       ],
       exhaustedBudget: false,
     });
     expect(mocks.processPublicScanJob).toHaveBeenCalledTimes(3);
+    expect(mocks.processPublicScanJob).toHaveBeenNthCalledWith(1, undefined);
+    expect(mocks.recordPublicScanStepMetrics).toHaveBeenCalledWith({
+      collectionVersion: "v4",
+      observations: [
+        expect.objectContaining({ phase: "merged_prs", outcome: "continued" }),
+        expect.objectContaining({ phase: "publish", outcome: "complete" }),
+      ],
+    });
+    log.mockRestore();
   });
 
-  it("caps one invocation before it can monopolize server runtime", async () => {
+  it("caps one Cron invocation before it can monopolize server runtime", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
     mocks.processPublicScanJob.mockResolvedValue({
       status: "continued",
       jobId: "job-id",
+      runId: "run-id",
       phase: "merged_prs",
     });
 
-    await expect(drainPublicScanJobs({ maxSteps: 2, maxDurationMs: 10_000 })).resolves.toMatchObject({
-      processed: 2,
-      exhaustedBudget: true,
-    });
+    await expect(
+      drainPublicScanJobs({
+        maxSteps: 2,
+        maxDurationMs: 10_000,
+        source: "cron",
+      }),
+    ).resolves.toMatchObject({ processed: 2, exhaustedBudget: true });
     expect(mocks.processPublicScanJob).toHaveBeenCalledTimes(2);
+    log.mockRestore();
+  });
+
+  it("runs exactly one bounded step for the explicitly created request job", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    mocks.processPublicScanJob.mockResolvedValue({
+      status: "continued",
+      jobId: "target-job-id",
+      runId: "target-run-id",
+      phase: "original_repos",
+    });
+
+    await expect(
+      drainPublicScanJobs({
+        maxSteps: 24,
+        maxDurationMs: 50_000,
+        source: "request",
+        targetJobId: "target-job-id",
+      }),
+    ).resolves.toMatchObject({ processed: 1, exhaustedBudget: true });
+    expect(mocks.processPublicScanJob).toHaveBeenCalledOnce();
+    expect(mocks.processPublicScanJob).toHaveBeenCalledWith("target-job-id");
+    log.mockRestore();
+  });
+
+  it("stops a global drain after slot contention without counting a processed step", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    mocks.processPublicScanJob.mockResolvedValue({
+      status: "slot_busy",
+      jobId: "blocked-job-id",
+      runId: "blocked-run-id",
+      phase: "quick",
+    });
+
+    await expect(
+      drainPublicScanJobs({
+        maxSteps: 24,
+        maxDurationMs: 50_000,
+        source: "cron",
+      }),
+    ).resolves.toMatchObject({ processed: 0, exhaustedBudget: false });
+    expect(mocks.processPublicScanJob).toHaveBeenCalledOnce();
+    expect(mocks.recordPublicScanStepMetrics).toHaveBeenCalledWith({
+      collectionVersion: "v4",
+      observations: [expect.objectContaining({ phase: "quick", outcome: "slot_busy" })],
+    });
+    log.mockRestore();
+  });
+
+  it("records a successful Cron heartbeat even when the queue is empty", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    mocks.processPublicScanJob.mockResolvedValue({ status: "idle" });
+
+    await expect(drainPublicScanJobsFromCron()).resolves.toMatchObject({ processed: 0 });
+    expect(mocks.recordPublicScanCronMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ processed: 0, failedSteps: 0, success: true }),
+    );
+    log.mockRestore();
+  });
+
+  it("records a failed Cron heartbeat without logging the raw exception", async () => {
+    const rawMarker = "sensitive-upstream-marker";
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.processPublicScanJob.mockRejectedValue(new Error(rawMarker));
+
+    await expect(drainPublicScanJobsFromCron()).rejects.toThrow("public scan Cron drain failed");
+    expect(mocks.recordPublicScanCronMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+    expect(log.mock.calls.flat().join(" ")).not.toContain(rawMarker);
+    log.mockRestore();
+  });
+
+  it("fails Cron when its durable heartbeat cannot be persisted", async () => {
+    const rawMarker = "sensitive-metrics-marker";
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.processPublicScanJob.mockResolvedValue({ status: "idle" });
+    mocks.recordPublicScanCronMetrics.mockRejectedValue(new Error(rawMarker));
+
+    await expect(drainPublicScanJobsFromCron()).rejects.toThrow("public scan Cron drain failed");
+    expect(mocks.recordPublicScanCronMetrics).toHaveBeenCalledTimes(2);
+    expect(log.mock.calls.flat().join(" ")).not.toContain(rawMarker);
+    log.mockRestore();
   });
 });

--- a/src/lib/__tests__/public-scan-worker.test.ts
+++ b/src/lib/__tests__/public-scan-worker.test.ts
@@ -3,12 +3,19 @@ import { PUBLIC_SCAN_COLLECTION_VERSION } from "../scan-run-types";
 import type { ScanResult } from "../types";
 
 const mocks = vi.hoisted(() => ({
+  PublicScanStorageError: class PublicScanStorageError extends Error {
+    constructor(readonly operation: string) {
+      super("public scan storage unavailable");
+      this.name = "PublicScanStorageError";
+    }
+  },
   claimPublicScanJob: vi.fn(),
   acquirePublicScanExecutionLease: vi.fn(),
   getPublicScanRun: vi.fn(),
   savePublicScanQuickResult: vi.fn(),
   savePublicScanJobProgress: vi.fn(),
   releasePublicScanExecutionLease: vi.fn(),
+  releasePublicScanJobClaim: vi.fn(),
   buildScanResult: vi.fn(),
   fetchDurablePullRequestPage: vi.fn(),
   failPublicScanJob: vi.fn(),
@@ -17,6 +24,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/db", () => ({
+  PublicScanStorageError: mocks.PublicScanStorageError,
   acquirePublicScanExecutionLease: mocks.acquirePublicScanExecutionLease,
   acquirePublicScanRateWindow: vi.fn(),
   claimPublicScanJob: mocks.claimPublicScanJob,
@@ -38,6 +46,7 @@ vi.mock("@/lib/db", () => ({
   upsertPublicScanPrFacts: mocks.upsertPublicScanPrFacts,
   recordPublicScanCommitVerificationPage: vi.fn(),
   releasePublicScanExecutionLease: mocks.releasePublicScanExecutionLease,
+  releasePublicScanJobClaim: mocks.releasePublicScanJobClaim,
 }));
 
 vi.mock("@/lib/github", () => ({
@@ -92,6 +101,8 @@ describe("public scan worker", () => {
     mocks.buildScanResult.mockResolvedValue(quickScan);
     mocks.savePublicScanQuickResult.mockResolvedValue(true);
     mocks.savePublicScanJobProgress.mockResolvedValue(true);
+    mocks.failPublicScanJob.mockResolvedValue(true);
+    mocks.releasePublicScanJobClaim.mockResolvedValue(true);
     mocks.fetchDurablePullRequestPage.mockResolvedValue({ facts: [], hasNextPage: false, endCursor: null });
     mocks.upsertPublicScanPrFacts.mockResolvedValue(true);
     mocks.upsertPublicScanCommitRepoFacts.mockResolvedValue(true);
@@ -101,6 +112,7 @@ describe("public scan worker", () => {
     await expect(processPublicScanJob("job-id")).resolves.toEqual({
       status: "continued",
       jobId: "job-id",
+      runId: "run-id",
       phase: "original_repos",
     });
     expect(mocks.savePublicScanQuickResult).toHaveBeenCalledWith(
@@ -145,16 +157,86 @@ describe("public scan worker", () => {
     await expect(processPublicScanJob("obsolete-job-id")).resolves.toEqual({
       status: "failed",
       jobId: "obsolete-job-id",
+      runId: "obsolete-run-id",
+      phase: "quick",
+      retryScheduled: false,
     });
     expect(mocks.acquirePublicScanExecutionLease).not.toHaveBeenCalled();
     expect(mocks.buildScanResult).not.toHaveBeenCalled();
     expect(mocks.failPublicScanJob).toHaveBeenCalledWith(
       expect.objectContaining({
         jobId: "obsolete-job-id",
+        error: "worker_non_canonical",
         retryAt: undefined,
       }),
     );
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain("synthetic-worker-case");
     consoleError.mockRestore();
+  });
+
+  it("returns a slot-busy claim to the immediately ready queue", async () => {
+    mocks.acquirePublicScanExecutionLease.mockResolvedValue(null);
+
+    await expect(processPublicScanJob("job-id")).resolves.toEqual({
+      status: "slot_busy",
+      jobId: "job-id",
+      runId: "run-id",
+      phase: "quick",
+    });
+    expect(mocks.releasePublicScanJobClaim).toHaveBeenCalledWith({
+      jobId: "job-id",
+      runId: "run-id",
+      leaseToken: "lease-token",
+    });
+    expect(mocks.getPublicScanRun).not.toHaveBeenCalled();
+    expect(mocks.savePublicScanJobProgress).not.toHaveBeenCalled();
+    expect(mocks.buildScanResult).not.toHaveBeenCalled();
+  });
+
+  it("surfaces durable storage failures instead of reporting an idle queue", async () => {
+    mocks.claimPublicScanJob.mockRejectedValue(
+      new mocks.PublicScanStorageError("claim_job"),
+    );
+
+    await expect(processPublicScanJob("job-id")).rejects.toMatchObject({
+      name: "PublicScanStorageError",
+      operation: "claim_job",
+    });
+    expect(mocks.acquirePublicScanExecutionLease).not.toHaveBeenCalled();
+    expect(mocks.failPublicScanJob).not.toHaveBeenCalled();
+    expect(mocks.buildScanResult).not.toHaveBeenCalled();
+  });
+
+  it("allows only one synthetic concurrent job to reach GitHub work", async () => {
+    mocks.claimPublicScanJob.mockImplementation(async ({ jobId }: { jobId?: string }) => ({
+      leaseToken: `lease-${jobId}`,
+      job: {
+        id: jobId,
+        runId: `run-${jobId}`,
+        username: `synthetic-${jobId}`,
+        phase: "quick",
+        payload: "{}",
+        attemptCount: 0,
+        collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+      },
+    }));
+    mocks.acquirePublicScanExecutionLease
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(null);
+
+    const results = await Promise.all([
+      processPublicScanJob("job-a"),
+      processPublicScanJob("job-b"),
+    ]);
+
+    expect(results.map((result) => result.status).sort()).toEqual(["continued", "slot_busy"]);
+    expect(mocks.buildScanResult).toHaveBeenCalledOnce();
+    expect(mocks.releasePublicScanJobClaim).toHaveBeenCalledOnce();
+    expect(mocks.releasePublicScanJobClaim).toHaveBeenCalledWith({
+      jobId: "job-b",
+      runId: "run-job-b",
+      leaseToken: "lease-job-b",
+    });
   });
 
   it("persists successful contribution-graph commits before collecting complete PR history", async () => {
@@ -213,6 +295,7 @@ describe("public scan worker", () => {
     await expect(processPublicScanJob("job-id")).resolves.toEqual({
       status: "continued",
       jobId: "job-id",
+      runId: "run-id",
       phase: "publish",
     });
     expect(mocks.savePublicScanJobProgress).toHaveBeenCalledWith(

--- a/src/lib/__tests__/public-scan.test.ts
+++ b/src/lib/__tests__/public-scan.test.ts
@@ -129,7 +129,7 @@ describe("durable public scan admission", () => {
     await expect(resolvePublicScanFromTrustedQuickScan("durable-case", quick)).resolves.toMatchObject({
       status: "pending",
       run: { id: "run-id" },
-      shouldDrain: true,
+      headStartJobId: "job-id",
     });
     expect(mocks.seedPublicScanQuickResult).toHaveBeenCalledWith(
       expect.objectContaining({ jobId: "job-id", runId: "run-id" }),
@@ -228,7 +228,7 @@ describe("durable public scan admission", () => {
 
     await expect(startPublicScan("durable-case")).resolves.toMatchObject({
       status: "pending",
-      shouldDrain: false,
+      headStartJobId: null,
     });
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,9 +1,11 @@
 /**
  * Turso (libSQL) persistence for the leaderboard + percentile.
  *
- * Optional, like {@link ./redis}: if `TURSO_DATABASE_URL` is unset, every function
- * no-ops (returns null/empty) so the app runs fine without it. Stores one latest
- * row per scanned account plus append-only score snapshots for long-term progress.
+ * Optional, like {@link ./redis}: most passive persistence functions no-op when
+ * `TURSO_DATABASE_URL` is unset so the app can run without it. Durable public-scan
+ * worker operations are the exception: they fail closed so Cron health cannot
+ * report an unavailable queue as empty. Stores one latest row per scanned account
+ * plus append-only score snapshots for long-term progress.
  * The score itself is still computed deterministically by `lib/score.ts`; this
  * layer only persists the result for cross-account ranking.
  */
@@ -72,6 +74,7 @@ import type {
   PublicScanRun,
   PublicScanRunState,
   PublicScanSourceStatus,
+  PublicScanStepOutcome,
 } from "./scan-run-types";
 
 const EMPTY_TAGS: Tags = { zh: [], en: [] };
@@ -80,6 +83,35 @@ const PUBLIC_PROFILE_SCORE_VERSIONS = RELEASE_VERSION_MANIFEST.compatibility
 const HEAT_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const TRENDING_LOOKUP_WINDOW_MS = 7 * HEAT_LOOKUP_WINDOW_MS;
 const MIN_RECORDED_LOOKUP_COUNT = 1;
+
+function logPublicScanDbFailure(operation: string, error: unknown): void {
+  console.error(
+    "public_scan.db_failure",
+    JSON.stringify({
+      operation,
+      errorType: error instanceof Error ? error.constructor.name : "Unknown",
+    }),
+  );
+}
+
+export class PublicScanStorageError extends Error {
+  constructor(readonly operation: string) {
+    super("public scan storage unavailable");
+    this.name = "PublicScanStorageError";
+  }
+}
+
+function throwPublicScanStorageFailure(operation: string, error: unknown): never {
+  if (error instanceof PublicScanStorageError) throw error;
+  logPublicScanDbFailure(operation, error);
+  throw new PublicScanStorageError(operation);
+}
+
+function requirePublicScanDb(operation: string): Client {
+  const db = getClient();
+  if (!db) throwPublicScanStorageFailure(operation, new Error("DatabaseUnavailable"));
+  return db;
+}
 
 // User-selectable leaderboard time window. Every board shares one meaning: the
 // candidate pool is "accounts looked up within this window" (and the recent-heat
@@ -334,6 +366,26 @@ function ensureSchema(db: Client): Promise<void> {
              window_started   INTEGER NOT NULL,
              count            INTEGER NOT NULL DEFAULT 0,
              PRIMARY KEY(bucket, window_started)
+           )`,
+          `CREATE TABLE IF NOT EXISTS public_scan_step_metrics (
+             collection_version TEXT NOT NULL,
+             phase              TEXT NOT NULL,
+             outcome            TEXT NOT NULL CHECK(outcome IN ('continued', 'complete', 'failed_retrying', 'failed_terminal', 'slot_busy')),
+             step_count         INTEGER NOT NULL DEFAULT 0,
+             total_duration_ms  INTEGER NOT NULL DEFAULT 0,
+             max_duration_ms    INTEGER NOT NULL DEFAULT 0,
+             updated_at         INTEGER NOT NULL,
+             PRIMARY KEY(collection_version, phase, outcome)
+           )`,
+          `CREATE TABLE IF NOT EXISTS public_scan_cron_metrics (
+             singleton            INTEGER PRIMARY KEY CHECK(singleton = 1),
+             last_started_at       INTEGER,
+             last_success_at       INTEGER,
+             last_duration_ms      INTEGER,
+             last_processed        INTEGER NOT NULL DEFAULT 0,
+             last_failed_steps     INTEGER NOT NULL DEFAULT 0,
+             consecutive_failures  INTEGER NOT NULL DEFAULT 0,
+             updated_at            INTEGER NOT NULL
            )`,
           `CREATE TABLE IF NOT EXISTS public_scan_pr_facts (
              run_id             TEXT NOT NULL,
@@ -1189,7 +1241,7 @@ export async function enqueuePublicScan(
       throw error;
     }
   } catch (error) {
-    console.error("enqueuePublicScan failed:", error);
+    logPublicScanDbFailure("enqueue", error);
     return null;
   }
 }
@@ -1212,14 +1264,13 @@ export async function getLatestPublicScanRun(
     const row = result.rows[0];
     return row ? mapPublicScanRun(row as Record<string, unknown>) : null;
   } catch (error) {
-    console.error("getLatestPublicScanRun failed:", error);
+    logPublicScanDbFailure("get_latest_run", error);
     return null;
   }
 }
 
 export async function getPublicScanRun(runId: string): Promise<PublicScanRun | null> {
-  const db = getClient();
-  if (!db) return null;
+  const db = requirePublicScanDb("get_run");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -1230,8 +1281,7 @@ export async function getPublicScanRun(runId: string): Promise<PublicScanRun | n
       ? mapPublicScanRun(result.rows[0] as Record<string, unknown>)
       : null;
   } catch (error) {
-    console.error("getPublicScanRun failed:", error);
-    return null;
+    throwPublicScanStorageFailure("get_run", error);
   }
 }
 
@@ -1275,7 +1325,7 @@ export async function getPublicScanJobVersionSummary(): Promise<
       count: Number(row.count),
     }));
   } catch (error) {
-    console.error("getPublicScanJobVersionSummary failed:", error);
+    logPublicScanDbFailure("version_summary", error);
     return null;
   }
 }
@@ -1418,7 +1468,7 @@ export async function quarantineObsoletePublicScanJobs(input: {
       throw error;
     }
   } catch (error) {
-    console.error("quarantineObsoletePublicScanJobs failed:", error);
+    logPublicScanDbFailure("quarantine_obsolete", error);
     return null;
   }
 }
@@ -1435,8 +1485,7 @@ export async function claimPublicScanJob(
     leaseMs?: number;
   },
 ): Promise<PublicScanJobLease | null> {
-  const db = getClient();
-  if (!db) return null;
+  const db = requirePublicScanDb("claim_job");
   try {
     await ensureSchema(db);
     const now = Date.now();
@@ -1486,8 +1535,7 @@ export async function claimPublicScanJob(
         args: [leaseToken, leaseExpiresAt, now, candidateJob.id, input.collectionVersion],
       });
       if (Number(claimed.rowsAffected ?? 0) !== 1) {
-        await tx.rollback();
-        return null;
+        throw new Error("public scan claim candidate changed inside write transaction");
       }
       const run = await tx.execute({
         sql: `UPDATE public_scan_runs
@@ -1496,8 +1544,7 @@ export async function claimPublicScanJob(
         args: [now, candidateJob.runId, input.collectionVersion],
       });
       if (Number(run.rowsAffected ?? 0) !== 1) {
-        await tx.rollback();
-        return null;
+        throw new Error("public scan run missing while claiming job");
       }
       await tx.commit();
       return {
@@ -1515,8 +1562,54 @@ export async function claimPublicScanJob(
       throw error;
     }
   } catch (error) {
-    console.error("claimPublicScanJob failed:", error);
-    return null;
+    throwPublicScanStorageFailure("claim_job", error);
+  }
+}
+
+/**
+ * Return a claimed job to the ready queue when the process-wide execution slot
+ * is busy. The lease CAS prevents an old worker from releasing a newer claim;
+ * attempt_count and next_run_at are deliberately untouched so Cron can claim it
+ * immediately after capacity becomes available.
+ */
+export async function releasePublicScanJobClaim(input: {
+  jobId: string;
+  runId: string;
+  leaseToken: string;
+}): Promise<boolean> {
+  const db = requirePublicScanDb("release_claim");
+  try {
+    await ensureSchema(db);
+    const now = Date.now();
+    const tx = await db.transaction("write");
+    try {
+      const released = await tx.execute({
+        sql: `UPDATE public_scan_jobs
+              SET state = 'queued', lease_token = NULL, lease_expires_at = NULL, updated_at = ?
+              WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?`,
+        args: [now, input.jobId, input.runId, input.leaseToken],
+      });
+      if (Number(released.rowsAffected ?? 0) !== 1) {
+        await tx.rollback();
+        return false;
+      }
+      const run = await tx.execute({
+        sql: `UPDATE public_scan_runs
+              SET state = 'queued', updated_at = ?
+              WHERE id = ? AND state = 'running'`,
+        args: [now, input.runId],
+      });
+      if (Number(run.rowsAffected ?? 0) !== 1) {
+        throw new Error("public scan run missing while releasing claim");
+      }
+      await tx.commit();
+      return true;
+    } catch (error) {
+      await tx.rollback().catch(() => {});
+      throw error;
+    }
+  } catch (error) {
+    throwPublicScanStorageFailure("release_claim", error);
   }
 }
 
@@ -1532,8 +1625,7 @@ export async function acquirePublicScanExecutionLease(input: {
   leaseToken: string;
   leaseMs?: number;
 }): Promise<number | null> {
-  const db = getClient();
-  if (!db) return null;
+  const db = requirePublicScanDb("acquire_execution_slot");
   try {
     await ensureSchema(db);
     const now = Date.now();
@@ -1541,14 +1633,17 @@ export async function acquirePublicScanExecutionLease(input: {
     const tx = await db.transaction("write");
     try {
       const candidate = await tx.execute({
-        sql: `SELECT slot FROM public_scan_execution_leases
-              WHERE lease_expires_at <= ?
-              ORDER BY slot
+        sql: `SELECT slot, lease_expires_at
+              FROM public_scan_execution_leases
+              WHERE slot = 1
               LIMIT 1`,
-        args: [now],
+        args: [],
       });
       const slot = candidate.rows[0]?.slot;
       if (typeof slot !== "number") {
+        throw new Error("public scan execution slot is missing");
+      }
+      if (Number(candidate.rows[0]?.lease_expires_at ?? 0) > now) {
         await tx.rollback();
         return null;
       }
@@ -1559,8 +1654,7 @@ export async function acquirePublicScanExecutionLease(input: {
         args: [input.jobId, input.leaseToken, leaseExpiresAt, slot, now],
       });
       if (Number(update.rowsAffected ?? 0) !== 1) {
-        await tx.rollback();
-        return null;
+        throw new Error("public scan execution slot changed inside write transaction");
       }
       await tx.commit();
       return slot;
@@ -1569,8 +1663,7 @@ export async function acquirePublicScanExecutionLease(input: {
       throw error;
     }
   } catch (error) {
-    console.error("acquirePublicScanExecutionLease failed:", error);
-    return null;
+    throwPublicScanStorageFailure("acquire_execution_slot", error);
   }
 }
 
@@ -1579,8 +1672,7 @@ export async function releasePublicScanExecutionLease(input: {
   jobId: string;
   leaseToken: string;
 }): Promise<void> {
-  const db = getClient();
-  if (!db) return;
+  const db = requirePublicScanDb("release_execution_slot");
   try {
     await ensureSchema(db);
     await db.execute({
@@ -1590,7 +1682,7 @@ export async function releasePublicScanExecutionLease(input: {
       args: [input.slot, input.jobId, input.leaseToken],
     });
   } catch (error) {
-    console.error("releasePublicScanExecutionLease failed:", error);
+    throwPublicScanStorageFailure("release_execution_slot", error);
   }
 }
 
@@ -1604,12 +1696,11 @@ export async function acquirePublicScanRateWindow(input: {
   limit: number;
   windowMs: number;
 }): Promise<{ granted: boolean; retryAt: number }> {
-  const db = getClient();
   const now = Date.now();
   const safeWindow = Math.max(1_000, Math.floor(input.windowMs));
   const startedAt = Math.floor(now / safeWindow) * safeWindow;
   const retryAt = startedAt + safeWindow;
-  if (!db) return { granted: false, retryAt };
+  const db = requirePublicScanDb("acquire_rate_window");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -1622,8 +1713,307 @@ export async function acquirePublicScanRateWindow(input: {
     // `rowsAffected` is 0 when a full existing window rejected the increment.
     return { granted: Number(result.rowsAffected ?? 0) === 1, retryAt };
   } catch (error) {
-    console.error("acquirePublicScanRateWindow failed:", error);
-    return { granted: false, retryAt };
+    throwPublicScanStorageFailure("acquire_rate_window", error);
+  }
+}
+
+export interface PublicScanStepObservation {
+  phase: PublicScanJobPhase;
+  outcome: PublicScanStepOutcome;
+  durationMs: number;
+}
+
+/** Persist aggregate-only worker observations; job and account IDs never enter this table. */
+export async function recordPublicScanStepMetrics(input: {
+  collectionVersion: string;
+  observations: PublicScanStepObservation[];
+}): Promise<boolean> {
+  if (input.observations.length === 0) return true;
+  const db = requirePublicScanDb("metrics_write");
+  const aggregated = new Map<
+    string,
+    { phase: PublicScanJobPhase; outcome: PublicScanStepOutcome; count: number; total: number; max: number }
+  >();
+  for (const observation of input.observations) {
+    const duration = Number.isFinite(observation.durationMs)
+      ? Math.max(0, Math.floor(observation.durationMs))
+      : 0;
+    const key = `${observation.phase}\0${observation.outcome}`;
+    const current = aggregated.get(key);
+    if (current) {
+      current.count += 1;
+      current.total += duration;
+      current.max = Math.max(current.max, duration);
+    } else {
+      aggregated.set(key, {
+        phase: observation.phase,
+        outcome: observation.outcome,
+        count: 1,
+        total: duration,
+        max: duration,
+      });
+    }
+  }
+  try {
+    await ensureSchema(db);
+    const now = Date.now();
+    const tx = await db.transaction("write");
+    try {
+      for (const metric of aggregated.values()) {
+        await tx.execute({
+          sql: `INSERT INTO public_scan_step_metrics
+                  (collection_version, phase, outcome, step_count, total_duration_ms, max_duration_ms, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(collection_version, phase, outcome) DO UPDATE SET
+                  step_count = public_scan_step_metrics.step_count + excluded.step_count,
+                  total_duration_ms = public_scan_step_metrics.total_duration_ms + excluded.total_duration_ms,
+                  max_duration_ms = MAX(public_scan_step_metrics.max_duration_ms, excluded.max_duration_ms),
+                  updated_at = excluded.updated_at`,
+          args: [
+            input.collectionVersion,
+            metric.phase,
+            metric.outcome,
+            metric.count,
+            metric.total,
+            metric.max,
+            now,
+          ],
+        });
+      }
+      await tx.commit();
+      return true;
+    } catch (error) {
+      await tx.rollback().catch(() => {});
+      throw error;
+    }
+  } catch (error) {
+    throwPublicScanStorageFailure("metrics_write", error);
+  }
+}
+
+export async function recordPublicScanCronMetrics(input: {
+  startedAt: number;
+  completedAt: number;
+  processed: number;
+  failedSteps: number;
+  success: boolean;
+}): Promise<boolean> {
+  const db = requirePublicScanDb("cron_metrics_write");
+  try {
+    await ensureSchema(db);
+    const durationMs = Math.max(0, Math.floor(input.completedAt - input.startedAt));
+    const values = [
+      1,
+      input.startedAt,
+      input.success ? input.completedAt : null,
+      durationMs,
+      Math.max(0, Math.floor(input.processed)),
+      Math.max(0, Math.floor(input.failedSteps)),
+      input.success ? 0 : 1,
+      input.completedAt,
+    ];
+    await db.execute({
+      sql: `INSERT INTO public_scan_cron_metrics
+              (singleton, last_started_at, last_success_at, last_duration_ms,
+               last_processed, last_failed_steps, consecutive_failures, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(singleton) DO UPDATE SET
+              last_started_at = excluded.last_started_at,
+              last_success_at = CASE WHEN ? = 1
+                                     THEN excluded.last_success_at
+                                     ELSE public_scan_cron_metrics.last_success_at END,
+              last_duration_ms = excluded.last_duration_ms,
+              last_processed = excluded.last_processed,
+              last_failed_steps = excluded.last_failed_steps,
+              consecutive_failures = CASE WHEN ? = 1
+                                          THEN 0
+                                          ELSE public_scan_cron_metrics.consecutive_failures + 1 END,
+              updated_at = excluded.updated_at`,
+      args: [...values, input.success ? 1 : 0, input.success ? 1 : 0],
+    });
+    return true;
+  } catch (error) {
+    throwPublicScanStorageFailure("cron_metrics_write", error);
+  }
+}
+
+export interface PublicScanOperationalMetrics {
+  generatedAt: number;
+  canonicalCollectionVersion: string;
+  queue: {
+    depth: number;
+    queued: number;
+    running: number;
+    ready: number;
+    deferred: number;
+    retrying: number;
+    oldestAgeMs: number | null;
+    byPhase: Array<{ phase: string; queued: number; running: number }>;
+  };
+  failures: {
+    currentFailedJobs: number;
+    retryingSteps: number;
+    terminalSteps: number;
+  };
+  execution: {
+    activeSlots: number;
+    capacity: number;
+    contentionSteps: number;
+  };
+  obsoleteActiveJobs: number;
+  steps: Array<{
+    phase: string;
+    outcome: PublicScanStepOutcome;
+    count: number;
+    averageDurationMs: number;
+    maxDurationMs: number;
+  }>;
+  cron: {
+    lastStartedAt: number | null;
+    lastSuccessAt: number | null;
+    lastDurationMs: number | null;
+    lastProcessed: number;
+    lastFailedSteps: number;
+    consecutiveFailures: number;
+  };
+}
+
+/** Aggregate operational state for the authenticated release-operations endpoint. */
+export async function getPublicScanOperationalMetrics(
+  canonicalCollectionVersion: string,
+): Promise<PublicScanOperationalMetrics | null> {
+  const db = getClient();
+  if (!db) return null;
+  try {
+    await ensureSchema(db);
+    const now = Date.now();
+    const [active, failureState, obsolete, slots, steps, cron] = await db.batch(
+      [
+        {
+          sql: `SELECT state, phase, COUNT(*) AS count, MIN(created_at) AS oldest_created_at,
+                       SUM(CASE WHEN state = 'queued' AND next_run_at <= ? THEN 1 ELSE 0 END) AS ready_count,
+                       SUM(CASE WHEN state = 'queued' AND next_run_at > ? THEN 1 ELSE 0 END) AS deferred_count
+                FROM public_scan_jobs
+                WHERE collection_version = ? AND state IN ('queued', 'running')
+                GROUP BY state, phase`,
+          args: [now, now, canonicalCollectionVersion],
+        },
+        {
+          sql: `SELECT
+                  SUM(CASE WHEN state = 'failed' THEN 1 ELSE 0 END) AS failed_jobs,
+                  SUM(CASE WHEN state = 'queued' AND attempt_count > 0 THEN 1 ELSE 0 END) AS retrying_jobs
+                FROM public_scan_jobs
+                WHERE collection_version = ?`,
+          args: [canonicalCollectionVersion],
+        },
+        {
+          sql: `SELECT COUNT(*) AS count
+                FROM public_scan_jobs
+                WHERE collection_version <> ? AND state IN ('queued', 'running')`,
+          args: [canonicalCollectionVersion],
+        },
+        {
+          sql: `SELECT COUNT(*) AS count
+                FROM public_scan_execution_leases
+                WHERE lease_expires_at > ?`,
+          args: [now],
+        },
+        {
+          sql: `SELECT phase, outcome, step_count, total_duration_ms, max_duration_ms
+                FROM public_scan_step_metrics
+                WHERE collection_version = ?
+                ORDER BY phase, outcome`,
+          args: [canonicalCollectionVersion],
+        },
+        {
+          sql: `SELECT last_started_at, last_success_at, last_duration_ms, last_processed,
+                       last_failed_steps, consecutive_failures
+                FROM public_scan_cron_metrics
+                WHERE singleton = 1`,
+          args: [],
+        },
+      ],
+      "read",
+    );
+    const phases = new Map<string, { phase: string; queued: number; running: number }>();
+    let queued = 0;
+    let running = 0;
+    let ready = 0;
+    let deferred = 0;
+    let oldestCreatedAt: number | null = null;
+    for (const row of active.rows) {
+      const phase = String(row.phase);
+      const count = Number(row.count ?? 0);
+      const item = phases.get(phase) ?? { phase, queued: 0, running: 0 };
+      if (row.state === "queued") {
+        item.queued += count;
+        queued += count;
+        ready += Number(row.ready_count ?? 0);
+        deferred += Number(row.deferred_count ?? 0);
+      } else if (row.state === "running") {
+        item.running += count;
+        running += count;
+      }
+      phases.set(phase, item);
+      const candidate = Number(row.oldest_created_at);
+      if (Number.isFinite(candidate)) {
+        oldestCreatedAt = oldestCreatedAt === null ? candidate : Math.min(oldestCreatedAt, candidate);
+      }
+    }
+    const stepMetrics = steps.rows.map((row) => {
+      const count = Math.max(0, Number(row.step_count ?? 0));
+      const total = Math.max(0, Number(row.total_duration_ms ?? 0));
+      return {
+        phase: String(row.phase),
+        outcome: String(row.outcome) as PublicScanStepOutcome,
+        count,
+        averageDurationMs: count > 0 ? Math.round(total / count) : 0,
+        maxDurationMs: Math.max(0, Number(row.max_duration_ms ?? 0)),
+      };
+    });
+    const countOutcome = (outcome: PublicScanStepOutcome) =>
+      stepMetrics
+        .filter((metric) => metric.outcome === outcome)
+        .reduce((total, metric) => total + metric.count, 0);
+    const failureRow = failureState.rows[0];
+    const cronRow = cron.rows[0];
+    return {
+      generatedAt: now,
+      canonicalCollectionVersion,
+      queue: {
+        depth: queued + running,
+        queued,
+        running,
+        ready,
+        deferred,
+        retrying: Number(failureRow?.retrying_jobs ?? 0),
+        oldestAgeMs: oldestCreatedAt === null ? null : Math.max(0, now - oldestCreatedAt),
+        byPhase: [...phases.values()].sort((left, right) => left.phase.localeCompare(right.phase)),
+      },
+      failures: {
+        currentFailedJobs: Number(failureRow?.failed_jobs ?? 0),
+        retryingSteps: countOutcome("failed_retrying"),
+        terminalSteps: countOutcome("failed_terminal"),
+      },
+      execution: {
+        activeSlots: Number(slots.rows[0]?.count ?? 0),
+        capacity: 1,
+        contentionSteps: countOutcome("slot_busy"),
+      },
+      obsoleteActiveJobs: Number(obsolete.rows[0]?.count ?? 0),
+      steps: stepMetrics,
+      cron: {
+        lastStartedAt: cronRow?.last_started_at == null ? null : Number(cronRow.last_started_at),
+        lastSuccessAt: cronRow?.last_success_at == null ? null : Number(cronRow.last_success_at),
+        lastDurationMs: cronRow?.last_duration_ms == null ? null : Number(cronRow.last_duration_ms),
+        lastProcessed: Number(cronRow?.last_processed ?? 0),
+        lastFailedSteps: Number(cronRow?.last_failed_steps ?? 0),
+        consecutiveFailures: Number(cronRow?.consecutive_failures ?? 0),
+      },
+    };
+  } catch {
+    console.error("public_scan.metrics_read_failed");
+    return null;
   }
 }
 
@@ -1636,40 +2026,51 @@ export async function savePublicScanJobProgress(input: {
   sourceStatus?: PublicScanSourceStatus;
   nextRunAt?: number;
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("save_job_progress");
   try {
     await ensureSchema(db);
     const now = Date.now();
     const nextRunAt = input.nextRunAt ?? now;
-    const update = await db.execute({
-      sql: `UPDATE public_scan_jobs
-            SET state = 'queued', phase = ?, payload = ?, next_run_at = ?,
-                lease_token = NULL, lease_expires_at = NULL, updated_at = ?
-            WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?
-              AND lease_expires_at > ?`,
-      args: [
-        input.phase,
-        input.payload,
-        nextRunAt,
-        now,
-        input.jobId,
-        input.runId,
-        input.leaseToken,
-        now,
-      ],
-    });
-    if (Number(update.rowsAffected ?? 0) !== 1) return false;
-    if (input.sourceStatus) {
-      await db.execute({
-        sql: `UPDATE public_scan_runs SET source_status = ?, updated_at = ? WHERE id = ?`,
-        args: [JSON.stringify(input.sourceStatus), now, input.runId],
+    const tx = await db.transaction("write");
+    try {
+      const update = await tx.execute({
+        sql: `UPDATE public_scan_jobs
+              SET state = 'queued', phase = ?, payload = ?, next_run_at = ?,
+                  lease_token = NULL, lease_expires_at = NULL, updated_at = ?
+              WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?
+                AND lease_expires_at > ?`,
+        args: [
+          input.phase,
+          input.payload,
+          nextRunAt,
+          now,
+          input.jobId,
+          input.runId,
+          input.leaseToken,
+          now,
+        ],
       });
+      if (Number(update.rowsAffected ?? 0) !== 1) {
+        await tx.rollback();
+        return false;
+      }
+      if (input.sourceStatus) {
+        const run = await tx.execute({
+          sql: `UPDATE public_scan_runs SET source_status = ?, updated_at = ? WHERE id = ?`,
+          args: [JSON.stringify(input.sourceStatus), now, input.runId],
+        });
+        if (Number(run.rowsAffected ?? 0) !== 1) {
+          throw new Error("public scan run missing while saving progress");
+        }
+      }
+      await tx.commit();
+      return true;
+    } catch (error) {
+      await tx.rollback().catch(() => {});
+      throw error;
     }
-    return true;
   } catch (error) {
-    console.error("savePublicScanJobProgress failed:", error);
-    return false;
+    throwPublicScanStorageFailure("save_job_progress", error);
   }
 }
 
@@ -1680,27 +2081,39 @@ export async function savePublicScanQuickResult(input: {
   quickScan: string;
   sourceStatus: PublicScanSourceStatus;
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("save_quick_result");
   try {
     await ensureSchema(db);
-    const job = await db.execute({
-      sql: `SELECT id FROM public_scan_jobs
-            WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?
-              AND lease_expires_at > ?`,
-      args: [input.jobId, input.runId, input.leaseToken, Date.now()],
-    });
-    if (!job.rows[0]) return false;
-    await db.execute({
-      sql: `UPDATE public_scan_runs
-            SET quick_scan = ?, source_status = ?, updated_at = ?, last_error = NULL
-            WHERE id = ?`,
-      args: [input.quickScan, JSON.stringify(input.sourceStatus), Date.now(), input.runId],
-    });
-    return true;
+    const tx = await db.transaction("write");
+    try {
+      const now = Date.now();
+      const job = await tx.execute({
+        sql: `SELECT id FROM public_scan_jobs
+              WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?
+                AND lease_expires_at > ?`,
+        args: [input.jobId, input.runId, input.leaseToken, now],
+      });
+      if (!job.rows[0]) {
+        await tx.rollback();
+        return false;
+      }
+      const run = await tx.execute({
+        sql: `UPDATE public_scan_runs
+              SET quick_scan = ?, source_status = ?, updated_at = ?, last_error = NULL
+              WHERE id = ?`,
+        args: [input.quickScan, JSON.stringify(input.sourceStatus), now, input.runId],
+      });
+      if (Number(run.rowsAffected ?? 0) !== 1) {
+        throw new Error("public scan run missing while saving quick result");
+      }
+      await tx.commit();
+      return true;
+    } catch (error) {
+      await tx.rollback().catch(() => {});
+      throw error;
+    }
   } catch (error) {
-    console.error("savePublicScanQuickResult failed:", error);
-    return false;
+    throwPublicScanStorageFailure("save_quick_result", error);
   }
 }
 
@@ -1745,7 +2158,7 @@ export async function seedPublicScanQuickResult(input: {
       throw error;
     }
   } catch (error) {
-    console.error("seedPublicScanQuickResult failed:", error);
+    logPublicScanDbFailure("seed_quick_result", error);
     return false;
   }
 }
@@ -1767,8 +2180,7 @@ export async function completePublicScanRun(input: {
   ) {
     return false;
   }
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("complete_run");
   try {
     await ensureSchema(db);
     const tx = await db.transaction("write");
@@ -1815,8 +2227,7 @@ export async function completePublicScanRun(input: {
       throw error;
     }
   } catch (error) {
-    console.error("completePublicScanRun failed:", error);
-    return false;
+    throwPublicScanStorageFailure("complete_run", error);
   }
 }
 
@@ -1827,38 +2238,49 @@ export async function failPublicScanJob(input: {
   error: string;
   retryAt?: number;
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("fail_job");
   try {
     await ensureSchema(db);
     const now = Date.now();
     const retry = input.retryAt != null;
-    const update = await db.execute({
-      sql: `UPDATE public_scan_jobs
-            SET state = ?, attempt_count = attempt_count + 1, next_run_at = ?,
-                lease_token = NULL, lease_expires_at = NULL, updated_at = ?
-            WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?
-              AND lease_expires_at > ?`,
-      args: [
-        retry ? "queued" : "failed",
-        input.retryAt ?? now,
-        now,
-        input.jobId,
-        input.runId,
-        input.leaseToken,
-        now,
-      ],
-    });
-    if (Number(update.rowsAffected ?? 0) !== 1) return false;
-    await db.execute({
-      sql: `UPDATE public_scan_runs
-            SET state = ?, updated_at = ?, last_error = ? WHERE id = ?`,
-      args: [retry ? "queued" : "failed", now, input.error.slice(0, 2_000), input.runId],
-    });
-    return true;
+    const tx = await db.transaction("write");
+    try {
+      const update = await tx.execute({
+        sql: `UPDATE public_scan_jobs
+              SET state = ?, attempt_count = attempt_count + 1, next_run_at = ?,
+                  lease_token = NULL, lease_expires_at = NULL, updated_at = ?
+              WHERE id = ? AND run_id = ? AND state = 'running' AND lease_token = ?
+                AND lease_expires_at > ?`,
+        args: [
+          retry ? "queued" : "failed",
+          input.retryAt ?? now,
+          now,
+          input.jobId,
+          input.runId,
+          input.leaseToken,
+          now,
+        ],
+      });
+      if (Number(update.rowsAffected ?? 0) !== 1) {
+        await tx.rollback();
+        return false;
+      }
+      const run = await tx.execute({
+        sql: `UPDATE public_scan_runs
+              SET state = ?, updated_at = ?, last_error = ? WHERE id = ?`,
+        args: [retry ? "queued" : "failed", now, input.error.slice(0, 2_000), input.runId],
+      });
+      if (Number(run.rowsAffected ?? 0) !== 1) {
+        throw new Error("public scan run missing while recording failure");
+      }
+      await tx.commit();
+      return true;
+    } catch (error) {
+      await tx.rollback().catch(() => {});
+      throw error;
+    }
   } catch (error) {
-    console.error("failPublicScanJob failed:", error);
-    return false;
+    throwPublicScanStorageFailure("fail_job", error);
   }
 }
 
@@ -1887,8 +2309,7 @@ export async function upsertPublicScanPrFacts(input: {
   facts: PublicScanPrFact[];
 }): Promise<boolean> {
   if (input.facts.length === 0) return true;
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("upsert_pr_facts");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -1937,8 +2358,7 @@ export async function upsertPublicScanPrFacts(input: {
     );
     return true;
   } catch (error) {
-    console.error("upsertPublicScanPrFacts failed:", error);
-    return false;
+    throwPublicScanStorageFailure("upsert_pr_facts", error);
   }
 }
 
@@ -1950,8 +2370,7 @@ export async function upsertPublicScanCommitRepoFacts(input: {
   facts: PublicScanCommitRepoFact[];
 }): Promise<boolean> {
   if (input.facts.length === 0) return true;
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("upsert_commit_repo_facts");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -1999,8 +2418,7 @@ export async function upsertPublicScanCommitRepoFacts(input: {
     );
     return true;
   } catch (error) {
-    console.error("upsertPublicScanCommitRepoFacts failed:", error);
-    return false;
+    throwPublicScanStorageFailure("upsert_commit_repo_facts", error);
   }
 }
 
@@ -2011,8 +2429,7 @@ export async function upsertPublicScanCommitCandidates(input: {
   candidates: PublicScanCommitCandidate[];
 }): Promise<boolean> {
   if (input.candidates.length === 0) return true;
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("upsert_commit_candidates");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -2042,8 +2459,7 @@ export async function upsertPublicScanCommitCandidates(input: {
     );
     return true;
   } catch (error) {
-    console.error("upsertPublicScanCommitCandidates failed:", error);
-    return false;
+    throwPublicScanStorageFailure("upsert_commit_candidates", error);
   }
 }
 
@@ -2054,8 +2470,7 @@ export async function upsertPublicScanOwnedRepoFacts(input: {
   facts: PublicScanOwnedRepoFact[];
 }): Promise<boolean> {
   if (input.facts.length === 0) return true;
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("upsert_owned_repo_facts");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -2095,14 +2510,12 @@ export async function upsertPublicScanOwnedRepoFacts(input: {
     );
     return true;
   } catch (error) {
-    console.error("upsertPublicScanOwnedRepoFacts failed:", error);
-    return false;
+    throwPublicScanStorageFailure("upsert_owned_repo_facts", error);
   }
 }
 
 export async function getPublicScanOwnedRepoFacts(runId: string): Promise<PublicScanOwnedRepoFact[]> {
-  const db = getClient();
-  if (!db) return [];
+  const db = requirePublicScanDb("get_owned_repo_facts");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -2138,8 +2551,7 @@ export async function getPublicScanOwnedRepoFacts(runId: string): Promise<Public
       };
     });
   } catch (error) {
-    console.error("getPublicScanOwnedRepoFacts failed:", error);
-    return [];
+    throwPublicScanStorageFailure("get_owned_repo_facts", error);
   }
 }
 
@@ -2149,8 +2561,7 @@ export async function preparePublicScanCommitVerificationWork(input: {
   runId: string;
   leaseToken: string;
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("prepare_commit_verification");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -2173,8 +2584,7 @@ export async function preparePublicScanCommitVerificationWork(input: {
     });
     return true;
   } catch (error) {
-    console.error("preparePublicScanCommitVerificationWork failed:", error);
-    return false;
+    throwPublicScanStorageFailure("prepare_commit_verification", error);
   }
 }
 
@@ -2234,8 +2644,7 @@ function mapPublicScanCommitVerificationWork(
 export async function getNextPublicScanCommitVerificationWork(
   runId: string,
 ): Promise<PublicScanCommitVerificationWork | null> {
-  const db = getClient();
-  if (!db) return null;
+  const db = requirePublicScanDb("get_commit_verification");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -2249,8 +2658,7 @@ export async function getNextPublicScanCommitVerificationWork(
       ? mapPublicScanCommitVerificationWork(result.rows[0] as Record<string, unknown>)
       : null;
   } catch (error) {
-    console.error("getNextPublicScanCommitVerificationWork failed:", error);
-    return null;
+    throwPublicScanStorageFailure("get_commit_verification", error);
   }
 }
 
@@ -2267,8 +2675,7 @@ export async function recordPublicScanCommitVerificationPage(input: {
   commits: { sha: string; committedAt: string | null }[];
   complete: boolean;
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("record_commit_verification");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -2326,8 +2733,7 @@ export async function recordPublicScanCommitVerificationPage(input: {
     });
     return Number(update.rowsAffected ?? 0) === 1;
   } catch (error) {
-    console.error("recordPublicScanCommitVerificationPage failed:", error);
-    return false;
+    throwPublicScanStorageFailure("record_commit_verification", error);
   }
 }
 
@@ -2339,8 +2745,7 @@ export async function splitPublicScanCommitVerificationWork(input: {
   left: { from: string; to: string };
   right: { from: string; to: string };
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("split_commit_verification");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -2381,8 +2786,7 @@ export async function splitPublicScanCommitVerificationWork(input: {
       throw error;
     }
   } catch (error) {
-    console.error("splitPublicScanCommitVerificationWork failed:", error);
-    return false;
+    throwPublicScanStorageFailure("split_commit_verification", error);
   }
 }
 
@@ -2392,8 +2796,7 @@ export async function materializePublicScanCommitRepoFacts(input: {
   runId: string;
   leaseToken: string;
 }): Promise<boolean> {
-  const db = getClient();
-  if (!db) return false;
+  const db = requirePublicScanDb("materialize_commit_facts");
   try {
     await ensureSchema(db);
     if (!(await hasPublicScanLease(db, input))) return false;
@@ -2442,8 +2845,7 @@ export async function materializePublicScanCommitRepoFacts(input: {
     });
     return true;
   } catch (error) {
-    console.error("materializePublicScanCommitRepoFacts failed:", error);
-    return false;
+    throwPublicScanStorageFailure("materialize_commit_facts", error);
   }
 }
 
@@ -2468,8 +2870,7 @@ export async function getPublicScanPrSummary(
   runId: string,
   username: string,
 ): Promise<PublicScanPrSummary> {
-  const db = getClient();
-  if (!db) return { nativeMergedPrs: 0, workflowLandedPrs: 0, workflowLandedImpactPrs: 0 };
+  const db = requirePublicScanDb("get_pr_summary");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -2492,14 +2893,12 @@ export async function getPublicScanPrSummary(
       workflowLandedImpactPrs: Number(row?.workflow_landed_impact_prs) || 0,
     };
   } catch (error) {
-    console.error("getPublicScanPrSummary failed:", error);
-    return { nativeMergedPrs: 0, workflowLandedPrs: 0, workflowLandedImpactPrs: 0 };
+    throwPublicScanStorageFailure("get_pr_summary", error);
   }
 }
 
 export async function getPublicScanSignaturePrFacts(runId: string): Promise<PublicScanPrFact[]> {
-  const db = getClient();
-  if (!db) return [];
+  const db = requirePublicScanDb("get_signature_pr_facts");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -2553,8 +2952,7 @@ export async function getPublicScanSignaturePrFacts(runId: string): Promise<Publ
       };
     });
   } catch (error) {
-    console.error("getPublicScanSignaturePrFacts failed:", error);
-    return [];
+    throwPublicScanStorageFailure("get_signature_pr_facts", error);
   }
 }
 
@@ -2566,8 +2964,7 @@ export async function getPublicScanSignaturePrFacts(runId: string): Promise<Publ
 export async function getPublicScanContributionAggregates(
   runId: string,
 ): Promise<PublicScanContributionAggregate[]> {
-  const db = getClient();
-  if (!db) return [];
+  const db = requirePublicScanDb("get_contribution_aggregates");
   try {
     await ensureSchema(db);
     const result = await db.execute({
@@ -2630,8 +3027,7 @@ export async function getPublicScanContributionAggregates(
       };
     });
   } catch (error) {
-    console.error("getPublicScanContributionAggregates failed:", error);
-    return [];
+    throwPublicScanStorageFailure("get_contribution_aggregates", error);
   }
 }
 

--- a/src/lib/public-scan-dispatcher.ts
+++ b/src/lib/public-scan-dispatcher.ts
@@ -1,5 +1,11 @@
 import { after } from "next/server";
+import {
+  recordPublicScanCronMetrics,
+  recordPublicScanStepMetrics,
+  type PublicScanStepObservation,
+} from "./db";
 import { processPublicScanJob, type PublicScanWorkerResult } from "./public-scan-worker";
+import { PUBLIC_SCAN_COLLECTION_VERSION, type PublicScanStepOutcome } from "./scan-run-types";
 
 // A response-side head start is optional acceleration only. Keep it to one
 // bounded unit so a high-history scan cannot make the initiating public API
@@ -15,6 +21,34 @@ export interface PublicScanDrainResult {
   exhaustedBudget: boolean;
 }
 
+type PublicScanDrainSource = "request" | "cron";
+
+function stepOutcome(result: Exclude<PublicScanWorkerResult, { status: "idle" }>): PublicScanStepOutcome {
+  if (result.status === "failed") {
+    return result.retryScheduled ? "failed_retrying" : "failed_terminal";
+  }
+  return result.status;
+}
+
+function logStep(
+  source: PublicScanDrainSource,
+  result: Exclude<PublicScanWorkerResult, { status: "idle" }>,
+  durationMs: number,
+): void {
+  console.info(
+    "public_scan.step",
+    JSON.stringify({
+      source,
+      status: result.status,
+      jobId: result.jobId,
+      runId: result.runId,
+      phase: result.phase,
+      durationMs,
+      ...(result.status === "failed" ? { retryScheduled: result.retryScheduled } : {}),
+    }),
+  );
+}
+
 /**
  * Drain short, leased units from the Turso-backed queue. There is intentionally
  * no process-local queue and no network callback: every continuation has already
@@ -24,21 +58,36 @@ export interface PublicScanDrainResult {
 export async function drainPublicScanJobs(input: {
   maxSteps: number;
   maxDurationMs: number;
+  source: PublicScanDrainSource;
+  targetJobId?: string;
 }): Promise<PublicScanDrainResult> {
-  const maxSteps = Math.max(1, Math.floor(input.maxSteps));
+  const maxSteps = input.targetJobId ? 1 : Math.max(1, Math.floor(input.maxSteps));
   const deadline = Date.now() + Math.max(1_000, Math.floor(input.maxDurationMs));
   const results: PublicScanWorkerResult[] = [];
+  const observations: PublicScanStepObservation[] = [];
 
   while (results.length < maxSteps && Date.now() < deadline) {
-    const result = await processPublicScanJob();
+    const startedAt = Date.now();
+    const result = await processPublicScanJob(input.targetJobId);
+    const durationMs = Math.max(0, Date.now() - startedAt);
     if (result.status === "idle") break;
     results.push(result);
+    observations.push({ phase: result.phase, outcome: stepOutcome(result), durationMs });
+    logStep(input.source, result, durationMs);
+    if (input.targetJobId || result.status === "slot_busy") break;
   }
 
+  await recordPublicScanStepMetrics({
+    collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+    observations,
+  });
+
+  const processed = results.filter((result) => result.status !== "slot_busy").length;
+
   return {
-    processed: results.length,
+    processed,
     results,
-    exhaustedBudget: results.length >= maxSteps || Date.now() >= deadline,
+    exhaustedBudget: processed >= maxSteps || Date.now() >= deadline,
   };
 }
 
@@ -47,22 +96,70 @@ export async function drainPublicScanJobs(input: {
  * make the browser responsible for work: the durable job is already committed
  * to Turso and the deployment Cron remains the recovery mechanism.
  */
-export function kickPublicScanDrain(): void {
+export function kickPublicScanDrain(jobId: string): void {
   after(async () => {
     try {
       await drainPublicScanJobs({
         maxSteps: REQUEST_DRAIN_MAX_STEPS,
         maxDurationMs: REQUEST_DRAIN_MAX_MS,
+        source: "request",
+        targetJobId: jobId,
       });
-    } catch (error) {
-      console.error("request public scan drain failed:", error);
+    } catch {
+      console.error(
+        "public_scan.request_head_start_failed",
+        JSON.stringify({ jobId, kind: "dispatcher_failure" }),
+      );
     }
   });
 }
 
 export async function drainPublicScanJobsFromCron(): Promise<PublicScanDrainResult> {
-  return drainPublicScanJobs({
-    maxSteps: CRON_DRAIN_MAX_STEPS,
-    maxDurationMs: CRON_DRAIN_MAX_MS,
-  });
+  const startedAt = Date.now();
+  try {
+    const result = await drainPublicScanJobs({
+      maxSteps: CRON_DRAIN_MAX_STEPS,
+      maxDurationMs: CRON_DRAIN_MAX_MS,
+      source: "cron",
+    });
+    const completedAt = Date.now();
+    const failedSteps = result.results.filter((step) => step.status === "failed").length;
+    await recordPublicScanCronMetrics({
+      startedAt,
+      completedAt,
+      processed: result.processed,
+      failedSteps,
+      success: true,
+    });
+    console.info(
+      "public_scan.cron",
+      JSON.stringify({
+        status: "ok",
+        processed: result.processed,
+        failedSteps,
+        durationMs: completedAt - startedAt,
+        exhaustedBudget: result.exhaustedBudget,
+      }),
+    );
+    return result;
+  } catch {
+    const completedAt = Date.now();
+    try {
+      await recordPublicScanCronMetrics({
+        startedAt,
+        completedAt,
+        processed: 0,
+        failedSteps: 0,
+        success: false,
+      });
+    } catch {
+      // The 5xx and fixed log line remain the health signal when storage itself
+      // is unavailable and cannot persist the failed heartbeat.
+    }
+    console.error(
+      "public_scan.cron",
+      JSON.stringify({ status: "failed", durationMs: completedAt - startedAt }),
+    );
+    throw new Error("public scan Cron drain failed");
+  }
 }

--- a/src/lib/public-scan-worker.ts
+++ b/src/lib/public-scan-worker.ts
@@ -13,6 +13,7 @@ import {
   getPublicScanRun,
   materializePublicScanCommitRepoFacts,
   preparePublicScanCommitVerificationWork,
+  PublicScanStorageError,
   savePublicScanJobProgress,
   savePublicScanQuickResult,
   splitPublicScanCommitVerificationWork,
@@ -22,6 +23,7 @@ import {
   upsertPublicScanPrFacts,
   recordPublicScanCommitVerificationPage,
   releasePublicScanExecutionLease,
+  releasePublicScanJobClaim,
 } from "./db";
 import {
   fetchDurableOwnedRepositoryPage,
@@ -62,11 +64,36 @@ interface WorkerPayload {
 
 class NonCanonicalPublicScanError extends Error {}
 
+function publicScanErrorKind(error: unknown):
+  | "non_canonical"
+  | "rate_limited"
+  | "timeout"
+  | "upstream"
+  | "invalid_state"
+  | "unknown" {
+  if (error instanceof NonCanonicalPublicScanError) return "non_canonical";
+  const message = error instanceof Error ? error.message : "";
+  if (/rate.?limit|secondary rate|quota/i.test(message)) return "rate_limited";
+  if (/timeout|timed out|abort/i.test(message)) return "timeout";
+  if (/github|graphql|http|fetch|upstream/i.test(message)) return "upstream";
+  if (/missing|malformed|unsupported|disappeared|cannot be split/i.test(message)) {
+    return "invalid_state";
+  }
+  return "unknown";
+}
+
 export type PublicScanWorkerResult =
   | { status: "idle" }
-  | { status: "continued"; jobId: string; phase: PublicScanJobPhase }
-  | { status: "complete"; runId: string }
-  | { status: "failed"; jobId: string };
+  | { status: "slot_busy"; jobId: string; runId: string; phase: PublicScanJobPhase }
+  | { status: "continued"; jobId: string; runId: string; phase: PublicScanJobPhase }
+  | { status: "complete"; jobId: string; runId: string; phase: "publish" }
+  | {
+      status: "failed";
+      jobId: string;
+      runId: string;
+      phase: PublicScanJobPhase;
+      retryScheduled: boolean;
+    };
 
 function parsePayload(raw: string): WorkerPayload {
   try {
@@ -156,7 +183,12 @@ async function continueJob(input: {
         : undefined,
   });
   if (!saved) return { status: "idle" };
-  return { status: "continued", jobId: input.jobId, phase: input.phase };
+  return {
+    status: "continued",
+    jobId: input.jobId,
+    runId: input.runId,
+    phase: input.phase,
+  };
 }
 
 /**
@@ -183,17 +215,14 @@ export async function processPublicScanJob(jobId?: string): Promise<PublicScanWo
       leaseToken,
     });
     if (executionSlot === null) {
-      const run = await getPublicScanRun(job.runId);
-      if (!run) throw new Error("durable scan run disappeared before execution");
-      return continueJob({
+      const released = await releasePublicScanJobClaim({
         jobId: job.id,
         runId: job.runId,
         leaseToken,
-        phase: job.phase,
-        payload: parsePayload(job.payload),
-        sources: sourceStatus(run.sourceStatus),
-        delaySeconds: 10,
       });
+      return released
+        ? { status: "slot_busy", jobId: job.id, runId: job.runId, phase: job.phase }
+        : { status: "idle" };
     }
     const run = await getPublicScanRun(job.runId);
     if (!run) throw new Error("durable scan run disappeared");
@@ -575,25 +604,42 @@ export async function processPublicScanJob(jobId?: string): Promise<PublicScanWo
       });
       if (!published) return { status: "idle" };
       await setCachedScan(completed.metrics.username, completed);
-      return { status: "complete", runId: job.runId };
+      return { status: "complete", jobId: job.id, runId: job.runId, phase: "publish" };
     }
 
     throw new Error(`unsupported durable scan phase: ${job.phase}`);
   } catch (error) {
-    const detail = error instanceof Error ? error.message : "durable public scan failed";
+    if (error instanceof PublicScanStorageError) throw error;
+    const kind = publicScanErrorKind(error);
     const retryAt =
       !(error instanceof NonCanonicalPublicScanError) && job.attemptCount < 4
         ? Date.now() + 5_000 * 2 ** job.attemptCount
         : undefined;
-    await failPublicScanJob({
+    const failed = await failPublicScanJob({
       jobId: job.id,
       runId: job.runId,
       leaseToken,
-      error: detail,
+      error: `worker_${kind}`,
       retryAt,
     });
-    console.error("processPublicScanJob failed:", error);
-    return { status: "failed", jobId: job.id };
+    if (!failed) return { status: "idle" };
+    console.error(
+      "public_scan.step_failed",
+      JSON.stringify({
+        jobId: job.id,
+        runId: job.runId,
+        phase: job.phase,
+        kind,
+        retryScheduled: retryAt !== undefined,
+      }),
+    );
+    return {
+      status: "failed",
+      jobId: job.id,
+      runId: job.runId,
+      phase: job.phase,
+      retryScheduled: retryAt !== undefined,
+    };
   } finally {
     if (executionSlot !== null) {
       await releasePublicScanExecutionLease({

--- a/src/lib/public-scan.ts
+++ b/src/lib/public-scan.ts
@@ -69,8 +69,8 @@ export type PublicScanResolution =
       status: "pending";
       run: PublicScanRun;
       retryAfterSeconds: number;
-      /** Only the request that created a job may start one response-side step. */
-      shouldDrain: boolean;
+      /** Present only for the request that atomically created this job. */
+      headStartJobId: string | null;
     }
   | { status: "queue_full" | "admission_limited"; run: null; retryAfterSeconds: number }
   | { status: "storage_unavailable"; run: PublicScanRun | null; retryAfterSeconds: number }
@@ -198,7 +198,7 @@ async function resolvePublicScan(
     status: "pending",
     run: enqueued.run,
     retryAfterSeconds: retryAfter(enqueued.run),
-    shouldDrain: enqueued.created,
+    headStartJobId: enqueued.created ? enqueued.job.id : null,
   };
 }
 
@@ -248,7 +248,7 @@ export async function getPublicScanStatus(username: string): Promise<PublicScanR
     return { status: "failed", run, retryAfterSeconds: retryAfter(run) };
   }
   if (run.state === "queued" || run.state === "running") {
-    return { status: "pending", run, retryAfterSeconds: retryAfter(run), shouldDrain: false };
+    return { status: "pending", run, retryAfterSeconds: retryAfter(run), headStartJobId: null };
   }
   // Corrupt/legacy terminal rows must be repaired by resolvePublicScan rather
   // than reported as endlessly pending when no active job remains.

--- a/src/lib/scan-run-types.ts
+++ b/src/lib/scan-run-types.ts
@@ -35,6 +35,13 @@ export type PublicScanJobPhase =
   | "commit_recovery"
   | "publish";
 
+export type PublicScanStepOutcome =
+  | "continued"
+  | "complete"
+  | "failed_retrying"
+  | "failed_terminal"
+  | "slot_busy";
+
 export type PublicScanSourceState = "pending" | "complete" | "unavailable" | "failed";
 
 export type PublicScanSourceStatus = Record<string, PublicScanSourceState>;


### PR DESCRIPTION
Closes #120

## 语义路径

```mermaid
flowchart LR
  A["请求原子创建 v4 job"] --> B["仅按该 job ID 推进 1 个 bounded step"]
  C["cache / status / 已存在 pending"] --> D["只读返回，不启动 worker"]
  E["Vercel Cron"] --> F["消费 canonical v4 queue"]
  B --> G{"全局执行槽"}
  F --> G
  G -->|可用| H["执行一个 phase 并持久化"]
  G -->|busy| I["原样释放 claim"]
  I --> J["attempt 与 next_run_at 不变"]
  H --> K["聚合指标 + 隐私安全日志"]
  G -->|存储或不变量故障| L["Cron 503，禁止伪装空队列 200"]
```

## 改动

- request-side head start 绑定 enqueue 返回的精确 job ID，并强制最多一步。
- status、缓存命中、stale fallback 和既有 pending 请求不再触发 dispatcher。
- execution slot busy 时以 lease CAS 释放 claim，不增加 attempt，也不推迟调度。
- durable worker 的存储与队列不变量故障 fail-closed；Cron 以 503 暴露故障。
- 增加聚合队列、phase、步骤耗时、失败重试、slot contention、obsolete job 与 Cron heartbeat 指标。
- 日志只包含不透明 job/run ID 和固定错误分类；不记录账号、IP、header、凭据或原始上游错误。
- 增加 owner 侧 Vercel 监控与告警 runbook。

## 安全边界

- 正式版本保持 score `v9` / roast `v9` / collection `v4`。
- 非 v4 job 不会成为 alias、fallback、replay 或迁移来源。
- 不修改 #111 的确定性评分机制。
- 不恢复 LLM score delta，roast delta 仍固定为 `0`。
- 不触发全局 drain、全站重爬、榜单回填或历史数据重写。

## 自检

- `pnpm test`: 63 files / 491 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`: 177 static pages generated
- `pnpm versions:check -- --base upstream/dev`
- `pnpm smoke:deployment -- --help`
- `git diff --check`
- 独立审查：无 P0/P1
- 提交新增行扫描：无真实用户名、明文 key、凭据形态、`v14` 或 `v30`

## 部署后 owner 验证

合入并部署 `dev` 后，按 `docs/operations/public-scan-monitoring.md` 配置告警并确认 Cron 持续返回 200。该生产权限步骤不由本 PR 冒充完成。