### PR TITLE
fix(scan): retain validated v3 snapshots during v4 refresh

### DIFF
--- a/docs/releases/v9-v9-v4-rollout.md
+++ b/docs/releases/v9-v9-v4-rollout.md
@@ -69,6 +69,20 @@ text is detached. A roast write is accepted only while the account row still has
 the exact score-write token and timestamp, preventing both cross-release and
 same-release late reports from attaching to a newer scan.
 
+## v3 stale-read fallback
+
+When no valid complete v4 snapshot exists, public scan status may serve the
+newest complete v3 snapshot only after its hash, account identity, coverage,
+required sources, payload shape, and stored-score shape all validate. The
+response marks `stale`, `served_collection_version=v3`, and
+`target_collection_version=v4`. It never materializes a v9 score or report
+from v3 evidence.
+
+Passive profile, score, search, leaderboard, facet, sitemap, and MCP reads do
+not create a refresh. An explicit scan may create at most one v4 job and keeps
+returning the v3 snapshot while that refresh is pending or failed. v5 and every
+other non-formal collection remain ineligible for this path.
+
 ## Obsolete-job quarantine
 
 The operator endpoint returns aggregate counts only:

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -309,6 +309,36 @@ beforeEach(() => {
 });
 
 describe("roast API persistence", () => {
+  it("does not generate or queue a report from stale v3 evidence", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "DemoDev", collectionVersion: "v3" },
+      scan,
+      refreshPending: false,
+      refreshRun: null,
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ scan, lang: "zh" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "scan_enrichment_pending",
+      stale: true,
+      served_collection_version: "v3",
+      target_collection_version: "v4",
+    });
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
+  });
+
   it("limits every roast path before durable-status and scan-cache reads", async () => {
     mocks.checkRoastRequestRateLimit.mockResolvedValue({ success: false });
     mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "60" });

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -689,6 +689,19 @@ export async function POST(req: NextRequest) {
     getPublicScanStatus(username),
     getCachedScan(username),
   ]);
+  if (publicStatus?.status === "stale") {
+    return NextResponse.json(
+      {
+        error: "scan_enrichment_pending",
+        username,
+        stale: true,
+        refresh_pending: publicStatus.refreshPending,
+        served_collection_version: publicStatus.servedCollectionVersion,
+        target_collection_version: publicStatus.targetCollectionVersion,
+      },
+      { status: 409, headers: { "Cache-Control": "no-store" } },
+    );
+  }
   let completedPublicRun = publicStatus?.status === "complete" ? publicStatus.run : null;
   const completedPublicScan = publicStatus?.status === "complete" ? publicStatus.scan : null;
   const serverScan = completedPublicScan ?? cachedScan;
@@ -706,7 +719,7 @@ export async function POST(req: NextRequest) {
         ? `bearer:${req.headers.get("authorization") ?? ""}`
         : `ip:${clientIp(req)}`,
     );
-    const resolution = publicStatus && publicStatus.status !== "complete"
+    const resolution = publicStatus?.status === "pending" || publicStatus?.status === "failed"
       ? publicStatus
       : serverScan
         ? await resolvePublicScanFromTrustedQuickScan(username, serverScan, durableAdmission)

--- a/src/app/api/scan-status/[username]/route.test.ts
+++ b/src/app/api/scan-status/[username]/route.test.ts
@@ -91,6 +91,31 @@ describe("durable scan status API", () => {
     });
   });
 
