### PR TITLE
fix(config): validate canonical production origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,10 @@ PUBLIC_SCAN_WORKER_SECRET=
 # with header `x-admin-secret`). No default → the endpoint is inert until set.
 ADMIN_SECRET=
 
-# Public site URL (used for OpenRouter attribution + share links)
+# Public origin (used for metadata, API profile URLs, share links, and provider
+# attribution). Vercel Production requires both values to be identical HTTPS
+# origins; the default production origin is https://ghfind.com.
+NEXT_PUBLIC_SITE_URL=https://ghfind.com
 PUBLIC_SITE_URL=https://ghfind.com
 
 # ── 用户登录 / GitHub OAuth (optional) ────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ TURSO_DATABASE_URL=file:./local.db
 4. (Optional) Turso: `TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` to enable the leaderboard, archived reports, profile comments/reactions, and resumable public-history scans.
 5. For resumable public-history scans in Vercel, set `CRON_SECRET`. The included `vercel.json` invokes the authenticated internal worker every five minutes; Turso is the durable queue and no additional queue SaaS is required. This cadence requires a Vercel plan that permits sub-daily Cron jobs; Vercel Hobby deployments reject the five-minute schedule at deployment time.
 6. (Optional) GitHub OAuth: `AUTH_GITHUB_ID` + `AUTH_GITHUB_SECRET` + `AUTH_SECRET` to enable signed-in comments/reactions.
-7. (Optional) set `PUBLIC_SITE_URL` when deploying under a custom domain so metadata, sitemap, cards, and LLM attribution use the right origin.
+7. Set both `NEXT_PUBLIC_SITE_URL` and `PUBLIC_SITE_URL` to the same HTTPS origin. Vercel Production rejects a missing, local, HTTP, malformed, or mismatched value during the build so metadata, sitemap, API profile URLs, cards, and LLM attribution cannot drift.
 8. Deploy.
 
 ## Bring your own model / API key

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -27,3 +27,9 @@ Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
 API, autocomplete, score leaderboard, facet bucket, complete scan status,
 optional pending scan status, and canonical origin. Missing required values,
 `localhost` canonical output, unexpected status, or malformed JSON fails the run.
+
+Before promoting a Vercel deployment, set both `NEXT_PUBLIC_SITE_URL` and
+`PUBLIC_SITE_URL` to the same HTTPS origin in the Production environment. The
+build rejects missing, local, HTTP, malformed, or mismatched production values.
+Use an explicit local origin only in local development or Preview; never copy
+the value or unrelated environment settings into logs, issues, or screenshots.

--- a/src/app/api/score/[username]/route.test.ts
+++ b/src/app/api/score/[username]/route.test.ts
@@ -147,6 +147,7 @@ describe("score durable scan guardrails", () => {
       stale: true,
       username: "stored-fixture",
       final_score: 84,
+      profile: "https://ghfind.com/u/stored-fixture",
     });
     expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
     expect(mocks.getCachedScan).not.toHaveBeenCalled();

