### PR TITLE
fix(read): replay v5 profiles during canonical scans

### DIFF
--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -235,22 +235,28 @@ export default async function AccountPage({
   // Direct visits / shared links (no param) keep the popup-free SSR page.
   const fromHome = query.roasting === "1";
   const refreshRunId = typeof query.refresh_run_id === "string" ? query.refresh_run_id : null;
-  const legacyReadFallback = d.score_version === LEGACY_READ_FALLBACK.score;
+  const legacyReadFallback = d.legacy_read_fallback;
   // eslint-disable-next-line react-hooks/purity -- force-dynamic Server Component: rendered per request, so wall-clock staleness here is intentional (and the server re-validates before spending LLM credit)
   const staleReroast = !legacyReadFallback && fromHome && Boolean(roast) && Date.now() - d.scanned_at > ROAST_FRESH_MS;
   // A profile read must stay read-only. Only the explicit homepage handoff may
   // mount LiveRoast and spend LLM credit; direct/shared profile visits show a
   // stable pending state even if a scan happens to remain in Redis.
-  const shouldStreamRoast = shouldStartProfileRoast({
-    explicitHandoff: fromHome,
-    hasReport: Boolean(roast),
-    staleReport: staleReroast,
-  });
+  const shouldStreamRoast =
+    !legacyReadFallback &&
+    shouldStartProfileRoast({
+      explicitHandoff: fromHome,
+      hasReport: Boolean(roast),
+      staleReport: staleReroast,
+    });
   const liveScan = shouldStreamRoast ? await getLiveScan(d.username) : null;
   // getAccountDetail only exposes report text after both its score and the
   // selected-language roast pass the canonical version checks. Preserve that
   // boundary here instead of guessing compatibility from report contents.
-  const selectedRoastVersion = roast ? ROAST_CACHE_VERSION : null;
+  const selectedRoastVersion = roast
+    ? legacyReadFallback
+      ? LEGACY_READ_FALLBACK.roast
+      : ROAST_CACHE_VERSION
+    : null;
   const artifactState = resolveProfileArtifactState({
     scoreVersion: d.score_version,
     sourceCollectionVersion: d.score_source_collection_version,

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   score: vi.fn(),
   verifyTurnstile: vi.fn(),
   ensureCanonicalScoreForPublicRun: vi.fn(),
+  hasLegacyReadFallbackProfile: vi.fn(),
   getLegacyReadFallbackScan: vi.fn(),
   publishCompleteQuickScan: vi.fn(),
   recordAccountLookup: vi.fn(),
@@ -26,6 +27,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/db", () => ({
   ensureCanonicalScoreForPublicRun: mocks.ensureCanonicalScoreForPublicRun,
+  hasLegacyReadFallbackProfile: mocks.hasLegacyReadFallbackProfile,
   getLegacyReadFallbackScan: mocks.getLegacyReadFallbackScan,
   publishCompleteQuickScan: mocks.publishCompleteQuickScan,
   recordAccountLookup: mocks.recordAccountLookup,
@@ -136,6 +138,7 @@ describe("scan route machine auth", () => {
       scannedAt: 1_800_000_000_000,
       token: "score-write-token",
     });
+    mocks.hasLegacyReadFallbackProfile.mockResolvedValue(false);
     mocks.getLegacyReadFallbackScan.mockResolvedValue(null);
     mocks.clearCachedScan.mockResolvedValue(undefined);
     mocks.recordAccountLookup.mockResolvedValue(true);
@@ -327,6 +330,45 @@ describe("scan route machine auth", () => {
     expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
     expect(mocks.recordAccountLookup).not.toHaveBeenCalled();
+  });
+
+  it("hands a stored v5 profile to the browser without fabricating a v3 scan", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "pending",
+      run: { id: "canonical-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: null,
+    });
+    mocks.hasLegacyReadFallbackProfile.mockResolvedValue(true);
+    mocks.startPublicScan.mockResolvedValue({
+      status: "pending",
+      run: { id: "canonical-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: "canonical-job",
+    });
+
+    const response = await POST(request({ auth: "Bearer cli-secret" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      username: "DemoDev",
+      cached: true,
+      stale: true,
+      legacy_read_fallback: true,
+      legacy_profile: true,
+      refresh_pending: true,
+      run_id: "canonical-run",
+      served_score_version: "v5",
+      served_roast_version: "v5",
+      served_collection_version: "v3",
+      target_score_version: "v9",
+      target_roast_version: "v9",
+      target_collection_version: "v4",
+    });
+    expect(mocks.getLegacyReadFallbackScan).toHaveBeenCalledWith("DemoDev");
+    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
+    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("canonical-job");
+    expect(mocks.collect).not.toHaveBeenCalled();
   });
 
   it("keeps the verified v5/v5/v3 profile readable when v9 admission is full", async () => {

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { campaignSlug, type CampaignSlug } from "@/lib/campaigns";
 import {
   ensureCanonicalScoreForPublicRun,
+  hasLegacyReadFallbackProfile,
   getLegacyReadFallbackScan,
   publishCompleteQuickScan,
   recordAccountLookup,
@@ -208,6 +209,48 @@ async function legacyReadFallbackResponse(input: {
   );
 }
 
+/**
+ * A v5/v5 profile can be useful even when the old v3 ScanResult has expired.
+ * Return a dedicated handoff rather than inventing a partial scan payload; the
+ * profile page reads the persisted artifact while the canonical v9/v4 job runs.
+ */
+async function legacyReadFallbackProfileResponse(input: {
+  username: string;
+  admission: ReturnType<typeof publicScanAdmission>;
+  headers: Record<string, string>;
+}) {
+  let refresh: PublicScanResolution | null = null;
+  try {
+    refresh = await startPublicScan(input.username, input.admission);
+    if (refresh.status === "pending" && refresh.headStartJobId) {
+      kickPublicScanDrain(refresh.headStartJobId);
+    }
+  } catch {
+    // A persisted read-only profile remains useful when the refresh queue is
+    // temporarily unavailable.
+    console.error("legacyReadFallback profile refresh start failed");
+  }
+  const refreshRun = refresh && "run" in refresh ? refresh.run : null;
+  return NextResponse.json(
+    {
+      username: input.username,
+      cached: true,
+      stale: true,
+      legacy_read_fallback: true,
+      legacy_profile: true,
+      refresh_pending: refresh?.status === "pending",
+      served_score_version: LEGACY_READ_FALLBACK.score,
+      served_roast_version: LEGACY_READ_FALLBACK.roast,
+      served_collection_version: LEGACY_READ_FALLBACK.collection,
+      target_score_version: RUNTIME_RELEASE_VERSIONS.score,
+      target_roast_version: RUNTIME_RELEASE_VERSIONS.roast,
+      target_collection_version: RUNTIME_RELEASE_VERSIONS.collection,
+      ...(refreshRun ? { run_id: refreshRun.id } : {}),
+    },
+    { headers: { ...input.headers, "Cache-Control": "no-store" } },
+  );
+}
+
 async function durableResponse(input: {
   username: string;
   scan: import("@/lib/types").ScanResult;
@@ -312,6 +355,18 @@ export async function POST(req: NextRequest) {
     return legacyReadFallbackResponse({
       username: legacyScan.metrics.username,
       scan: legacyScan,
+      admission: durableAdmission,
+      headers: { ...idem, ...rlHeaders },
+    });
+  }
+
+  // A complete old ScanResult is optional for continuity. The normal v5
+  // profile path below has an exact stored v5 score/report but no longer has
+  // its full v3 snapshot, so hand the browser to the profile instead of making
+  // it wait for a v9/v4 crawl or fabricating a scan payload.
+  if (await hasLegacyReadFallbackProfile(username)) {
+    return legacyReadFallbackProfileResponse({
+      username,
       admission: durableAdmission,
       headers: { ...idem, ...rlHeaders },
     });

--- a/src/components/CanonicalProfileUpgrade.tsx
+++ b/src/components/CanonicalProfileUpgrade.tsx
@@ -7,7 +7,10 @@ import {
   isCanonicalProfileUpgradeComplete,
 } from "@/lib/canonical-profile-upgrade";
 
-const MAX_WAIT_MS = 10 * 60 * 1_000;
+// Large public histories can take tens of minutes. The legacy profile is
+// already visible, so continue observing its single explicit refresh long
+// enough to switch to canonical data without starting another job.
+const MAX_WAIT_MS = 45 * 60 * 1_000;
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -248,6 +248,12 @@ export function Roaster({
           100,
         );
       };
+      const presentLegacyProfile = (handle: string, refreshRunId?: string) => {
+        const profileParams = new URLSearchParams({ roasting: "1" });
+        if (campaign) profileParams.set("campaign", campaign);
+        if (refreshRunId) profileParams.set("refresh_run_id", refreshRunId);
+        router.push(`/u/${handle}?${profileParams.toString()}`);
+      };
       try {
         const res = await fetch("/api/scan", {
           method: "POST",
@@ -303,6 +309,13 @@ export function Roaster({
         if (!res.ok) {
           setError(tScan.has(data?.error) ? tScan(data.error) : t("errScanFailed"));
           setScanning(false);
+          return;
+        }
+        if (data?.legacy_profile === true && typeof data.username === "string") {
+          presentLegacyProfile(
+            data.username,
+            typeof data?.run_id === "string" ? data.run_id : undefined,
+          );
           return;
         }
         const result = data as ScanResult;

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -290,6 +290,7 @@ describe("getArchivedRoast", () => {
       username,
       final_score: entry.final_score,
       score_version: LEGACY_READ_FALLBACK.score,
+      legacy_read_fallback: true,
       tags: entry.tags,
       roast: "## 旧版中文点评\n只读回放。",
       roast_en: "## Legacy English roast\nRead-only replay.",
@@ -308,7 +309,7 @@ describe("getArchivedRoast", () => {
     });
   });
 
-  it("rejects a v5 report when its v3 snapshot no longer proves the exact tuple", async () => {
+  it("keeps a v5 profile readable when its old v3 snapshot is no longer usable", async () => {
     const username = "legacy-fallback-mismatch";
     await writeLegacyReadFallback(username);
     const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
@@ -317,17 +318,21 @@ describe("getArchivedRoast", () => {
       args: ["v6", username],
     });
 
+    await expect(db.hasLegacyReadFallbackProfile(username)).resolves.toBe(true);
     await expect(db.getAccountDetail(username)).resolves.toMatchObject({
       final_score: entry.final_score,
-      tags: { zh: [], en: [] },
-      roast: null,
-      roast_en: null,
+      legacy_read_fallback: true,
+      tags: entry.tags,
+      roast: "## 旧版中文点评\n只读回放。",
+      roast_en: "## Legacy English roast\nRead-only replay.",
     });
-    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toBeNull();
+    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toMatchObject({
+      report: "## 旧版中文点评\n只读回放。",
+    });
     await expect(db.getLegacyReadFallbackScan(username)).resolves.toBeNull();
   });
 
-  it("rejects a v5 report when its v3 snapshot score differs from the score row", async () => {
+  it("does not turn a mismatched v3 snapshot into a complete scan", async () => {
     const username = "legacy-fallback-score-mismatch";
     await writeLegacyReadFallback(username);
     const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
@@ -341,11 +346,14 @@ describe("getArchivedRoast", () => {
 
     await expect(db.getAccountDetail(username)).resolves.toMatchObject({
       final_score: entry.final_score,
-      tags: { zh: [], en: [] },
-      roast: null,
-      roast_en: null,
+      legacy_read_fallback: true,
+      tags: entry.tags,
+      roast: "## 旧版中文点评\n只读回放。",
+      roast_en: "## Legacy English roast\nRead-only replay.",
     });
-    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toBeNull();
+    await expect(db.getLegacyReadFallbackRoast(username, "zh")).resolves.toMatchObject({
+      report: "## 旧版中文点评\n只读回放。",
+    });
     await expect(db.getLegacyReadFallbackScan(username)).resolves.toBeNull();
   });
 

--- a/src/lib/__tests__/verdict.test.ts
+++ b/src/lib/__tests__/verdict.test.ts
@@ -25,6 +25,7 @@ function acct(username: string, final: number, sub: Partial<SubScores> = {}): Ac
     roast_line: { zh: "", en: "" },
     roast: null,
     roast_en: null,
+    legacy_read_fallback: false,
     score_source_collection_version: null,
     score_source_snapshot_hash: null,
     scanned_at: 0,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -101,6 +101,16 @@ function hasLegacyReadFallbackReport(row: Record<string, unknown>): boolean {
   );
 }
 
+/**
+ * A stored v5/v5 score/report pair is safe to show as a stale profile even
+ * when its old collector snapshot is no longer retained. This deliberately
+ * proves only the persisted presentation artifact. Callers that need a full
+ * ScanResult must use the stricter snapshot verifier below.
+ */
+function isLegacyReadFallbackProfile(row: Record<string, unknown>): boolean {
+  return hasLegacyReadFallbackReport(row);
+}
+
 function parseVerifiedLegacyReadFallbackRun(
   run: PublicScanRun,
   username: string,
@@ -137,9 +147,9 @@ function parseVerifiedLegacyReadFallbackRun(
 }
 
 /**
- * A v5 report may be served only when its score row and a complete v3 factual
- * snapshot agree on the same account/version contract. This is read-only: it
- * never upgrades, queues, re-scores, or invokes an LLM.
+ * A full v5 scan payload may be served only when its score row and a complete
+ * v3 factual snapshot agree on the same account/version contract. This is
+ * read-only: it never upgrades, queues, re-scores, or invokes an LLM.
  */
 async function getVerifiedLegacyReadFallbackScan(
   db: Client,
@@ -180,13 +190,6 @@ async function getVerifiedLegacyReadFallbackScan(
   } catch {
     return null;
   }
-}
-
-async function isVerifiedLegacyReadFallback(
-  db: Client,
-  row: Record<string, unknown>,
-): Promise<boolean> {
-  return Boolean(await getVerifiedLegacyReadFallbackScan(db, row));
 }
 
 function logPublicScanDbFailure(operation: string, error: unknown): void {
@@ -5335,6 +5338,8 @@ export interface AccountDetail {
   roast_en: string | null;
   /** Score formula version that produced this persisted profile. */
   score_version?: string | null;
+  /** True only for the explicit read-only v5/v5/v3 continuity path. */
+  legacy_read_fallback: boolean;
   /** Canonical collection provenance; null for historical/legacy score rows. */
   score_source_collection_version: string | null;
   /** SHA-256 identity of the complete source snapshot; null for legacy rows. */
@@ -5670,10 +5675,8 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
       r.score_source_collection_version === PUBLIC_SCAN_COLLECTION_VERSION &&
       typeof r.score_source_snapshot_hash === "string" &&
       /^[a-f0-9]{64}$/.test(r.score_source_snapshot_hash);
-    const legacyReadFallback = !canonicalScore && await isVerifiedLegacyReadFallback(
-      db,
-      r as Record<string, unknown>,
-    );
+    const legacyReadFallback =
+      !canonicalScore && isLegacyReadFallbackProfile(r as Record<string, unknown>);
     const readableArtifacts = canonicalScore || legacyReadFallback;
     const artifactRoastVersion = canonicalScore
       ? ROAST_CACHE_VERSION
@@ -5699,6 +5702,7 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
           ? ((r.roast_en as string | null) ?? null)
           : null,
       score_version: typeof r.score_version === "string" ? r.score_version : null,
+      legacy_read_fallback: legacyReadFallback,
       score_source_collection_version:
         typeof r.score_source_collection_version === "string"
           ? r.score_source_collection_version
@@ -5712,6 +5716,31 @@ export async function getAccountDetail(username: string): Promise<AccountDetail 
   } catch (e) {
     console.error("getAccountDetail failed:", e);
     return null;
+  }
+}
+
+/**
+ * Whether an account has a stored v5/v5 profile that can be shown immediately
+ * while canonical v9/v9/v4 collection runs. This does not assert that a full
+ * historical scan snapshot exists, so it must never be used as a score source.
+ */
+export async function hasLegacyReadFallbackProfile(username: string): Promise<boolean> {
+  const db = getClient();
+  if (!db) return false;
+  try {
+    await ensureSchema(db);
+    const result = await db.execute({
+      sql: `SELECT score_version, roast, roast_en, roast_version, roast_en_version
+            FROM scores
+            WHERE username = ? AND hidden = 0 AND score_version = ?
+            LIMIT 1`,
+      args: [username.toLowerCase(), LEGACY_READ_FALLBACK.score],
+    });
+    const row = result.rows[0] as Record<string, unknown> | undefined;
+    return Boolean(row && isLegacyReadFallbackProfile(row));
+  } catch (error) {
+    console.error("hasLegacyReadFallbackProfile failed:", error);
+    return false;
   }
 }
 
@@ -5743,9 +5772,10 @@ export async function getLegacyReadFallbackScan(username: string): Promise<ScanR
 }
 
 /**
- * Read one verified v5/v5/v3 report without requiring a current scan or LLM
- * configuration. The caller must treat it as stale and must never cache it as
- * a canonical v9 report.
+ * Read one v5/v5 report without requiring a current scan or LLM configuration.
+ * The caller must treat it as stale and must never cache it as a canonical v9
+ * report. Full v3 snapshot provenance is intentionally not required here: a
+ * profile replay does not claim to be a complete scan result.
  */
 export async function getLegacyReadFallbackRoast(
   username: string,
@@ -5766,7 +5796,7 @@ export async function getLegacyReadFallbackRoast(
       args: [username.toLowerCase(), LEGACY_READ_FALLBACK.score],
     });
     const row = result.rows[0] as Record<string, unknown> | undefined;
-    if (!row || !(await isVerifiedLegacyReadFallback(db, row))) return null;
+    if (!row || !isLegacyReadFallbackProfile(row)) return null;
     if (
       row[versionCol] !== LEGACY_READ_FALLBACK.roast ||
       typeof row[col] !== "string" ||


### PR DESCRIPTION
## Summary
- serve stored v5/v5 profile and report artifacts immediately while canonical v9/v9/v4 collection continues
- keep complete v3 snapshot validation exclusively for full scan payloads
- extend the existing profile-side canonical upgrade watcher for large public histories

## Safety
- no runtime version, release manifest, Cron, queue, rate-limit, or credential changes
- fallback is read-only and never materializes canonical scores, caches, rankings, or scan facts

## Verification
- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm versions:check
- pnpm build