### PR TITLE
fix(scan): hand off verified legacy artifacts before refresh

### DIFF
--- a/docs/releases/v9-v9-v4-rollout.md
+++ b/docs/releases/v9-v9-v4-rollout.md
@@ -92,11 +92,13 @@ version v5. This exact v5/v5/v3 tuple is not an alias, a formal compatibility
 target, a queue target, or a write/migration source.
 
 The fallback serves existing profile and score reads as stale and can replay the
-stored report without an LLM configuration, Cron run, cache write, scan, score
-materialization, or refresh job. It never reconstructs a report from
-`score_snapshots`: those rows do not contain report markdown. A caller that
-explicitly requests refresh bypasses the fallback and continues toward canonical
-v9 work. Missing, mismatched, corrupt, or incomplete tuple members fail closed.
+stored report without an LLM configuration, Cron run, cache write, scan, or score
+materialization. A home-page explicit scan first returns the verified v5/v5/v3
+profile and report handoff, then best-effort starts or resumes only its canonical
+v9/v4 refresh; queue admission or storage failure cannot turn that readable
+result into a waiting screen. It never reconstructs a report from
+`score_snapshots`: those rows do not contain report markdown. Missing,
+mismatched, corrupt, or incomplete tuple members fail closed.
 
 ## Obsolete-job quarantine
 

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   score: vi.fn(),
   verifyTurnstile: vi.fn(),
   ensureCanonicalScoreForPublicRun: vi.fn(),
+  getLegacyReadFallbackScan: vi.fn(),
   publishCompleteQuickScan: vi.fn(),
   recordAccountLookup: vi.fn(),
   getLatestPublicScanRun: vi.fn(),
@@ -25,6 +26,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/db", () => ({
   ensureCanonicalScoreForPublicRun: mocks.ensureCanonicalScoreForPublicRun,
+  getLegacyReadFallbackScan: mocks.getLegacyReadFallbackScan,
   publishCompleteQuickScan: mocks.publishCompleteQuickScan,
   recordAccountLookup: mocks.recordAccountLookup,
   getLatestPublicScanRun: mocks.getLatestPublicScanRun,
@@ -134,6 +136,7 @@ describe("scan route machine auth", () => {
       scannedAt: 1_800_000_000_000,
       token: "score-write-token",
     });
+    mocks.getLegacyReadFallbackScan.mockResolvedValue(null);
     mocks.clearCachedScan.mockResolvedValue(undefined);
     mocks.recordAccountLookup.mockResolvedValue(true);
     mocks.getLatestPublicScanRun.mockResolvedValue(null);