--- a/src/lib/__tests__/llm.test.ts
+++ b/src/lib/__tests__/llm.test.ts
@@ -62,6 +62,7 @@ describe("chatStreamEvents request options", () => {
 
     const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(JSON.parse(String(request.body))).toMatchObject({ reasoning_effort: "low" });
+    expect(new Headers(request.headers).get("HTTP-Referer")).toBe("https://ghfind.com");
   });
 
   it("does not send StepFun-only fields to other compatible providers", async () => {

--- a/src/lib/__tests__/site.test.ts
+++ b/src/lib/__tests__/site.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSiteUrl } from "../site";
+
+const production = {
+  VERCEL_ENV: "production",
+  NEXT_PUBLIC_SITE_URL: "https://ghfind.com",
+  PUBLIC_SITE_URL: "https://ghfind.com",
+} as const;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("public site origin", () => {
+  it("normalizes the matching Vercel production origin", () => {
+    expect(
+      resolveSiteUrl({
+        ...production,
+        NEXT_PUBLIC_SITE_URL: "https://ghfind.com/",
+      }),
+    ).toBe("https://ghfind.com");
+  });
+
+  it("permits an explicit local origin outside production", () => {
+    expect(
+      resolveSiteUrl({
+        VERCEL_ENV: "preview",
+        NEXT_PUBLIC_SITE_URL: "http://localhost:3000",
+      }),
+    ).toBe("http://localhost:3000");
+  });
+
+  it.each([
+    ["missing public setting", { ...production, PUBLIC_SITE_URL: undefined }],
+    ["empty public setting", { ...production, PUBLIC_SITE_URL: " " }],
+    ["localhost", { ...production, NEXT_PUBLIC_SITE_URL: "http://localhost:3000", PUBLIC_SITE_URL: "http://localhost:3000" }],
+    ["http", { ...production, NEXT_PUBLIC_SITE_URL: "http://ghfind.com", PUBLIC_SITE_URL: "http://ghfind.com" }],
+    ["malformed", { ...production, NEXT_PUBLIC_SITE_URL: "not-a-url", PUBLIC_SITE_URL: "not-a-url" }],
+    ["mismatched", { ...production, PUBLIC_SITE_URL: "https://www.ghfind.com" }],
+  ])("rejects %s in Vercel production", (_name, environment) => {
+    expect(() => resolveSiteUrl(environment)).toThrow();
+  });
+
+  it("fails while evaluating the production site module", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "http://localhost:3000");
+    vi.stubEnv("PUBLIC_SITE_URL", "http://localhost:3000");
+    vi.resetModules();
+
+    await expect(import("../site")).rejects.toThrow("Vercel production site URL must be a non-local HTTPS origin");
+  });
+});

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,3 +1,5 @@
+import { SITE_URL } from "@/lib/site";
+
 /**
  * Minimal OpenAI-compatible streaming chat client.
  *
@@ -177,7 +179,7 @@ export async function* chatStreamEvents(
         "Content-Type": "application/json",
         Authorization: `Bearer ${config.apiKey}`,
         // OpenRouter attribution headers (ignored by other providers).
-        "HTTP-Referer": process.env.PUBLIC_SITE_URL || "https://ghfind.com",
+        "HTTP-Referer": SITE_URL,
         "X-Title": "GitHub Roast",
       },
       body: JSON.stringify({

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,5 +1,74 @@
 import { HTML_LANG, routing, type Locale } from "@/i18n/routing";
 
+const DEFAULT_SITE_URL = "https://ghfind.com";
+
+export interface SiteUrlEnvironment {
+  [name: string]: string | undefined;
+  NEXT_PUBLIC_SITE_URL?: string;
+  PUBLIC_SITE_URL?: string;
+  VERCEL_ENV?: string;
+}
+
+function configuredValue(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function parseSiteOrigin(value: string, variable: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${variable} must be a valid absolute origin`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`${variable} must use http or https`);
+  }
+  if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`${variable} must contain only an origin`);
+  }
+  return url.origin;
+}
+
+function isLocalHostname(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
+
+/**
+ * Resolve the one public origin used by metadata, machine documents, API
+ * profile links, share surfaces, and provider attribution. Vercel production
+ * requires both public settings so a stale higher-priority value cannot shadow
+ * the operator's intended origin.
+ */
+export function resolveSiteUrl(environment: SiteUrlEnvironment): string {
+  const nextPublicRaw = configuredValue(environment.NEXT_PUBLIC_SITE_URL);
+  const publicRaw = configuredValue(environment.PUBLIC_SITE_URL);
+  const production = environment.VERCEL_ENV === "production";
+
+  if (production && (!nextPublicRaw || !publicRaw)) {
+    throw new Error("Vercel production requires NEXT_PUBLIC_SITE_URL and PUBLIC_SITE_URL");
+  }
+
+  const nextPublic = nextPublicRaw
+    ? parseSiteOrigin(nextPublicRaw, "NEXT_PUBLIC_SITE_URL")
+    : null;
+  const publicUrl = publicRaw ? parseSiteOrigin(publicRaw, "PUBLIC_SITE_URL") : null;
+
+  if (production) {
+    if (nextPublic !== publicUrl) {
+      throw new Error("Vercel production site URL settings must match");
+    }
+    const url = new URL(nextPublic!);
+    if (url.protocol !== "https:" || isLocalHostname(url.hostname)) {
+      throw new Error("Vercel production site URL must be a non-local HTTPS origin");
+    }
+  }
+
+  return nextPublic ?? publicUrl ?? DEFAULT_SITE_URL;
+}
+
 /**
  * Single source of truth for the public site origin.
  *
@@ -8,9 +77,7 @@ import { HTML_LANG, routing, type Locale } from "@/i18n/routing";
  * from the actual deployment. Everything that needs an absolute URL (metadata,
  * sitemap, robots, JSON-LD) now imports `SITE_URL` from here.
  */
-export const SITE_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL || process.env.PUBLIC_SITE_URL || "https://ghfind.com"
-).replace(/\/$/, "");
+export const SITE_URL = resolveSiteUrl(process.env);
 
 /**
  * Minimum public score for a profile to be submitted to search engines.


### PR DESCRIPTION
## Summary
- resolve every public absolute URL from one validated origin, including API profile links and LLM attribution
- fail Vercel Production evaluation when NEXT_PUBLIC_SITE_URL or PUBLIC_SITE_URL is missing, empty, malformed, non-HTTPS, local, or mismatched
- retain explicit local origins for Preview and local development; document the Production configuration and smoke step

## Verification
- pnpm test -- --reporter=dot (67 files, 554 tests)
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm versions:check -- --base upstream/dev
- git diff --check and staged sensitive-data audit

## Owner follow-up
Configure both Production URL variables to the same HTTPS public origin, deploy this dev commit, then run the private deployment smoke command. No secrets, credentials, or canary handles are included here.