### PR TITLE
fix(read): replay verified v5 legacy artifacts

### DIFF
--- a/config/release-versions.json
+++ b/config/release-versions.json
@@ -24,6 +24,11 @@
     ],
     "collectionReadOrder": ["v4", "v3"]
   },
+  "legacyReadFallback": {
+    "score": "v5",
+    "roast": "v5",
+    "collection": "v3"
+  },
   "changeControl": {
     "maxComponentsPerPullRequest": 1,
     "approvedMultiComponentIssue": null

--- a/docs/releases/v9-v9-v4-rollout.md
+++ b/docs/releases/v9-v9-v4-rollout.md
@@ -83,6 +83,21 @@ not create a refresh. An explicit scan may create at most one v4 job and keeps
 returning the v3 snapshot while that refresh is pending or failed. v5 and every
 other non-formal collection remain ineligible for this path.
 
+## v5 emergency artifact fallback
+
+The canonical runtime remains v9/v9/v4. Separately, a read-only continuity
+path may expose an already-persisted v5 score and v5 roast only when the same
+account has a complete, hash-validated v3 public snapshot recorded with score
+version v5. This exact v5/v5/v3 tuple is not an alias, a formal compatibility
+target, a queue target, or a write/migration source.
+
+The fallback serves existing profile and score reads as stale and can replay the
+stored report without an LLM configuration, Cron run, cache write, scan, score
+materialization, or refresh job. It never reconstructs a report from
+`score_snapshots`: those rows do not contain report markdown. A caller that
+explicitly requests refresh bypasses the fallback and continues toward canonical
+v9 work. Missing, mismatched, corrupt, or incomplete tuple members fail closed.
+
 ## Obsolete-job quarantine
 
 The operator endpoint returns aggregate counts only:

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -5,6 +5,7 @@ import type { ScanResult } from "@/lib/types";
 const mocks = vi.hoisted(() => ({
   getArchivedRoast: vi.fn(),
   getCanonicalScoreWriteIdentity: vi.fn(),
+  getLegacyReadFallbackRoast: vi.fn(),
   getScoreScannedAt: vi.fn(),
   getRank: vi.fn(),
   updateRoast: vi.fn(),
@@ -40,6 +41,7 @@ vi.mock("botid/server", () => ({
 vi.mock("@/lib/db", () => ({
   getArchivedRoast: mocks.getArchivedRoast,
   getCanonicalScoreWriteIdentity: mocks.getCanonicalScoreWriteIdentity,
+  getLegacyReadFallbackRoast: mocks.getLegacyReadFallbackRoast,
   getScoreScannedAt: mocks.getScoreScannedAt,
   updateRoast: mocks.updateRoast,
 }));
@@ -283,6 +285,7 @@ beforeEach(() => {
   mocks.requiresDurablePublicScan.mockReturnValue(false);
   mocks.getCachedRoast.mockResolvedValue(null);
   mocks.getArchivedRoast.mockResolvedValue(null);
+  mocks.getLegacyReadFallbackRoast.mockResolvedValue(null);
   mocks.getScoreScannedAt.mockResolvedValue(null);
   mocks.checkRoastRequestRateLimit.mockResolvedValue({ success: true });
   mocks.clearCachedRoast.mockResolvedValue(undefined);
@@ -309,6 +312,64 @@ beforeEach(() => {
 });
 
 describe("roast API persistence", () => {
+  it("replays a verified v5/v5/v3 artifact before any LLM or durable-scan work", async () => {
+    mocks.getLegacyReadFallbackRoast.mockResolvedValue({
+      username: "legacy-read-fixture",
+      final_score: 73,
+      tier: "人上人",
+      tags: { zh: ["旧版"], en: ["legacy"] },
+      roast_line: { zh: "旧版锐评。", en: "Legacy roast." },
+      report: "## 旧版点评\nCron 不可用时仍可阅读。",
+    });
+    mocks.defaultLlmConfig.mockReturnValue(null);
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ username: "legacy-read-fixture", lang: "zh" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("Cron 不可用时仍可阅读。");
+    expect(mocks.defaultLlmConfig).not.toHaveBeenCalled();
+    expect(mocks.getPublicScanStatus).not.toHaveBeenCalled();
+    expect(mocks.getCachedScan).not.toHaveBeenCalled();
+    expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
+    expect(mocks.setCachedRoast).not.toHaveBeenCalled();
+  });
+
+  it("skips the legacy artifact when refresh explicitly requests v9 work", async () => {
+    mocks.getLegacyReadFallbackRoast.mockResolvedValue({
+      username: "legacy-read-fixture",
+      final_score: 73,
+      tier: "人上人",
+      tags: { zh: ["旧版"], en: ["legacy"] },
+      roast_line: { zh: "旧版锐评。", en: "Legacy roast." },
+      report: "## 旧版点评\n只读回放。",
+    });
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "stale",
+      run: { id: "legacy-run", username: "legacy-read-fixture", collectionVersion: "v3" },
+      scan,
+      refreshPending: false,
+      refreshRun: null,
+      servedCollectionVersion: "v3",
+      targetCollectionVersion: "v4",
+    });
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ username: "legacy-read-fixture", lang: "zh", refresh: true }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(mocks.getLegacyReadFallbackRoast).not.toHaveBeenCalled();
+    expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
+  });
+
   it("does not generate or queue a report from stale v3 evidence", async () => {
     mocks.getPublicScanStatus.mockResolvedValue({
       status: "stale",

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -6,6 +6,7 @@ import { machineAuth } from "@/lib/machine-auth";
 import {
   getArchivedRoast,
   getCanonicalScoreWriteIdentity,
+  getLegacyReadFallbackRoast,
   getScoreScannedAt,
   updateRoast,
   type ScoreWriteIdentity,
@@ -646,6 +647,32 @@ export async function POST(req: NextRequest) {
   }
 
   const lang = normLang(body.lang);
+
+  // A verified v5/v5/v3 artifact is a read-only continuity path for a stalled
+  // v9 collector. It is intentionally checked before resolving an LLM config:
+  // replaying already-persisted public text must not depend on model capacity or
+  // spend credit. `refresh` explicitly opts out and continues toward v9 work.
+  if (body.refresh !== true) {
+    const legacyRoast = await getLegacyReadFallbackRoast(username, lang);
+    if (legacyRoast && reportMatchesLang(legacyRoast.report, lang)) {
+      const meta = await metaForStoredRoast(
+        legacyRoast.final_score,
+        legacyRoast.tier,
+        legacyRoast.tags,
+        legacyRoast.roast_line,
+        lang,
+      );
+      logRoastSummary({
+        requestId,
+        lang,
+        path: "legacy_read_fallback",
+        ok: true,
+        source: "legacy_v5_v5_v3",
+        requestTotalMs: Date.now() - reqT0,
+      });
+      return roastResponse(legacyRoast.report, meta);
+    }
+  }
 
   const resolved = resolveConfig(body.byoKey);
   if (!resolved) {

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -6,6 +6,7 @@ import { createClient } from "@libsql/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ROAST_CACHE_VERSION, SCORE_CACHE_VERSION } from "../cache-version";
 import type { ScoreEntry, ScoreWriteIdentity } from "../db";
+import { LEGACY_READ_FALLBACK } from "../release-versions";
 import { PUBLIC_SCAN_COLLECTION_VERSION, type PublicScanSourceStatus } from "../scan-run-types";
 import { score } from "../score";
 import type { RawMetrics, ScanResult } from "../types";
@@ -170,6 +171,54 @@ async function writeScore(scoreEntry: ScoreEntry): Promise<ScoreWriteIdentity> {
   return identity;
 }
 
+async function writeLegacyReadFallback(username: string): Promise<void> {
+  const identity = await db.recordScore({ ...entry, username });
+  if (!identity) throw new Error("expected synthetic legacy score write");
+  const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+  const scan = syntheticScan(username);
+  scan.scoring.final_score = entry.final_score;
+  const serialized = serializeScan(scan);
+  const now = entry.scanned_at;
+  await client.batch(
+    [
+      {
+        sql: `UPDATE scores
+              SET score_version = ?, score_source_collection_version = NULL,
+                  score_source_snapshot_hash = NULL, roast = ?, roast_version = ?,
+                  roast_en = ?, roast_en_version = ?
+              WHERE username = ?`,
+        args: [
+          LEGACY_READ_FALLBACK.score,
+          "## 旧版中文点评\n只读回放。",
+          LEGACY_READ_FALLBACK.roast,
+          "## Legacy English roast\nRead-only replay.",
+          LEGACY_READ_FALLBACK.roast,
+          username,
+        ],
+      },
+      {
+        sql: `INSERT INTO public_scan_runs
+                (id, username, score_version, collection_version, state, coverage,
+                 source_status, snapshot, snapshot_hash, started_at, completed_at, updated_at)
+              VALUES (?, ?, ?, ?, 'complete_public', 'complete_public', ?, ?, ?, ?, ?, ?)`,
+        args: [
+          `legacy-read-${username}`,
+          username,
+          LEGACY_READ_FALLBACK.score,
+          LEGACY_READ_FALLBACK.collection,
+          JSON.stringify(COMPLETE_PUBLIC_SOURCES),
+          serialized.snapshot,
+          serialized.snapshotHash,
+          now,
+          now,
+          now,
+        ],
+      },
+    ],
+    "write",
+  );
+}
+
 describe("getArchivedRoast", () => {
   it("replays archived reports by username and language", async () => {
     const scoreWrite = await writeScore(entry);
@@ -231,6 +280,67 @@ describe("getArchivedRoast", () => {
 
     await expect(db.getArchivedRoast(username, "zh")).resolves.toBeNull();
     await expect(db.getAccountDetail(username)).resolves.toMatchObject({ roast: null });
+  });
+
+  it("serves an exact v5/v5/v3 artifact as a stale read without changing its score", async () => {
+    const username = "legacy-read-fixture";
+    await writeLegacyReadFallback(username);
+
+    await expect(db.getAccountDetail(username)).resolves.toMatchObject({
+      username,
+      final_score: entry.final_score,
+      score_version: LEGACY_READ_FALLBACK.score,
+      tags: entry.tags,
+      roast: "## 旧版中文点评\n只读回放。",
+      roast_en: "## Legacy English roast\nRead-only replay.",
+    });
+    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toMatchObject({
+      username,
+      final_score: entry.final_score,
+      report: "## 旧版中文点评\n只读回放。",
+    });
+    await expect(db.getLegacyReadFallbackRoast(username, "en")).resolves.toMatchObject({
+      report: "## Legacy English roast\nRead-only replay.",
+    });
+  });
+
+  it("rejects a v5 report when its v3 snapshot no longer proves the exact tuple", async () => {
+    const username = "legacy-fallback-mismatch";
+    await writeLegacyReadFallback(username);
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: `UPDATE public_scan_runs SET score_version = ? WHERE username = ?`,
+      args: ["v6", username],
+    });
+
+    await expect(db.getAccountDetail(username)).resolves.toMatchObject({
+      final_score: entry.final_score,
+      tags: { zh: [], en: [] },
+      roast: null,
+      roast_en: null,
+    });
+    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toBeNull();
+  });
+
+  it("rejects a v5 report when its v3 snapshot score differs from the score row", async () => {
+    const username = "legacy-fallback-score-mismatch";
+    await writeLegacyReadFallback(username);
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    const tamperedSnapshot = syntheticScan(username);
+    tamperedSnapshot.scoring.final_score = entry.final_score + 1;
+    const serialized = serializeScan(tamperedSnapshot);
+    await client.execute({
+      sql: `UPDATE public_scan_runs SET snapshot = ?, snapshot_hash = ? WHERE username = ?`,
+      args: [serialized.snapshot, serialized.snapshotHash, username],
+    });
+
+    await expect(db.getAccountDetail(username)).resolves.toMatchObject({
+      final_score: entry.final_score,
+      tags: { zh: [], en: [] },
+      roast: null,
+      roast_en: null,
+    });
+    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toBeNull();
   });
 
   it("clears generated reports when the deterministic score identity changes", async () => {

--- a/src/lib/__tests__/release-versions.test.ts
+++ b/src/lib/__tests__/release-versions.test.ts
@@ -26,6 +26,17 @@ describe("release version contract", () => {
     expect(RELEASE_VERSION_MANIFEST.aliases).toEqual([]);
   });
 
+  it("keeps the v5/v5/v3 emergency reader outside the formal lineage", () => {
+    expect(RELEASE_VERSION_MANIFEST.legacyReadFallback).toEqual({
+      score: "v5",
+      roast: "v5",
+      collection: "v3",
+    });
+    expect(RELEASE_VERSION_MANIFEST.compatibility.roastReplay).toEqual([
+      { score: "v9", roast: "v9" },
+    ]);
+  });
+
   it("requires the runtime to remain on the canonical release after normalization", () => {
     expect(releaseVersionErrors()).toEqual([]);
     expect(RELEASE_VERSION_MANIFEST.runtimeEnforcement).toEqual({
@@ -57,6 +68,12 @@ describe("release version contract", () => {
     replayManifest.compatibility.roastReplay = [{ score: "local", roast: "local" }];
     expect(releaseVersionErrors(replayManifest)).toContain(
       "roast replay must require the canonical score and roast pair",
+    );
+
+    const changedFallback = manifestCopy();
+    changedFallback.legacyReadFallback.score = "v6";
+    expect(releaseVersionErrors(changedFallback)).toContain(
+      "legacy read fallback must remain the exact v5/v5/v3 artifact tuple",
     );
   });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -45,7 +45,7 @@ import {
 } from "./redis";
 import type { Lang } from "./lang";
 import { rankSimilar } from "./similarity";
-import { RELEASE_VERSION_MANIFEST } from "./release-versions";
+import { LEGACY_READ_FALLBACK, RELEASE_VERSION_MANIFEST } from "./release-versions";
 import {
   materializeCanonicalScore,
   type CanonicalScoreMaterialization,
@@ -88,6 +88,91 @@ const PUBLIC_PROFILE_SCORE_VERSIONS = RELEASE_VERSION_MANIFEST.compatibility
 const HEAT_LOOKUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const TRENDING_LOOKUP_WINDOW_MS = 7 * HEAT_LOOKUP_WINDOW_MS;
 const MIN_RECORDED_LOOKUP_COUNT = 1;
+
+function hasLegacyReadFallbackReport(row: Record<string, unknown>): boolean {
+  return (
+    row.score_version === LEGACY_READ_FALLBACK.score &&
+    ((row.roast_version === LEGACY_READ_FALLBACK.roast &&
+      typeof row.roast === "string" &&
+      row.roast.length > 0) ||
+      (row.roast_en_version === LEGACY_READ_FALLBACK.roast &&
+        typeof row.roast_en === "string" &&
+        row.roast_en.length > 0))
+  );
+}
+
+function isVerifiedLegacyReadFallbackRun(
+  run: PublicScanRun,
+  username: string,
+  finalScore: number,
+): boolean {
+  if (
+    run.scoreVersion !== LEGACY_READ_FALLBACK.score ||
+    run.collectionVersion !== LEGACY_READ_FALLBACK.collection ||
+    !run.snapshot ||
+    !run.snapshotHash ||
+    !hasCompletePublicScanSources(run.sourceStatus) ||
+    createHash("sha256").update(run.snapshot).digest("hex") !== run.snapshotHash
+  ) {
+    return false;
+  }
+  try {
+    const snapshot = JSON.parse(run.snapshot) as Partial<ScanResult>;
+    return (
+      typeof snapshot.metrics?.username === "string" &&
+      snapshot.metrics.username.trim().toLowerCase() === username &&
+      typeof snapshot.scoring?.final_score === "number" &&
+      Number.isFinite(snapshot.scoring.final_score) &&
+      snapshot.scoring.final_score === finalScore
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A v5 report may be served only when its score row and a complete v3 factual
+ * snapshot agree on the same account/version contract. This is read-only: it
+ * never upgrades, queues, re-scores, or invokes an LLM.
+ */
+async function isVerifiedLegacyReadFallback(
+  db: Client,
+  row: Record<string, unknown>,
+): Promise<boolean> {
+  if (!hasLegacyReadFallbackReport(row)) return false;
+  const username = typeof row.username === "string" ? row.username.trim().toLowerCase() : "";
+  const finalScore = Number(row.final_score);
+  if (!username || !Number.isFinite(finalScore)) return false;
+  try {
+    const result = await db.execute({
+      sql: `SELECT * FROM public_scan_runs
+            WHERE username = ?
+              AND score_version = ?
+              AND collection_version = ?
+              AND state = 'complete_public'
+              AND coverage = 'complete_public'
+              AND snapshot IS NOT NULL
+              AND snapshot_hash IS NOT NULL
+              AND completed_at IS NOT NULL
+            ORDER BY completed_at DESC, id DESC
+            LIMIT 8`,
+      args: [
+        username,
+        LEGACY_READ_FALLBACK.score,
+        LEGACY_READ_FALLBACK.collection,
+      ],
+    });
+    return result.rows.some((run) =>
+      isVerifiedLegacyReadFallbackRun(
+        mapPublicScanRun(run as Record<string, unknown>),
+        username,
+        finalScore,
+      ),
+    );
+  } catch {
+    return false;
+  }
+}
 
 function logPublicScanDbFailure(operation: string, error: unknown): void {
   console.error(
@@ -5570,6 +5655,16 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
       r.score_source_collection_version === PUBLIC_SCAN_COLLECTION_VERSION &&
       typeof r.score_source_snapshot_hash === "string" &&
       /^[a-f0-9]{64}$/.test(r.score_source_snapshot_hash);
+    const legacyReadFallback = !canonicalScore && await isVerifiedLegacyReadFallback(
+      db,
+      r as Record<string, unknown>,
+    );
+    const readableArtifacts = canonicalScore || legacyReadFallback;
+    const artifactRoastVersion = canonicalScore
+      ? ROAST_CACHE_VERSION
+      : legacyReadFallback
+        ? LEGACY_READ_FALLBACK.roast
+        : null;
     return {
       username: String(r.username),
       display_name: r.display_name as string | null,
@@ -5577,15 +5672,15 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
       profile_url: r.profile_url as string | null,
       final_score: Number(r.final_score),
       tier: String(r.tier) as Tier,
-      tags: canonicalScore ? parseTags(r.tags) : EMPTY_TAGS,
-      roast_line: canonicalScore ? parseRoastLine(r.roast_line) : EMPTY_ROAST_LINE,
+      tags: readableArtifacts ? parseTags(r.tags) : EMPTY_TAGS,
+      roast_line: readableArtifacts ? parseRoastLine(r.roast_line) : EMPTY_ROAST_LINE,
       sub_scores: parseSubScores(r.sub_scores),
       roast:
-        canonicalScore && r.roast_version === ROAST_CACHE_VERSION
+        artifactRoastVersion && r.roast_version === artifactRoastVersion
           ? ((r.roast as string | null) ?? null)
           : null,
       roast_en:
-        canonicalScore && r.roast_en_version === ROAST_CACHE_VERSION
+        artifactRoastVersion && r.roast_en_version === artifactRoastVersion
           ? ((r.roast_en as string | null) ?? null)
           : null,
       score_version: typeof r.score_version === "string" ? r.score_version : null,
@@ -5601,6 +5696,52 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
     };
   } catch (e) {
     console.error("getAccountDetail failed:", e);
+    return null;
+  }
+}
+
+/**
+ * Read one verified v5/v5/v3 report without requiring a current scan or LLM
+ * configuration. The caller must treat it as stale and must never cache it as
+ * a canonical v9 report.
+ */
+export async function getLegacyReadFallbackRoast(
+  username: string,
+  lang: Lang,
+): Promise<ArchivedRoast | null> {
+  const db = getClient();
+  if (!db) return null;
+  const col = lang === "en" ? "roast_en" : "roast";
+  const versionCol = lang === "en" ? "roast_en_version" : "roast_version";
+  try {
+    await ensureSchema(db);
+    const result = await db.execute({
+      sql: `SELECT username, final_score, tier, tags, roast_line, score_version,
+                   roast, roast_en, roast_version, roast_en_version
+            FROM scores
+            WHERE username = ? AND hidden = 0 AND score_version = ?
+            LIMIT 1`,
+      args: [username.toLowerCase(), LEGACY_READ_FALLBACK.score],
+    });
+    const row = result.rows[0] as Record<string, unknown> | undefined;
+    if (!row || !(await isVerifiedLegacyReadFallback(db, row))) return null;
+    if (
+      row[versionCol] !== LEGACY_READ_FALLBACK.roast ||
+      typeof row[col] !== "string" ||
+      !row[col]
+    ) {
+      return null;
+    }
+    return {
+      username: String(row.username),
+      final_score: Number(row.final_score),
+      tier: String(row.tier) as Tier,
+      tags: parseTags(row.tags),
+      roast_line: parseRoastLine(row.roast_line),
+      report: row[col],
+    };
+  } catch (error) {
+    console.error("getLegacyReadFallbackRoast failed:", error);
     return null;
   }
 }

--- a/src/lib/release-versions.ts
+++ b/src/lib/release-versions.ts
@@ -24,6 +24,11 @@ export interface ReleaseVersionManifest {
     roastReplay: { score: string; roast: string }[];
     collectionReadOrder: string[];
   };
+  /**
+   * A read-only emergency artifact tuple. It is never a canonical version,
+   * replay alias, migration source, or queue target.
+   */
+  legacyReadFallback: ReleaseVersionSet;
   changeControl: {
     maxComponentsPerPullRequest: number;
     approvedMultiComponentIssue: number | null;
@@ -33,6 +38,19 @@ export interface ReleaseVersionManifest {
 }
 
 export const RELEASE_VERSION_MANIFEST = manifestJson as ReleaseVersionManifest;
+
+/**
+ * The only historical artifact tuple permitted for emergency reads. Keep this
+ * separate from `compatibility`: normal reads remain v9 -> v8 and v4 -> v3.
+ */
+export const LEGACY_READ_FALLBACK: ReleaseVersionSet =
+  RELEASE_VERSION_MANIFEST.legacyReadFallback;
+
+const EXPECTED_LEGACY_READ_FALLBACK: ReleaseVersionSet = {
+  score: "v5",
+  roast: "v5",
+  collection: "v3",
+};
 
 export const RUNTIME_RELEASE_VERSIONS: ReleaseVersionSet = {
   score: SCORE_CACHE_VERSION,
@@ -207,6 +225,13 @@ export function releaseVersionErrors(
     ) {
       errors.push("roast replay must require the canonical score and roast pair");
     }
+  }
+
+  if (
+    !isVersionSet(typed.legacyReadFallback) ||
+    !sameVersions(typed.legacyReadFallback, EXPECTED_LEGACY_READ_FALLBACK)
+  ) {
+    errors.push("legacy read fallback must remain the exact v5/v5/v3 artifact tuple");
   }
 
   if (!Array.isArray(typed.aliases) || typed.aliases.length !== 0) {


### PR DESCRIPTION
## Behavior
- Keeps the canonical runtime at v9/v9/v4.
- Serves a v5 score/report only when a complete, SHA-256-validated v3 public snapshot for the same account has the exact v5 score.
- Replays the stored report before LLM configuration, Cron, queue, scan, or cache work for ordinary reads; `refresh: true` bypasses this fallback and continues toward canonical v9 work.
- Fails closed for a missing, mismatched, corrupt, or incomplete artifact tuple.

## Guardrails
- v5/v5/v3 is an explicit read-only emergency tuple, not an alias, canonical target, queue target, or write/migration source.
- Existing reports cannot be reconstructed from score snapshots; only a still-persisted matching report may be replayed.

## Verification
- `pnpm test` (71 files, 586 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `node --import tsx scripts/check-release-versions.mts --base-ref upstream/dev`

## Staging smoke
Validate one pre-existing v5/v5/v3 artifact and one tuple mismatch. Confirm that the fallback remains stale/read-only and that explicit refresh still requests v9 work.