@@ -272,6 +275,112 @@ describe("scan route machine auth", () => {
     expect(mocks.collect).not.toHaveBeenCalled();
     expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
+  });
+
+  it("hands a verified v5/v5/v3 profile to the home flow while v9/v4 refreshes", async () => {
+    const legacyScan = {
+      metrics,
+      scoring,
+      top_repos: [],
+      recent_prs: [],
+      flood_pr_titles: [],
+      impact_repos: [],
+      verified_impact_prs: [],
+      pinned_repos: [],
+      organizations: [],
+    };
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "pending",
+      run: { id: "canonical-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: null,
+    });
+    mocks.getLegacyReadFallbackScan.mockResolvedValue(legacyScan);
+    mocks.startPublicScan.mockResolvedValue({
+      status: "pending",
+      run: { id: "canonical-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: "canonical-job",
+    });
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      metrics: { username: "DemoDev" },
+      cached: true,
+      stale: true,
+      legacy_read_fallback: true,
+      refresh_pending: true,
+      run_id: "canonical-run",
+      served_score_version: "v5",
+      served_roast_version: "v5",
+      served_collection_version: "v3",
+      target_score_version: "v9",
+      target_roast_version: "v9",
+      target_collection_version: "v4",
+    });
+    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("canonical-job");
+    expect(mocks.getCachedScan).not.toHaveBeenCalled();
+    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
+    expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
+    expect(mocks.recordAccountLookup).not.toHaveBeenCalled();
+  });
+
+  it("keeps the verified v5/v5/v3 profile readable when v9 admission is full", async () => {
+    mocks.getLegacyReadFallbackScan.mockResolvedValue({
+      metrics,
+      scoring,
+      top_repos: [],
+      recent_prs: [],
+      flood_pr_titles: [],
+      impact_repos: [],
+      verified_impact_prs: [],
+      pinned_repos: [],
+      organizations: [],
+    });
+    mocks.startPublicScan.mockResolvedValue({
+      status: "queue_full",
+      run: null,
+      retryAfterSeconds: 60,
+    });
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      legacy_read_fallback: true,
+      refresh_pending: false,
+    });
+    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+  });
+
+  it("keeps the verified v5/v5/v3 profile readable when starting v9 refresh throws", async () => {
+    mocks.getLegacyReadFallbackScan.mockResolvedValue({
+      metrics,
+      scoring,
+      top_repos: [],
+      recent_prs: [],
+      flood_pr_titles: [],
+      impact_repos: [],
+      verified_impact_prs: [],
+      pinned_repos: [],
+      organizations: [],
+    });
+    mocks.startPublicScan.mockRejectedValue(new Error("storage unavailable"));
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      legacy_read_fallback: true,
+      refresh_pending: false,
+    });
+    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
   });
 
   it("lets an explicit scan retry after a failed v4 refresh while serving v3", async () => {

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { campaignSlug, type CampaignSlug } from "@/lib/campaigns";
 import {
   ensureCanonicalScoreForPublicRun,
+  getLegacyReadFallbackScan,
   publishCompleteQuickScan,
   recordAccountLookup,
   recordCampaignParticipant,
@@ -26,6 +27,7 @@ import {
   startPublicScan,
 } from "@/lib/public-scan";
 import { kickPublicScanDrain } from "@/lib/public-scan-dispatcher";
+import { LEGACY_READ_FALLBACK, RUNTIME_RELEASE_VERSIONS } from "@/lib/release-versions";
 import { verifyTurnstile } from "@/lib/turnstile";
 import { normalizeUsername } from "@/lib/username";
 
@@ -162,6 +164,50 @@ async function staleSnapshotResponse(input: {
   );
 }
 
+/**
+ * An explicit scan may ask for canonical v9/v4 work, but a verified v5/v5/v3
+ * artifact is still immediately useful to the visitor. The refresh attempt is
+ * intentionally best-effort: queue or storage pressure must never turn a
+ * readable historical profile back into a waiting screen.
+ */
+async function legacyReadFallbackResponse(input: {
+  username: string;
+  scan: import("@/lib/types").ScanResult;
+  admission: ReturnType<typeof publicScanAdmission>;
+  headers: Record<string, string>;
+}) {
+  let refresh: PublicScanResolution | null = null;
+  try {
+    refresh = await startPublicScan(input.username, input.admission);
+    if (refresh.status === "pending" && refresh.headStartJobId) {
+      kickPublicScanDrain(refresh.headStartJobId);
+    }
+  } catch {
+    // The fallback has already passed provenance validation. A failed refresh
+    // attempt must not withhold it from the visitor.
+    console.error("legacyReadFallback refresh start failed");
+  }
+  const refreshRun = refresh && "run" in refresh ? refresh.run : null;
+  return NextResponse.json(
+    {
+      ...input.scan,
+      cached: true,
+      coverage: "complete_public",
+      stale: true,
+      legacy_read_fallback: true,
+      refresh_pending: refresh?.status === "pending",
+      served_score_version: LEGACY_READ_FALLBACK.score,
+      served_roast_version: LEGACY_READ_FALLBACK.roast,
+      served_collection_version: LEGACY_READ_FALLBACK.collection,
+      target_score_version: RUNTIME_RELEASE_VERSIONS.score,
+      target_roast_version: RUNTIME_RELEASE_VERSIONS.roast,
+      target_collection_version: RUNTIME_RELEASE_VERSIONS.collection,
+      ...(refreshRun ? { run_id: refreshRun.id } : {}),
+    },
+    { headers: { ...input.headers, "Cache-Control": "no-store" } },
+  );
+}
+
 async function durableResponse(input: {
   username: string;
   scan: import("@/lib/types").ScanResult;
@@ -242,10 +288,8 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  // A cache entry is readable only when Turso has the matching complete run and
-  // canonical score. Pre-deployment quick cache entries have neither a trusted
-  // scan time nor provenance, so they are discarded and collected afresh.
-  const cached = await getCachedScan(username);
+  // Check the canonical durable state first. It always wins over the emergency
+  // read fallback if a v9/v4 result already exists.
   const status = await getPublicScanStatus(username);
   if (status?.status === "complete") {
     const scoreWrite = await ensureCanonicalScoreForPublicRun(status.run);
@@ -257,6 +301,26 @@ export async function POST(req: NextRequest) {
       { headers: { ...idem, ...rlHeaders } },
     );
   }
+
+  // The home flow starts here, before the profile page and /api/roast have a
+  // chance to replay a report. Without this handoff, a known-good v5/v5/v3
+  // artifact was hidden behind a v9/v4 collection wait. An explicit request
+  // may start canonical work, but only after this verified legacy result has
+  // been selected; it is never written into current caches or scores.
+  const legacyScan = await getLegacyReadFallbackScan(username);
+  if (legacyScan) {
+    return legacyReadFallbackResponse({
+      username: legacyScan.metrics.username,
+      scan: legacyScan,
+      admission: durableAdmission,
+      headers: { ...idem, ...rlHeaders },
+    });
+  }
+
+  // A cache entry is readable only when Turso has the matching complete run and
+  // canonical score. Pre-deployment quick cache entries have neither a trusted
+  // scan time nor provenance, so they are discarded and collected afresh.
+  const cached = await getCachedScan(username);
   if (status?.status === "stale") {
     await recordSuccessfulLookup(status.scan.metrics.username, ip, campaign);
     return staleSnapshotResponse({

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -302,6 +302,10 @@ describe("getArchivedRoast", () => {
     await expect(db.getLegacyReadFallbackRoast(username, "en")).resolves.toMatchObject({
       report: "## Legacy English roast\nRead-only replay.",
     });
+    await expect(db.getLegacyReadFallbackScan(username)).resolves.toMatchObject({
+      metrics: { username },
+      scoring: { final_score: entry.final_score },
+    });
   });
 
   it("rejects a v5 report when its v3 snapshot no longer proves the exact tuple", async () => {
@@ -320,6 +324,7 @@ describe("getArchivedRoast", () => {
       roast_en: null,
     });
     await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toBeNull();
+    await expect(db.getLegacyReadFallbackScan(username)).resolves.toBeNull();
   });
 
   it("rejects a v5 report when its v3 snapshot score differs from the score row", async () => {
@@ -341,6 +346,7 @@ describe("getArchivedRoast", () => {
       roast_en: null,
     });
     await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toBeNull();
+    await expect(db.getLegacyReadFallbackScan(username)).resolves.toBeNull();
   });
 
   it("clears generated reports when the deterministic score identity changes", async () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -101,11 +101,11 @@ function hasLegacyReadFallbackReport(row: Record<string, unknown>): boolean {
   );
 }
 
-function isVerifiedLegacyReadFallbackRun(
+function parseVerifiedLegacyReadFallbackRun(
   run: PublicScanRun,
   username: string,
   finalScore: number,
-): boolean {
+): ScanResult | null {
   if (
     run.scoreVersion !== LEGACY_READ_FALLBACK.score ||
     run.collectionVersion !== LEGACY_READ_FALLBACK.collection ||
@@ -114,19 +114,25 @@ function isVerifiedLegacyReadFallbackRun(
     !hasCompletePublicScanSources(run.sourceStatus) ||
     createHash("sha256").update(run.snapshot).digest("hex") !== run.snapshotHash
   ) {
-    return false;
+    return null;
   }
   try {
     const snapshot = JSON.parse(run.snapshot) as Partial<ScanResult>;
-    return (
-      typeof snapshot.metrics?.username === "string" &&
-      snapshot.metrics.username.trim().toLowerCase() === username &&
-      typeof snapshot.scoring?.final_score === "number" &&
-      Number.isFinite(snapshot.scoring.final_score) &&
-      snapshot.scoring.final_score === finalScore
-    );
+    if (
+      typeof snapshot.metrics?.username !== "string" ||
+      snapshot.metrics.username.trim().toLowerCase() !== username ||
+      typeof snapshot.scoring?.final_score !== "number" ||
+      !Number.isFinite(snapshot.scoring.final_score) ||
+      snapshot.scoring.final_score !== finalScore ||
+      !Array.isArray(snapshot.top_repos) ||
+      !Array.isArray(snapshot.recent_prs) ||
+      !Array.isArray(snapshot.flood_pr_titles)
+    ) {
+      return null;
+    }
+    return snapshot as ScanResult;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -135,14 +141,14 @@ function isVerifiedLegacyReadFallbackRun(
  * snapshot agree on the same account/version contract. This is read-only: it
  * never upgrades, queues, re-scores, or invokes an LLM.
  */
-async function isVerifiedLegacyReadFallback(
+async function getVerifiedLegacyReadFallbackScan(
   db: Client,
   row: Record<string, unknown>,
-): Promise<boolean> {
-  if (!hasLegacyReadFallbackReport(row)) return false;
+): Promise<ScanResult | null> {
+  if (!hasLegacyReadFallbackReport(row)) return null;
   const username = typeof row.username === "string" ? row.username.trim().toLowerCase() : "";
   const finalScore = Number(row.final_score);
-  if (!username || !Number.isFinite(finalScore)) return false;
+  if (!username || !Number.isFinite(finalScore)) return null;
   try {
     const result = await db.execute({
       sql: `SELECT * FROM public_scan_runs
@@ -162,16 +168,25 @@ async function isVerifiedLegacyReadFallback(
         LEGACY_READ_FALLBACK.collection,
       ],
     });
-    return result.rows.some((run) =>
-      isVerifiedLegacyReadFallbackRun(
+    for (const run of result.rows) {
+      const scan = parseVerifiedLegacyReadFallbackRun(
         mapPublicScanRun(run as Record<string, unknown>),
         username,
         finalScore,
-      ),
-    );
+      );
+      if (scan) return scan;
+    }
+    return null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+async function isVerifiedLegacyReadFallback(
+  db: Client,
+  row: Record<string, unknown>,
+): Promise<boolean> {
+  return Boolean(await getVerifiedLegacyReadFallbackScan(db, row));
 }
 
 function logPublicScanDbFailure(operation: string, error: unknown): void {
@@ -5696,6 +5711,33 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
     };
   } catch (e) {
     console.error("getAccountDetail failed:", e);
+    return null;
+  }
+}
+
+/**
+ * Return the complete stored v3 snapshot that proves a v5/v5 emergency read
+ * fallback. This is deliberately read-only: callers may display it immediately
+ * while separately requesting canonical v9/v4 collection, but must never cache
+ * it as current or use it to materialize a score.
+ */
+export async function getLegacyReadFallbackScan(username: string): Promise<ScanResult | null> {
+  const db = getClient();
+  if (!db) return null;
+  try {
+    await ensureSchema(db);
+    const result = await db.execute({
+      sql: `SELECT username, final_score, score_version, roast, roast_en,
+                   roast_version, roast_en_version
+            FROM scores
+            WHERE username = ? AND hidden = 0 AND score_version = ?
+            LIMIT 1`,
+      args: [username.toLowerCase(), LEGACY_READ_FALLBACK.score],
+    });
+    const row = result.rows[0] as Record<string, unknown> | undefined;
+    return row ? await getVerifiedLegacyReadFallbackScan(db, row) : null;
+  } catch (error) {
+    console.error("getLegacyReadFallbackScan failed:", error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- return a hash-validated v5/v5/v3 profile snapshot from the home scan API before a pending v9/v4 collector can produce a waiting state
- start or resume only canonical v9/v4 collection after the fallback is selected; admission and storage failures leave the verified legacy result readable
- keep version metadata sourced from the release manifest and document the explicit handoff contract

## Safety
- no version constants, Cron configuration, cache writes, score writes, or LLM generation were changed
- fallback requires matching account identity, v5 score/report versions, complete v3 sources, SHA-256 snapshot integrity, and exact final-score equality
- canonical v9/v4 still wins whenever it is already complete

## Verification
- `pnpm test` (71 files, 589 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm versions:check`