+  it("keeps a v3 snapshot readable while polling its v4 refresh run", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "durable-status-case", collectionVersion: "v3" },
+      scan: { metrics: { username: "durable-status-case" } },
+      refreshPending: true,
+      refreshRun: { id: "run-id", username: "durable-status-case", collectionVersion: "v4" },
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+
+    const response = await request("durable-status-case");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toContain("s-maxage=5");
+    await expect(response.json()).resolves.toMatchObject({
+      status: "stale_public",
+      run_id: "run-id",
+      stale: true,
+      refresh_pending: true,
+      served_collection_version: "v3",
+      target_collection_version: "v4",
+    });
+  });
+
   it("uses retryable pending and failed states without publishing a partial scan", async () => {
     mocks.getPublicScanStatus.mockResolvedValueOnce({
       status: "pending",

--- a/src/app/api/scan-status/[username]/route.ts
+++ b/src/app/api/scan-status/[username]/route.ts
@@ -43,7 +43,8 @@ export async function GET(
   }
 
   const status = await getPublicScanStatus(handle);
-  if (!status || !status.run || status.run.id !== runId) {
+  const activeRun = status?.status === "stale" ? status.refreshRun ?? status.run : status?.run;
+  if (!status || !activeRun || activeRun.id !== runId) {
     return NextResponse.json({ error: "scan_not_found" }, { status: 404, headers });
   }
   if (status.status === "complete") {
@@ -52,11 +53,31 @@ export async function GET(
       { headers: { ...headers, "Cache-Control": COMPLETE_CACHE } },
     );
   }
+  if (status.status === "stale") {
+    return NextResponse.json(
+      {
+        status: "stale_public",
+        username: status.run.username,
+        run_id: activeRun.id,
+        scan: status.scan,
+        stale: true,
+        refresh_pending: status.refreshPending,
+        served_collection_version: status.servedCollectionVersion,
+        target_collection_version: status.targetCollectionVersion,
+      },
+      {
+        headers: {
+          ...headers,
+          "Cache-Control": status.refreshPending ? PENDING_CACHE : COMPLETE_CACHE,
+        },
+      },
+    );
+  }
   return NextResponse.json(
     {
       status: status.status,
-      username: status.run.username,
-      run_id: status.run.id,
+      username: status.run?.username ?? handle,
+      run_id: activeRun.id,
       retry_after: status.retryAfterSeconds,
       ...(status.status === "failed" ? { error: "durable_scan_failed" } : {}),
     },

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   publicScanAdmission: vi.fn(() => ({ bucket: "test", limit: 2, windowMs: 60_000, maxActiveJobs: 24 })),
   requiresDurablePublicScan: vi.fn(),
   resolvePublicScanFromTrustedQuickScan: vi.fn(),
+  startPublicScan: vi.fn(),
   kickPublicScanDrain: vi.fn(),
 }));
 
@@ -57,6 +58,7 @@ vi.mock("@/lib/public-scan", () => ({
   publicScanAdmission: mocks.publicScanAdmission,
   requiresDurablePublicScan: mocks.requiresDurablePublicScan,
   resolvePublicScanFromTrustedQuickScan: mocks.resolvePublicScanFromTrustedQuickScan,
+  startPublicScan: mocks.startPublicScan,
 }));
 
 vi.mock("@/lib/public-scan-dispatcher", () => ({
@@ -236,6 +238,69 @@ describe("scan route machine auth", () => {
     expect(mocks.ensureCanonicalScoreForPublicRun).toHaveBeenCalledWith(run);
     expect(mocks.collect).not.toHaveBeenCalled();
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
+  });
+
+  it("serves a v3 snapshot and starts only one explicit v4 refresh", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "DemoDev", collectionVersion: "v3" },
+      scan: { metrics, scoring, top_repos: [], recent_prs: [], flood_pr_titles: [] },
+      refreshPending: false,
+      refreshRun: null,
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+    mocks.startPublicScan.mockResolvedValue({
+      status: "pending",
+      run: { id: "refresh-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: "refresh-job",
+    });
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      stale: true,
+      refresh_pending: true,
+      run_id: "refresh-run",
+      served_collection_version: "v3",
+      target_collection_version: "v4",
+    });
+    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("refresh-job");
+    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
+    expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit scan retry after a failed v4 refresh while serving v3", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "DemoDev", collectionVersion: "v3" },
+      scan: { metrics, scoring, top_repos: [], recent_prs: [], flood_pr_titles: [] },
+      refreshPending: false,
+      refreshRun: { id: "failed-refresh", username: "DemoDev", collectionVersion: "v4" },
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+    mocks.startPublicScan.mockResolvedValue({
+      status: "pending",
+      run: { id: "retry-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: "retry-job",
+    });
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      stale: true,
+      refresh_pending: true,
+      run_id: "retry-run",
+    });
+    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("retry-job");
   });
 
   it("discards an orphaned scan cache and publishes a fresh trusted quick scan", async () => {

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -23,6 +23,7 @@ import {
   type PublicScanResolution,
   requiresDurablePublicScan,
   resolvePublicScanFromTrustedQuickScan,
+  startPublicScan,
 } from "@/lib/public-scan";
 import { kickPublicScanDrain } from "@/lib/public-scan-dispatcher";
 import { verifyTurnstile } from "@/lib/turnstile";
@@ -91,7 +92,7 @@ async function recordSuccessfulLookup(
 
 function durableStatusResponse(input: {
   username: string;
-  resolution: Exclude<PublicScanResolution, { status: "complete" }>;
+  resolution: Exclude<PublicScanResolution, { status: "complete" | "stale" }>;
   headers: Record<string, string>;
 }) {
   if (input.resolution.status === "pending") {
@@ -130,6 +131,35 @@ function durableStatusResponse(input: {
       "Retry-After": String(input.resolution.retryAfterSeconds),
     },
   });
+}
+
+async function staleSnapshotResponse(input: {
+  username: string;
+  status: Extract<PublicScanResolution, { status: "stale" }>;
+  admission: ReturnType<typeof publicScanAdmission>;
+  headers: Record<string, string>;
+}) {
+  const refresh = input.status.refreshPending
+    ? null
+    : await startPublicScan(input.username, input.admission);
+  const refreshRun = refresh && "run" in refresh ? refresh.run : input.status.refreshRun;
+  const refreshPending = input.status.refreshPending || refresh?.status === "pending";
+  if (refresh?.status === "pending" && refresh.headStartJobId) {
+    kickPublicScanDrain(refresh.headStartJobId);
+  }
+  return NextResponse.json(
+    {
+      ...input.status.scan,
+      cached: true,
+      coverage: "complete_public",
+      stale: true,
+      refresh_pending: refreshPending,
+      served_collection_version: input.status.servedCollectionVersion,
+      target_collection_version: input.status.targetCollectionVersion,
+      ...(refreshRun ? { run_id: refreshRun.id } : {}),
+    },
+    { headers: { ...input.headers, "Cache-Control": "no-store" } },
+  );
 }
 
 async function durableResponse(input: {
@@ -226,6 +256,15 @@ export async function POST(req: NextRequest) {
       { ...status.scan, cached: true, coverage: "complete_public" },
       { headers: { ...idem, ...rlHeaders } },
     );
+  }
+  if (status?.status === "stale") {
+    await recordSuccessfulLookup(status.scan.metrics.username, ip, campaign);
+    return staleSnapshotResponse({
+      username: status.scan.metrics.username,
+      status,
+      admission: durableAdmission,
+      headers: { ...idem, ...rlHeaders },
+    });
   }
   if (status) {
     await recordSuccessfulLookup(username, ip, campaign);

--- a/src/app/api/score/[username]/route.test.ts
+++ b/src/app/api/score/[username]/route.test.ts
@@ -173,6 +173,34 @@ describe("score durable scan guardrails", () => {
     expect(mocks.getCachedScan).not.toHaveBeenCalled();
   });
 
+  it("serves a v3 score as stale without writing v9 or creating a refresh", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "DemoDev", collectionVersion: "v3" },
+      scan: quickScan,
+      refreshPending: false,
+      refreshRun: null,
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+
+    const response = await request();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    await expect(response.json()).resolves.toMatchObject({
+      source: "stale_public",
+      stale: true,
+      refresh_pending: false,
+      served_collection_version: "v3",
+      target_collection_version: "v4",
+    });
+    expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.buildScanResult).not.toHaveBeenCalled();
+    expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
+  });
+
   it("limits status reads before a durable lookup", async () => {
     mocks.checkPublicScanStatusRateLimit.mockResolvedValue({ success: false });
     mocks.rateLimitHeaders.mockReturnValue({ "Retry-After": "60" });

--- a/src/app/api/score/[username]/route.ts
+++ b/src/app/api/score/[username]/route.ts
@@ -102,7 +102,7 @@ async function percentileFor(finalScore: number) {
 
 function durableResponse(
   username: string,
-  resolution: Exclude<PublicScanResolution, { status: "complete" }>,
+  resolution: Exclude<PublicScanResolution, { status: "complete" | "stale" }>,
   headers: Record<string, string>,
 ) {
   if (resolution.status === "pending") {
@@ -245,6 +245,38 @@ export async function GET(
       },
       200,
       LIVE_CACHE,
+    );
+  }
+  if (publicStatus?.status === "stale") {
+    const s = publicStatus.scan.scoring;
+    const m = publicStatus.scan.metrics;
+    const tier = s.tier as Tier;
+    return json(
+      {
+        source: "stale_public",
+        cached: true,
+        stale: true,
+        refresh_pending: publicStatus.refreshPending,
+        served_collection_version: publicStatus.servedCollectionVersion,
+        target_collection_version: publicStatus.targetCollectionVersion,
+        username: m.username,
+        display_name: m.name,
+        avatar_url: m.avatar_url,
+        profile_url: m.profile_url ?? `https://github.com/${m.username}`,
+        final_score: s.final_score,
+        tier,
+        tier_key: TIER_KEY[tier],
+        sub_scores: s.sub_scores,
+        base_score: s.base_score,
+        total_penalty: s.total_penalty,
+        red_flags: s.red_flags,
+        tags: null,
+        roast_line: null,
+        percentile: await percentileFor(s.final_score),
+        profile: `${SITE_URL}/u/${m.username}`,
+      },
+      200,
+      "no-store",
     );
   }
   if (publicStatus) {

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -925,6 +925,78 @@ describe("durable public scan jobs", () => {
     ).resolves.toBe(true);
   });
 
+  it("returns only requested complete collection snapshots in completion order", async () => {
+    const username = "collection-read-order-fixture";
+    const serialized = serializeScan(syntheticScan(username));
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    const sources = JSON.stringify(COMPLETE_PUBLIC_SOURCES);
+    const completedAt = Date.now();
+    await client.batch(
+      [
+        {
+          sql: `INSERT INTO public_scan_runs
+                  (id, username, score_version, collection_version, state, coverage,
+                   source_status, snapshot, snapshot_hash, started_at, completed_at, updated_at)
+                VALUES (?, ?, ?, ?, 'complete_public', 'complete_public', ?, ?, ?, ?, ?, ?)`,
+          args: [
+            "collection-read-v3-older",
+            username,
+            "legacy-score-fixture",
+            "v3",
+            sources,
+            serialized.snapshot,
+            serialized.snapshotHash,
+            completedAt - 2,
+            completedAt - 2,
+            completedAt - 2,
+          ],
+        },
+        {
+          sql: `INSERT INTO public_scan_runs
+                  (id, username, score_version, collection_version, state, coverage,
+                   source_status, snapshot, snapshot_hash, started_at, completed_at, updated_at)
+                VALUES (?, ?, ?, ?, 'complete_public', 'complete_public', ?, ?, ?, ?, ?, ?)`,
+          args: [
+            "collection-read-v3-newer",
+            username,
+            "legacy-score-fixture",
+            "v3",
+            sources,
+            serialized.snapshot,
+            serialized.snapshotHash,
+            completedAt - 1,
+            completedAt - 1,
+            completedAt - 1,
+          ],
+        },
+        {
+          sql: `INSERT INTO public_scan_runs
+                  (id, username, score_version, collection_version, state, coverage,
+                   source_status, snapshot, snapshot_hash, started_at, completed_at, updated_at)
+                VALUES (?, ?, ?, ?, 'complete_public', 'complete_public', ?, ?, ?, ?, ?, ?)`,
+          args: [
+            "collection-read-non-formal",
+            username,
+            "non-formal-score-fixture",
+            "v5",
+            sources,
+            serialized.snapshot,
+            serialized.snapshotHash,
+            completedAt,
+            completedAt,
+            completedAt,
+          ],
+        },
+      ],
+      "write",
+    );
+
+    await expect(db.getCompletePublicScanRuns(username, "v3")).resolves.toMatchObject([
+      { id: "collection-read-v3-newer", collectionVersion: "v3" },
+      { id: "collection-read-v3-older", collectionVersion: "v3" },
+    ]);
+  });
+
   it("dry-runs and applies obsolete-job quarantine in bounded aggregate-only batches", async () => {
     const obsoleteCollection = "obsolete-collection-quarantine-fixture";
     const obsoleteJobs = [];

--- a/src/lib/__tests__/mcp-tools.test.ts
+++ b/src/lib/__tests__/mcp-tools.test.ts
@@ -78,4 +78,28 @@ describe("MCP stored score guardrail", () => {
     expect(mocks.buildScanResult).not.toHaveBeenCalled();
     expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
   });
+
+  it("returns stale v3 evidence without starting a canonical refresh", async () => {
+    mocks.getAccountDetail.mockResolvedValue(null);
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "mcp-stored-fixture", collectionVersion: "v3" },
+      scan: {
+        metrics: { username: "mcp-stored-fixture", name: "MCP Stored Fixture" },
+        scoring: { final_score: 82, tier: "人上人", sub_scores: {}, red_flags: [] },
+      },
+      refreshPending: false,
+      refreshRun: null,
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+
+    await expect(scoreUser("mcp-stored-fixture")).resolves.toMatchObject({
+      source: "stale_public",
+      stale: true,
+      served_collection_version: "v3",
+    });
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.buildScanResult).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/__tests__/public-scan.test.ts
+++ b/src/lib/__tests__/public-scan.test.ts
@@ -5,17 +5,20 @@ import { PUBLIC_SCAN_COLLECTION_VERSION, type PublicScanRun } from "../scan-run-
 
 const mocks = vi.hoisted(() => ({
   enqueuePublicScan: vi.fn(),
+  getCompletePublicScanRuns: vi.fn(),
   getLatestPublicScanRun: vi.fn(),
   seedPublicScanQuickResult: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
   enqueuePublicScan: mocks.enqueuePublicScan,
+  getCompletePublicScanRuns: mocks.getCompletePublicScanRuns,
   getLatestPublicScanRun: mocks.getLatestPublicScanRun,
   seedPublicScanQuickResult: mocks.seedPublicScanQuickResult,
 }));
 
 import {
+  getPublicScanStatus,
   publicScanAdmission,
   requiresDurablePublicScan,
   resolvePublicScanFromTrustedQuickScan,
@@ -59,7 +62,22 @@ function scan(overrides: Partial<ScanResult["metrics"]> = {}): ScanResult {
     top_repos: [],
     recent_prs: [],
     flood_pr_titles: [],
-    scoring: {} as ScanResult["scoring"],
+    scoring: {
+      final_score: 61,
+      base_score: 61,
+      total_penalty: 0,
+      tier: "NPC",
+      tier_label: "fixture",
+      sub_scores: {
+        account_maturity: 0,
+        original_project_quality: 0,
+        contribution_quality: 0,
+        ecosystem_impact: 0,
+        community_influence: 0,
+        activity_authenticity: 0,
+      },
+      red_flags: [],
+    },
   } as ScanResult;
 }
 
@@ -92,10 +110,26 @@ function completedSources() {
   } as const;
 }
 
+function completeRun(collectionVersion = "v3", overrides: Partial<PublicScanRun> = {}): PublicScanRun {
+  const snapshot = JSON.stringify(scan({ merged_pr_count: 301 }));
+  return {
+    ...pendingRun(),
+    collectionVersion,
+    state: "complete_public",
+    coverage: "complete_public",
+    sourceStatus: completedSources(),
+    snapshot,
+    snapshotHash: createHash("sha256").update(snapshot).digest("hex"),
+    completedAt: Date.now(),
+    ...overrides,
+  };
+}
+
 describe("durable public scan admission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getLatestPublicScanRun.mockResolvedValue(null);
+    mocks.getCompletePublicScanRuns.mockResolvedValue([]);
     mocks.seedPublicScanQuickResult.mockResolvedValue(true);
   });
 
@@ -152,6 +186,48 @@ describe("durable public scan admission", () => {
       status: "complete",
       scan: { metrics: { username: "durable-case" } },
     });
+    expect(mocks.enqueuePublicScan).not.toHaveBeenCalled();
+  });
+
+  it("serves only a validated v3 snapshot while a v4 refresh is pending", async () => {
+    const refresh = pendingRun();
+    const legacy = completeRun();
+    mocks.getLatestPublicScanRun.mockResolvedValue(refresh);
+    mocks.getCompletePublicScanRuns.mockImplementation(
+      async (_username: string, collectionVersion: string) =>
+        collectionVersion === "v3" ? [legacy] : [],
+    );
+
+    await expect(getPublicScanStatus("durable-case")).resolves.toMatchObject({
+      status: "stale",
+      run: { collectionVersion: "v3" },
+      refreshRun: { id: "run-id", collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION },
+      refreshPending: true,
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+    });
+    expect(mocks.enqueuePublicScan).not.toHaveBeenCalled();
+    expect(mocks.getCompletePublicScanRuns).toHaveBeenCalledWith("durable-case", "v3");
+  });
+
+  it("rejects corrupt and non-v3 complete rows as stale fallbacks", async () => {
+    const corrupt = completeRun("v3", { snapshotHash: "not-a-hash" });
+    const incompleteScoreSnapshot = JSON.stringify({
+      ...scan(),
+      scoring: { ...scan().scoring, sub_scores: {} },
+    });
+    const incompleteScore = completeRun("v3", {
+      snapshot: incompleteScoreSnapshot,
+      snapshotHash: createHash("sha256").update(incompleteScoreSnapshot).digest("hex"),
+    });
+    const nonCanonical = completeRun("v5");
+    mocks.getCompletePublicScanRuns.mockImplementation(
+      async (_username: string, collectionVersion: string) =>
+        collectionVersion === "v3" ? [corrupt, incompleteScore, nonCanonical] : [],
+    );
+
+    await expect(getPublicScanStatus("durable-case")).resolves.toBeNull();
+    expect(mocks.getCompletePublicScanRuns).not.toHaveBeenCalledWith("durable-case", "v5");
     expect(mocks.enqueuePublicScan).not.toHaveBeenCalled();
   });
 

--- a/src/lib/__tests__/release-versions.test.ts
+++ b/src/lib/__tests__/release-versions.test.ts
@@ -44,6 +44,10 @@ describe("release version contract", () => {
     expect(releaseVersionErrors(manifest, manifest.targetRelease)).toEqual([]);
   });
 
+  it("allows only the formal v3 collection as the v4 stale-read fallback", () => {
+    expect(RELEASE_VERSION_MANIFEST.compatibility.collectionReadOrder).toEqual(["v4", "v3"]);
+  });
+
   it("rejects aliases and accidental-version replay paths", () => {
     const aliasManifest = manifestCopy();
     aliasManifest.aliases = [{ from: "local", to: "formal" }];

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -347,6 +347,11 @@ function ensureSchema(db: Client): Promise<void> {
              ON public_scan_runs(username, collection_version, updated_at DESC)`,
           `CREATE INDEX IF NOT EXISTS idx_public_scan_runs_user_collection_started
              ON public_scan_runs(username, collection_version, started_at DESC, id DESC)`,
+          // Stale-read fallback selects the last valid completed snapshot for
+          // one exact collection contract. Keep that read bounded even when an
+          // account has accumulated several historical runs.
+          `CREATE INDEX IF NOT EXISTS idx_public_scan_runs_user_collection_completed
+             ON public_scan_runs(username, collection_version, completed_at DESC, id DESC)`,
           `CREATE INDEX IF NOT EXISTS idx_public_scan_runs_state
              ON public_scan_runs(state, updated_at)`,
           `CREATE TABLE IF NOT EXISTS public_scan_jobs (
@@ -1857,6 +1862,38 @@ export async function getLatestPublicScanRun(
   } catch (error) {
     logPublicScanDbFailure("get_latest_run", error);
     return null;
+  }
+}
+
+/**
+ * Return complete snapshots in newest-first order for one exact collection
+ * contract. Callers must validate hash and payload shape before serving a row;
+ * this query deliberately never crosses collection versions.
+ */
+export async function getCompletePublicScanRuns(
+  username: string,
+  collectionVersion: string,
+): Promise<PublicScanRun[]> {
+  const db = getClient();
+  if (!db) return [];
+  try {
+    await ensureSchema(db);
+    const result = await db.execute({
+      sql: `SELECT * FROM public_scan_runs
+            WHERE username = ?
+              AND collection_version = ?
+              AND state = 'complete_public'
+              AND coverage = 'complete_public'
+              AND snapshot IS NOT NULL
+              AND snapshot_hash IS NOT NULL
+              AND completed_at IS NOT NULL
+            ORDER BY completed_at DESC, id DESC`,
+      args: [username.toLowerCase(), collectionVersion],
+    });
+    return result.rows.map((row) => mapPublicScanRun(row as Record<string, unknown>));
+  } catch (error) {
+    logPublicScanDbFailure("get_complete_runs", error);
+    return [];
   }
 }
 

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -68,6 +68,26 @@ export async function scoreUser(
     const status = await getPublicScanStatus(handle);
     if (status?.status === "complete") {
       result = status.scan;
+    } else if (status?.status === "stale") {
+      const s = status.scan.scoring;
+      const m = status.scan.metrics;
+      const tier = s.tier as Tier;
+      return {
+        source: "stale_public",
+        stale: true,
+        refresh_pending: status.refreshPending,
+        served_collection_version: status.servedCollectionVersion,
+        target_collection_version: status.targetCollectionVersion,
+        username: m.username,
+        display_name: m.name,
+        final_score: s.final_score,
+        tier,
+        tier_key: TIER_KEY[tier],
+        sub_scores: s.sub_scores,
+        red_flags: s.red_flags,
+        percentile: await percentileFor(s.final_score),
+        profile: `${SITE_URL}/u/${m.username}`,
+      };
     } else {
       if (status) {
         return {
@@ -128,6 +148,16 @@ export async function scanUser(
   try {
     const status = await getPublicScanStatus(handle);
     if (status?.status === "complete") return status.scan;
+    if (status?.status === "stale") {
+      const staleScan: ScanResult = { ...status.scan };
+      Object.assign(staleScan, {
+        stale: true,
+        refresh_pending: status.refreshPending,
+        served_collection_version: status.servedCollectionVersion,
+        target_collection_version: status.targetCollectionVersion,
+      });
+      return staleScan;
+    }
     if (status) {
       return {
         error: "scan_enrichment_pending",

--- a/src/lib/public-scan.ts
+++ b/src/lib/public-scan.ts
@@ -1,11 +1,13 @@
 import { createHash } from "node:crypto";
 import {
   enqueuePublicScan,
+  getCompletePublicScanRuns,
   getLatestPublicScanRun,
   seedPublicScanQuickResult,
   type PublicScanAdmission,
 } from "./db";
 import { SCORE_CACHE_VERSION } from "./cache-version";
+import { RELEASE_VERSION_MANIFEST } from "./release-versions";
 import {
   PUBLIC_SCAN_COLLECTION_VERSION,
   hasCompletePublicScanSources,
@@ -50,6 +52,17 @@ const REQUIRED_NUMERIC_METRICS = [
   "templated_pr_ratio",
 ] as const;
 
+const REQUIRED_SUB_SCORE_KEYS = [
+  "account_maturity",
+  "original_project_quality",
+  "contribution_quality",
+  "ecosystem_impact",
+  "community_influence",
+  "activity_authenticity",
+] as const;
+
+const VALID_TIERS = new Set(["夯", "顶级", "人上人", "NPC", "拉完了"]);
+
 function hasUsableSnapshotShape(scan: Partial<ScanResult>): scan is ScanResult {
   if (
     !scan.metrics ||
@@ -63,8 +76,40 @@ function hasUsableSnapshotShape(scan: Partial<ScanResult>): scan is ScanResult {
   return REQUIRED_NUMERIC_METRICS.every((key) => Number.isFinite(scan.metrics![key]));
 }
 
+function hasStoredSnapshotScore(scan: Partial<ScanResult>): scan is ScanResult {
+  const scoring = scan.scoring;
+  return Boolean(
+    scoring &&
+      Number.isFinite(scoring.final_score) &&
+      Number.isFinite(scoring.base_score) &&
+      Number.isFinite(scoring.total_penalty) &&
+      VALID_TIERS.has(scoring.tier) &&
+      typeof scoring.tier_label === "string" &&
+      scoring.sub_scores &&
+      typeof scoring.sub_scores === "object" &&
+      REQUIRED_SUB_SCORE_KEYS.every((key) => Number.isFinite(scoring.sub_scores[key])) &&
+      Array.isArray(scoring.red_flags) &&
+      scoring.red_flags.every(
+        (flag) =>
+          flag &&
+          typeof flag.flag === "string" &&
+          typeof flag.detail === "string" &&
+          Number.isFinite(flag.penalty),
+      ),
+  );
+}
+
 export type PublicScanResolution =
   | { status: "complete"; run: PublicScanRun; scan: ScanResult }
+  | {
+      status: "stale";
+      run: PublicScanRun;
+      scan: ScanResult;
+      refreshPending: boolean;
+      refreshRun: PublicScanRun | null;
+      servedCollectionVersion: string;
+      targetCollectionVersion: string;
+    }
   | {
       status: "pending";
       run: PublicScanRun;
@@ -75,6 +120,11 @@ export type PublicScanResolution =
   | { status: "queue_full" | "admission_limited"; run: null; retryAfterSeconds: number }
   | { status: "storage_unavailable"; run: PublicScanRun | null; retryAfterSeconds: number }
   | { status: "failed"; run: PublicScanRun; retryAfterSeconds: number };
+
+export type CanonicalPublicScanResolution = Exclude<
+  PublicScanResolution,
+  { status: "stale" }
+>;
 
 /**
  * Build a privacy-preserving, persistent admission key for *new* durable jobs.
@@ -96,8 +146,13 @@ export function publicScanAdmission(principal: string): PublicScanAdmission {
   };
 }
 
-function parseCompleteSnapshot(run: PublicScanRun): ScanResult | null {
+function parseCompleteSnapshot(
+  run: PublicScanRun,
+  expectedCollectionVersion: string,
+  recomputeScore: boolean,
+): ScanResult | null {
   if (
+    run.collectionVersion !== expectedCollectionVersion ||
     run.state !== "complete_public" ||
     run.coverage !== "complete_public" ||
     !run.snapshot ||
@@ -111,14 +166,41 @@ function parseCompleteSnapshot(run: PublicScanRun): ScanResult | null {
   try {
     const scan = JSON.parse(run.snapshot) as Partial<ScanResult>;
     if (!hasUsableSnapshotShape(scan)) return null;
+    if (!recomputeScore && !hasStoredSnapshotScore(scan)) return null;
+    if (scan.metrics.username.trim().toLowerCase() !== run.username.trim().toLowerCase()) return null;
     // A complete public-history snapshot is a durable factual input. Score
     // formulas deliberately evolve faster than collectors, so recompute the
     // deterministic result at read time instead of forcing another historical
     // GitHub crawl solely because SCORE_CACHE_VERSION changed.
-    return { ...scan, scoring: score(scan.metrics) };
+    return recomputeScore ? { ...scan, scoring: score(scan.metrics) } : (scan as ScanResult);
   } catch {
     return null;
   }
+}
+
+async function latestCompleteSnapshot(
+  username: string,
+  collectionVersion: string,
+  recomputeScore: boolean,
+): Promise<{ run: PublicScanRun; scan: ScanResult } | null> {
+  const runs = await getCompletePublicScanRuns(username, collectionVersion);
+  for (const run of runs) {
+    const scan = parseCompleteSnapshot(run, collectionVersion, recomputeScore);
+    if (scan) return { run, scan };
+  }
+  return null;
+}
+
+function previousCollectionVersion(): string | null {
+  const [target, previous] = RELEASE_VERSION_MANIFEST.compatibility.collectionReadOrder;
+  if (
+    target !== PUBLIC_SCAN_COLLECTION_VERSION ||
+    previous !== RELEASE_VERSION_MANIFEST.previousRelease.collection ||
+    previous === PUBLIC_SCAN_COLLECTION_VERSION
+  ) {
+    return null;
+  }
+  return previous;
 }
 
 /**
@@ -154,15 +236,25 @@ async function resolvePublicScan(
   username: string,
   quickScan?: ScanResult,
   admission?: PublicScanAdmission,
-): Promise<PublicScanResolution> {
+): Promise<CanonicalPublicScanResolution> {
   const versions = {
     scoreVersion: SCORE_CACHE_VERSION,
     collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
   };
   const existing = await getLatestPublicScanRun(username, versions);
   if (existing) {
-    const complete = parseCompleteSnapshot(existing);
+    const complete = parseCompleteSnapshot(existing, PUBLIC_SCAN_COLLECTION_VERSION, true);
     if (complete) return { status: "complete", run: existing, scan: complete };
+  }
+  const canonicalComplete = await latestCompleteSnapshot(
+    username,
+    PUBLIC_SCAN_COLLECTION_VERSION,
+    true,
+  );
+  if (canonicalComplete) {
+    return { status: "complete", ...canonicalComplete };
+  }
+  if (existing) {
     if (existing.state === "failed" && Date.now() - existing.updatedAt < FAILED_RUN_RETRY_MS) {
       return { status: "failed", run: existing, retryAfterSeconds: retryAfter(existing) };
     }
@@ -210,7 +302,7 @@ async function resolvePublicScan(
 export async function startPublicScan(
   username: string,
   admission?: PublicScanAdmission,
-): Promise<PublicScanResolution> {
+): Promise<CanonicalPublicScanResolution> {
   return resolvePublicScan(username, undefined, admission);
 }
 
@@ -223,16 +315,17 @@ export async function resolvePublicScanFromTrustedQuickScan(
   username: string,
   quickScan: ScanResult,
   admission?: PublicScanAdmission,
-): Promise<PublicScanResolution> {
+): Promise<CanonicalPublicScanResolution> {
   return resolvePublicScan(username, quickScan, admission);
 }
 
 export async function getCompletedPublicScan(username: string): Promise<ScanResult | null> {
-  const run = await getLatestPublicScanRun(username, {
-    scoreVersion: SCORE_CACHE_VERSION,
-    collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
-  });
-  return run ? parseCompleteSnapshot(run) : null;
+  const complete = await latestCompleteSnapshot(
+    username,
+    PUBLIC_SCAN_COLLECTION_VERSION,
+    true,
+  );
+  return complete?.scan ?? null;
 }
 
 /** Read-only status probe for a job already requested through POST /api/scan. */
@@ -241,9 +334,34 @@ export async function getPublicScanStatus(username: string): Promise<PublicScanR
     scoreVersion: SCORE_CACHE_VERSION,
     collectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
   });
+  const scan = run
+    ? parseCompleteSnapshot(run, PUBLIC_SCAN_COLLECTION_VERSION, true)
+    : null;
+  if (scan && run) return { status: "complete", run, scan };
+  const canonicalComplete = await latestCompleteSnapshot(
+    username,
+    PUBLIC_SCAN_COLLECTION_VERSION,
+    true,
+  );
+  if (canonicalComplete) return { status: "complete", ...canonicalComplete };
+
+  const fallbackVersion = previousCollectionVersion();
+  if (fallbackVersion) {
+    const stale = await latestCompleteSnapshot(username, fallbackVersion, false);
+    if (stale) {
+      const refreshPending = run?.state === "queued" || run?.state === "running";
+      return {
+        status: "stale",
+        ...stale,
+        refreshPending,
+        refreshRun: run ?? null,
+        servedCollectionVersion: fallbackVersion,
+        targetCollectionVersion: PUBLIC_SCAN_COLLECTION_VERSION,
+      };
+    }
+  }
+
   if (!run) return null;
-  const scan = parseCompleteSnapshot(run);
-  if (scan) return { status: "complete", run, scan };
   if (run.state === "failed" && Date.now() - run.updatedAt < FAILED_RUN_RETRY_MS) {
     return { status: "failed", run, retryAfterSeconds: retryAfter(run) };
   }


### PR DESCRIPTION
## Purpose

Prevent a completed formal v3 public-history snapshot from disappearing while the canonical v4 collector is unavailable, queued, running, or retried.

## Read Contract

- Read only the manifest-defined order: `v4`, then formal `v3`.
- Never read, alias, replay, migrate, or backfill `v5` (or any other non-formal collection).
- Validate stored hash, identity, complete coverage/sources, required payload fields, and stored deterministic score structure before serving v3.
- Keep v3 explicitly marked as `stale`, with served and target collection versions in every affected response.

## Write Boundary

- Passive score, roast, status, MCP, profile/search/leaderboard/facet/sitemap paths do not enqueue v4 work from a stale v3 snapshot.
- Only explicit `POST /api/scan` may create or retry a single v4 durable job; it continues returning v3 until a complete v4 snapshot atomically replaces it.
- v3 evidence never writes a v9 score, roast, report, cache provenance, or leaderboard row.

## Verification

- Added DB, public-scan, REST, roast, MCP, and release-contract coverage for valid/stale, corrupt, rejected-v5, pending, and failed-refresh cases.
- `pnpm test` (67 files, 564 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm versions:check --base-ref upstream/dev` confirms canonical `v9/v9/v4`.

## Deployment Follow-up

After merging to `dev`, deploy that branch and verify a valid v3 stale response, an explicit v4 refresh, Cron progress, and the atomic switch to v4. Production promotion remains an operator-controlled step.