### PR TITLE
fix(scan): serve quick roasts before durable enrichment

### DIFF
--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -339,6 +339,37 @@ describe("roast API persistence", () => {
     expect(mocks.setCachedRoast).not.toHaveBeenCalled();
   });
 
+  it("uses the current trusted quick scan instead of replaying v5 for a new roast request", async () => {
+    mocks.getLegacyReadFallbackRoast.mockResolvedValue({
+      username: "DemoDev",
+      final_score: 73,
+      tier: "人上人",
+      tags: { zh: ["旧版"], en: ["legacy"] },
+      roast_line: { zh: "旧版锐评。", en: "Legacy roast." },
+      report: "## 旧版点评\n只读回放。",
+    });
+    mocks.getPublicScanStatus.mockResolvedValue({
+      status: "pending",
+      run: { id: "active-run", username: "DemoDev" },
+      retryAfterSeconds: 5,
+      headStartJobId: null,
+    });
+    mocks.requiresDurablePublicScan.mockReturnValue(true);
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/roast", {
+        method: "POST",
+        body: JSON.stringify({ scan, lang: "zh" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("开源活跃度在上升");
+    expect(mocks.getLegacyReadFallbackRoast).not.toHaveBeenCalled();
+    expect(mocks.getCanonicalScoreWriteIdentity).not.toHaveBeenCalled();
+    expect(mocks.updateRoast).not.toHaveBeenCalled();
+  });
+
   it("skips the legacy artifact when refresh explicitly requests v9 work", async () => {
     mocks.getLegacyReadFallbackRoast.mockResolvedValue({
       username: "legacy-read-fixture",
@@ -533,15 +564,14 @@ describe("roast API persistence", () => {
     expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
   });
 
-  it("head-starts only the durable job created by this roast request", async () => {
-    mocks.getPublicScanStatus.mockResolvedValue(null);
-    mocks.requiresDurablePublicScan.mockReturnValue(true);
-    mocks.resolvePublicScanFromTrustedQuickScan.mockResolvedValue({
+  it("streams a trusted provisional quick roast without creating durable work or a canonical report", async () => {
+    mocks.getPublicScanStatus.mockResolvedValue({
       status: "pending",
-      run: { id: "new-run-id", username: "DemoDev" },
+      run: { id: "active-run", username: "DemoDev" },
       retryAfterSeconds: 5,
-      headStartJobId: "new-job-id",
+      headStartJobId: null,
     });
+    mocks.requiresDurablePublicScan.mockReturnValue(true);
 
     const response = await POST(
       new NextRequest("https://example.test/api/roast", {
@@ -550,10 +580,14 @@ describe("roast API persistence", () => {
       }),
     );
 
-    expect(response.status).toBe(409);
-    expect(mocks.kickPublicScanDrain).toHaveBeenCalledOnce();
-    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("new-job-id");
-    expect(mocks.chatStreamEvents).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("开源活跃度在上升");
+    expect(mocks.getCanonicalScoreWriteIdentity).not.toHaveBeenCalled();
+    expect(mocks.updateRoast).not.toHaveBeenCalled();
+    expect(mocks.setCachedRoast).not.toHaveBeenCalled();
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
   });
 
   it("fails closed before LLM work when the canonical score identity is missing", async () => {

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -29,12 +29,8 @@ import { reportMatchesLang } from "@/lib/report";
 import { sanitizeIdentityClaims } from "@/lib/identity";
 import {
   getPublicScanStatus,
-  publicScanAdmission,
   requiresDurablePublicScan,
-  resolvePublicScanFromTrustedQuickScan,
-  startPublicScan,
 } from "@/lib/public-scan";
-import { kickPublicScanDrain } from "@/lib/public-scan-dispatcher";
 import {
   acquireRoastLock,
   checkRoastRequestRateLimit,
@@ -652,7 +648,7 @@ export async function POST(req: NextRequest) {
   // v9 collector. It is intentionally checked before resolving an LLM config:
   // replaying already-persisted public text must not depend on model capacity or
   // spend credit. `refresh` explicitly opts out and continues toward v9 work.
-  if (body.refresh !== true) {
+  if (body.refresh !== true && !body.scan) {
     const legacyRoast = await getLegacyReadFallbackRoast(username, lang);
     if (legacyRoast && reportMatchesLang(legacyRoast.report, lang)) {
       const meta = await metaForStoredRoast(
@@ -706,7 +702,9 @@ export async function POST(req: NextRequest) {
   // know to release it. Only the default model coalesces (BYO keys self-serve).
   let isLeader = false;
   let lockWaitMs = 0;
-  let generationPath: "leader" | "follower_fallback" | "byo" = isDefault ? "leader" : "byo";
+  let generationPath: "leader" | "follower_fallback" | "provisional" | "byo" = isDefault
+    ? "leader"
+    : "byo";
   let scoreIdentity: ScoreWriteIdentity | null = null;
 
   // Prefer a durable/current server snapshot. A request-body scan is accepted
@@ -716,7 +714,16 @@ export async function POST(req: NextRequest) {
     getPublicScanStatus(username),
     getCachedScan(username),
   ]);
-  if (publicStatus?.status === "stale") {
+  const completedPublicRun = publicStatus?.status === "complete" ? publicStatus.run : null;
+  const completedPublicScan = publicStatus?.status === "complete" ? publicStatus.scan : null;
+  // This is the only incomplete server scan that may reach the default model.
+  // It is server-authored by the bounded quick collector and the same result
+  // has already determined that a full-history job is needed. The response is
+  // transient: no canonical score/report cache or database row is touched.
+  const provisional = Boolean(
+    cachedScan && !completedPublicScan && requiresDurablePublicScan(cachedScan),
+  );
+  if (publicStatus?.status === "stale" && !provisional) {
     return NextResponse.json(
       {
         error: "scan_enrichment_pending",
@@ -729,143 +736,119 @@ export async function POST(req: NextRequest) {
       { status: 409, headers: { "Cache-Control": "no-store" } },
     );
   }
-  let completedPublicRun = publicStatus?.status === "complete" ? publicStatus.run : null;
-  const completedPublicScan = publicStatus?.status === "complete" ? publicStatus.scan : null;
   const serverScan = completedPublicScan ?? cachedScan;
-  let scan = serverScan ?? (!isDefault && body.scan ? sanitizeScan(body.scan) : null);
+  const scan = serverScan ?? (!isDefault && body.scan ? sanitizeScan(body.scan) : null);
   if (!scan?.metrics || !scan.scoring) {
     return NextResponse.json({ error: "missing_scan" }, { status: 400 });
   }
 
-  // A large public history cannot be truthfully represented by the quick
-  // sample. Never spend LLM credit or persist a leaderboard row from it: start
-  // (or resume) the durable collector and require its complete snapshot.
-  if (serverScan && !completedPublicScan && (publicStatus || requiresDurablePublicScan(scan))) {
-    const durableAdmission = publicScanAdmission(
-      auth === "valid"
-        ? `bearer:${req.headers.get("authorization") ?? ""}`
-        : `ip:${clientIp(req)}`,
+  // `/api/scan` owns durable job creation. A roast request must never create
+  // or head-start shared collection work; it either uses the trusted bounded
+  // result above, or asks the caller to return through the scan endpoint.
+  if (serverScan && !completedPublicScan && !provisional) {
+    const retryAfterSeconds = publicStatus && "retryAfterSeconds" in publicStatus
+      ? publicStatus.retryAfterSeconds
+      : 5;
+    return NextResponse.json(
+      {
+        error: "scan_enrichment_pending",
+        username,
+        ...(publicStatus?.status === "pending" ? { run_id: publicStatus.run.id } : {}),
+        retry_after: retryAfterSeconds,
+      },
+      {
+        status: 409,
+        headers: { "Retry-After": String(retryAfterSeconds), "Cache-Control": "no-store" },
+      },
     );
-    const resolution = publicStatus?.status === "pending" || publicStatus?.status === "failed"
-      ? publicStatus
-      : serverScan
-        ? await resolvePublicScanFromTrustedQuickScan(username, serverScan, durableAdmission)
-        : await startPublicScan(username, durableAdmission);
-    if (resolution.status === "complete") {
-      scan = resolution.scan;
-      completedPublicRun = resolution.run;
-    } else {
-      if (resolution.status === "pending" && resolution.headStartJobId) {
-        kickPublicScanDrain(resolution.headStartJobId);
-      }
-      const retryAfterSeconds = resolution.retryAfterSeconds;
-      const busy = resolution.status === "queue_full" || resolution.status === "admission_limited";
-      return NextResponse.json(
-        {
-          error: busy ? resolution.status : "scan_enrichment_pending",
-          username,
-          ...(resolution.status === "pending" ? { run_id: resolution.run.id } : {}),
-          retry_after: retryAfterSeconds,
-        },
-        {
-          status: busy ? 429 : 409,
-          headers: { "Retry-After": String(retryAfterSeconds), "Cache-Control": "no-store" },
-        },
-      );
-    }
   }
 
   // Default-model protections: serve a cached roast for free, else rate-limit the
   // (credit-spending) LLM call. BYO keys skip both — it's the user's own credit.
   if (isDefault) {
-    // Every replay and new report must belong to the deterministic score from
-    // this exact canonical snapshot. This also prevents pre-migration Redis
-    // entries (whose cache key has no snapshot hash) from bypassing provenance.
-    const snapshotHash = completedPublicRun?.snapshotHash;
-    if (!snapshotHash) {
-      return NextResponse.json(
-        { error: "score_materialization_pending" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
-      );
-    }
-    try {
-      scoreIdentity = await getCanonicalScoreWriteIdentity(username, snapshotHash);
-    } catch {
-      scoreIdentity = null;
-    }
-    if (!scoreIdentity) {
-      return NextResponse.json(
-        { error: "score_materialization_pending" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
-      );
-    }
-
-    // A validated `refresh` (homepage handoff onto a stale profile, or the
-    // owner's rescan) skips both replay paths below and regenerates. Server-
-    // checked against the row's scanned_at — without this, the DB archive
-    // replays a version-matched roast forever, no matter its age.
     let refreshHonored = false;
-    if (body.refresh === true) {
-      const scannedAt = await getScoreScannedAt(username);
-      refreshHonored = scannedAt == null || Date.now() - scannedAt > ROAST_FRESH_MS;
-    }
-
-    if (!refreshHonored) {
-      const cachedRoast = await getCachedRoast(username, lang);
-      if (
-        cachedRoast?.snapshot_hash === snapshotHash &&
-        reportMatchesLang(cachedRoast.report, lang)
-      ) {
-        const tags = cachedRoast.tags ?? { zh: [], en: [] };
-        const roastLine = cachedRoast.roast_line ?? EMPTY_ROAST_LINE;
-        const meta =
-          cachedRoast.final_score !== undefined && cachedRoast.tier
-            ? await metaForStoredRoast(
-                cachedRoast.final_score,
-                cachedRoast.tier,
-                tags,
-                roastLine,
-                lang,
-              )
-            : await computeMeta(scan, cachedRoast.delta, tags, roastLine, lang);
-        logRoastSummary({
-          requestId, lang, path, ok: true, source: "redis_cache",
-          requestTotalMs: Date.now() - reqT0,
-        });
-        return roastResponse(cachedRoast.report, meta);
-      }
-      // Old cache entries have no snapshot identity. Clear any rejected replay
-      // before single-flight acquisition so followers wait for the new report
-      // instead of immediately fanning out into duplicate generations.
-      if (cachedRoast) await clearCachedRoast(username, lang);
-
-      const archivedRoast = await getArchivedRoast(username, lang);
-      if (archivedRoast && reportMatchesLang(archivedRoast.report, lang)) {
-        const meta = await metaForStoredRoast(
-          archivedRoast.final_score,
-          archivedRoast.tier,
-          archivedRoast.tags,
-          archivedRoast.roast_line,
-          lang,
+    if (!provisional) {
+      // Every replay and new formal report must belong to the deterministic
+      // score from this exact canonical snapshot.
+      const snapshotHash = completedPublicRun?.snapshotHash;
+      if (!snapshotHash) {
+        return NextResponse.json(
+          { error: "score_materialization_pending" },
+          { status: 409, headers: { "Cache-Control": "no-store" } },
         );
-        await cacheRoastReplay(
-          username,
-          lang,
-          snapshotHash,
-          archivedRoast.report,
-          archivedRoast.tags,
-          archivedRoast.roast_line,
-          archivedRoast.final_score,
-          archivedRoast.tier,
+      }
+      try {
+        scoreIdentity = await getCanonicalScoreWriteIdentity(username, snapshotHash);
+      } catch {
+        scoreIdentity = null;
+      }
+      if (!scoreIdentity) {
+        return NextResponse.json(
+          { error: "score_materialization_pending" },
+          { status: 409, headers: { "Cache-Control": "no-store" } },
         );
-        logRoastSummary({
-          requestId, lang, path, ok: true, source: "archive",
-          requestTotalMs: Date.now() - reqT0,
-        });
-        return roastResponse(archivedRoast.report, meta);
+      }
+
+      // A validated `refresh` skips canonical replay paths only when the
+      // stored report is actually stale.
+      if (body.refresh === true) {
+        const scannedAt = await getScoreScannedAt(username);
+        refreshHonored = scannedAt == null || Date.now() - scannedAt > ROAST_FRESH_MS;
+      }
+
+      if (!refreshHonored) {
+        const cachedRoast = await getCachedRoast(username, lang);
+        if (
+          cachedRoast?.snapshot_hash === snapshotHash &&
+          reportMatchesLang(cachedRoast.report, lang)
+        ) {
+          const tags = cachedRoast.tags ?? { zh: [], en: [] };
+          const roastLine = cachedRoast.roast_line ?? EMPTY_ROAST_LINE;
+          const meta =
+            cachedRoast.final_score !== undefined && cachedRoast.tier
+              ? await metaForStoredRoast(
+                  cachedRoast.final_score,
+                  cachedRoast.tier,
+                  tags,
+                  roastLine,
+                  lang,
+                )
+              : await computeMeta(scan, cachedRoast.delta, tags, roastLine, lang);
+          logRoastSummary({
+            requestId, lang, path, ok: true, source: "redis_cache",
+            requestTotalMs: Date.now() - reqT0,
+          });
+          return roastResponse(cachedRoast.report, meta);
+        }
+        if (cachedRoast) await clearCachedRoast(username, lang);
+
+        const archivedRoast = await getArchivedRoast(username, lang);
+        if (archivedRoast && reportMatchesLang(archivedRoast.report, lang)) {
+          const meta = await metaForStoredRoast(
+            archivedRoast.final_score,
+            archivedRoast.tier,
+            archivedRoast.tags,
+            archivedRoast.roast_line,
+            lang,
+          );
+          await cacheRoastReplay(
+            username,
+            lang,
+            snapshotHash,
+            archivedRoast.report,
+            archivedRoast.tags,
+            archivedRoast.roast_line,
+            archivedRoast.final_score,
+            archivedRoast.tier,
+          );
+          logRoastSummary({
+            requestId, lang, path, ok: true, source: "archive",
+            requestTotalMs: Date.now() - reqT0,
+          });
+          return roastResponse(archivedRoast.report, meta);
+        }
       }
     }
-
     const generationLimit = await checkRoastRateLimit(clientIp(req));
     if (!generationLimit.success) {
       return NextResponse.json(
@@ -876,41 +859,43 @@ export async function POST(req: NextRequest) {
         },
       );
     }
-    // Single-flight: become the lone generator, or wait for whoever already is.
-    // Collapses a viral account's concurrent cold-cache requests into ONE LLM call.
-    isLeader = await acquireRoastLock(username, lang);
-    if (isLeader) {
-      // Regeneration leader: drop the (possibly archive-re-warmed) cached roast
-      // so single-flight followers wait for the NEW report, not the old one.
-      if (refreshHonored) await clearCachedRoast(username, lang);
+    if (provisional) {
+      generationPath = "provisional";
     } else {
-      const lockWaitStartedAt = Date.now();
-      const shared = await waitForCachedRoast(username, lang);
-      lockWaitMs = Date.now() - lockWaitStartedAt;
-      if (
-        shared?.snapshot_hash === snapshotHash &&
-        reportMatchesLang(shared.report, lang)
-      ) {
-        const tags = shared.tags ?? { zh: [], en: [] };
-        const roastLine = shared.roast_line ?? EMPTY_ROAST_LINE;
-        const meta =
-          shared.final_score !== undefined && shared.tier
-            ? await metaForStoredRoast(
-                shared.final_score,
-                shared.tier,
-                tags,
-                roastLine,
-                lang,
-              )
-            : await computeMeta(scan, shared.delta, tags, roastLine, lang);
-        logRoastSummary({
-          requestId, lang, path, ok: true, source: "singleflight_shared",
-          lockWaitMs, requestTotalMs: Date.now() - reqT0,
-        });
-        return roastResponse(shared.report, meta);
+      const snapshotHash = completedPublicRun!.snapshotHash!;
+      // Single-flight is only for a canonical artifact. A provisional report
+      // has no stable snapshot identity and must not be replayed.
+      isLeader = await acquireRoastLock(username, lang);
+      if (isLeader) {
+        if (refreshHonored) await clearCachedRoast(username, lang);
+      } else {
+        const lockWaitStartedAt = Date.now();
+        const shared = await waitForCachedRoast(username, lang);
+        lockWaitMs = Date.now() - lockWaitStartedAt;
+        if (
+          shared?.snapshot_hash === snapshotHash &&
+          reportMatchesLang(shared.report, lang)
+        ) {
+          const tags = shared.tags ?? { zh: [], en: [] };
+          const roastLine = shared.roast_line ?? EMPTY_ROAST_LINE;
+          const meta =
+            shared.final_score !== undefined && shared.tier
+              ? await metaForStoredRoast(
+                  shared.final_score,
+                  shared.tier,
+                  tags,
+                  roastLine,
+                  lang,
+                )
+              : await computeMeta(scan, shared.delta, tags, roastLine, lang);
+          logRoastSummary({
+            requestId, lang, path, ok: true, source: "singleflight_shared",
+            lockWaitMs, requestTotalMs: Date.now() - reqT0,
+          });
+          return roastResponse(shared.report, meta);
+        }
+        generationPath = "follower_fallback";
       }
-      // Leader failed or timed out — self-generate (we hold no lock).
-      generationPath = "follower_fallback";
     }
   }
 
@@ -966,7 +951,7 @@ export async function POST(req: NextRequest) {
         requestId,
         lang,
         path,
-        source: "generate",
+        source: provisional ? "quick_provisional" : "generate",
         generationPath,
         lockWaitMs,
         streamMs: Date.now() - t0,
@@ -1086,7 +1071,7 @@ export async function POST(req: NextRequest) {
         }
         // Persist under the exact score-write identity before warming replay.
         // A late report that loses the CAS must not enter either storage layer.
-        if (isDefault && reportMatchesLang(full, lang)) {
+        if (!provisional && isDefault && reportMatchesLang(full, lang)) {
           const persisted = scoreIdentity
             ? await updateRoast(username, full, lang, scoreIdentity, { tags, roastLine })
             : false;

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -246,7 +246,7 @@ describe("scan route machine auth", () => {
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
   });
 
-  it("serves a v3 snapshot and starts only one explicit v4 refresh", async () => {
+  it("runs a fresh quick scan before using a stale v3 snapshot", async () => {
     mocks.getPublicScanStatus.mockResolvedValue({
       status: "stale",
       run: { id: "legacy-run", username: "DemoDev", collectionVersion: "v3" },
@@ -256,31 +256,21 @@ describe("scan route machine auth", () => {
       servedCollectionVersion: "v3",
       targetCollectionVersion: "v4",
     });
-    mocks.startPublicScan.mockResolvedValue({
-      status: "pending",
-      run: { id: "refresh-run" },
-      retryAfterSeconds: 5,
-      headStartJobId: "refresh-job",
-    });
-
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      stale: true,
-      refresh_pending: true,
-      run_id: "refresh-run",
-      served_collection_version: "v3",
-      target_collection_version: "v4",
+      metrics: { username: "DemoDev" },
+      cached: false,
     });
-    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
-    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("refresh-job");
-    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.collect).toHaveBeenCalledWith("DemoDev");
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
     expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
-    expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
+    expect(mocks.publishCompleteQuickScan).toHaveBeenCalledTimes(1);
   });
 
-  it("hands a verified v5/v5/v3 profile to the home flow while v9/v4 refreshes", async () => {
+  it("serves a verified v5/v5/v3 scan only when the fresh quick scan fails", async () => {
     const legacyScan = {
       metrics,
       scoring,
@@ -292,19 +282,8 @@ describe("scan route machine auth", () => {
       pinned_repos: [],
       organizations: [],
     };
-    mocks.getPublicScanStatus.mockResolvedValue({
-      status: "pending",
-      run: { id: "canonical-run" },
-      retryAfterSeconds: 5,
-      headStartJobId: null,
-    });
     mocks.getLegacyReadFallbackScan.mockResolvedValue(legacyScan);
-    mocks.startPublicScan.mockResolvedValue({
-      status: "pending",
-      run: { id: "canonical-run" },
-      retryAfterSeconds: 5,
-      headStartJobId: "canonical-job",
-    });
+    mocks.collect.mockRejectedValueOnce(new Error("GitHub unavailable"));
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
@@ -314,8 +293,7 @@ describe("scan route machine auth", () => {
       cached: true,
       stale: true,
       legacy_read_fallback: true,
-      refresh_pending: true,
-      run_id: "canonical-run",
+      refresh_pending: false,
       served_score_version: "v5",
       served_roast_version: "v5",
       served_collection_version: "v3",
@@ -323,29 +301,17 @@ describe("scan route machine auth", () => {
       target_roast_version: "v9",
       target_collection_version: "v4",
     });
-    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
-    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("canonical-job");
-    expect(mocks.getCachedScan).not.toHaveBeenCalled();
-    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+    expect(mocks.getCachedScan).toHaveBeenCalledWith("DemoDev");
+    expect(mocks.collect).toHaveBeenCalledWith("DemoDev");
     expect(mocks.ensureCanonicalScoreForPublicRun).not.toHaveBeenCalled();
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
-    expect(mocks.recordAccountLookup).not.toHaveBeenCalled();
   });
 
-  it("hands a stored v5 profile to the browser without fabricating a v3 scan", async () => {
-    mocks.getPublicScanStatus.mockResolvedValue({
-      status: "pending",
-      run: { id: "canonical-run" },
-      retryAfterSeconds: 5,
-      headStartJobId: null,
-    });
+  it("hands a stored v5 profile to the browser only after a quick-scan failure", async () => {
     mocks.hasLegacyReadFallbackProfile.mockResolvedValue(true);
-    mocks.startPublicScan.mockResolvedValue({
-      status: "pending",
-      run: { id: "canonical-run" },
-      retryAfterSeconds: 5,
-      headStartJobId: "canonical-job",
-    });
+    mocks.collect.mockRejectedValueOnce(new Error("GitHub unavailable"));
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
@@ -356,8 +322,7 @@ describe("scan route machine auth", () => {
       stale: true,
       legacy_read_fallback: true,
       legacy_profile: true,
-      refresh_pending: true,
-      run_id: "canonical-run",
+      refresh_pending: false,
       served_score_version: "v5",
       served_roast_version: "v5",
       served_collection_version: "v3",
@@ -366,12 +331,12 @@ describe("scan route machine auth", () => {
       target_collection_version: "v4",
     });
     expect(mocks.getLegacyReadFallbackScan).toHaveBeenCalledWith("DemoDev");
-    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
-    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("canonical-job");
-    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
+    expect(mocks.collect).toHaveBeenCalledWith("DemoDev");
   });
 
-  it("keeps the verified v5/v5/v3 profile readable when v9 admission is full", async () => {
+  it("does not enqueue a durable job merely by serving a v5 fallback", async () => {
     mocks.getLegacyReadFallbackScan.mockResolvedValue({
       metrics,
       scoring,
@@ -383,11 +348,7 @@ describe("scan route machine auth", () => {
       pinned_repos: [],
       organizations: [],
     });
-    mocks.startPublicScan.mockResolvedValue({
-      status: "queue_full",
-      run: null,
-      retryAfterSeconds: 60,
-    });
+    mocks.collect.mockRejectedValueOnce(new Error("GitHub unavailable"));
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
@@ -396,36 +357,13 @@ describe("scan route machine auth", () => {
       legacy_read_fallback: true,
       refresh_pending: false,
     });
-    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.collect).toHaveBeenCalledWith("DemoDev");
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
     expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
   });
 
-  it("keeps the verified v5/v5/v3 profile readable when starting v9 refresh throws", async () => {
-    mocks.getLegacyReadFallbackScan.mockResolvedValue({
-      metrics,
-      scoring,
-      top_repos: [],
-      recent_prs: [],
-      flood_pr_titles: [],
-      impact_repos: [],
-      verified_impact_prs: [],
-      pinned_repos: [],
-      organizations: [],
-    });
-    mocks.startPublicScan.mockRejectedValue(new Error("storage unavailable"));
-
-    const response = await POST(request({ auth: "Bearer cli-secret" }));
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      legacy_read_fallback: true,
-      refresh_pending: false,
-    });
-    expect(mocks.collect).not.toHaveBeenCalled();
-    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
-  });
-
-  it("lets an explicit scan retry after a failed v4 refresh while serving v3", async () => {
+  it("uses a stale snapshot only when the current quick scan and v5 fallback are unavailable", async () => {
     mocks.getPublicScanStatus.mockResolvedValue({
       status: "stale",
       run: { id: "legacy-run", username: "DemoDev", collectionVersion: "v3" },
@@ -435,35 +373,30 @@ describe("scan route machine auth", () => {
       servedCollectionVersion: "v3",
       targetCollectionVersion: "v4",
     });
-    mocks.startPublicScan.mockResolvedValue({
-      status: "pending",
-      run: { id: "retry-run" },
-      retryAfterSeconds: 5,
-      headStartJobId: "retry-job",
-    });
+    mocks.collect.mockRejectedValueOnce(new Error("GitHub unavailable"));
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       stale: true,
-      refresh_pending: true,
-      run_id: "retry-run",
+      refresh_pending: false,
+      run_id: "failed-refresh",
     });
-    expect(mocks.startPublicScan).toHaveBeenCalledTimes(1);
-    expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("retry-job");
+    expect(mocks.startPublicScan).not.toHaveBeenCalled();
+    expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
   });
 
-  it("discards an orphaned scan cache and publishes a fresh trusted quick scan", async () => {
+  it("uses a current-release quick cache without republishing or recollecting", async () => {
     mocks.getCachedScan.mockResolvedValue({ metrics, scoring });
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
     expect(response.status).toBe(200);
-    expect((await response.json()).cached).toBe(false);
-    expect(mocks.clearCachedScan).toHaveBeenCalledWith("DemoDev");
-    expect(mocks.collect).toHaveBeenCalledWith("DemoDev");
-    expect(mocks.publishCompleteQuickScan).toHaveBeenCalledTimes(1);
+    expect((await response.json()).cached).toBe(true);
+    expect(mocks.clearCachedScan).not.toHaveBeenCalled();
+    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
   });
 
   it("fails closed when a complete run cannot materialize its canonical score", async () => {
@@ -497,7 +430,7 @@ describe("scan route machine auth", () => {
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
   });
 
-  it("does not rerun a quick GitHub scan while a durable job is pending", async () => {
+  it("serves a cached quick result while its durable job is pending", async () => {
     mocks.getCachedScan.mockResolvedValue({ metrics, scoring });
     mocks.requiresDurablePublicScan.mockReturnValue(true);
     mocks.getPublicScanStatus.mockResolvedValue({
@@ -505,21 +438,32 @@ describe("scan route machine auth", () => {
       run: { id: "active-run" },
       retryAfterSeconds: 5,
     });
+    mocks.resolvePublicScanFromTrustedQuickScan.mockResolvedValue({
+      status: "pending",
+      run: { id: "active-run" },
+      retryAfterSeconds: 5,
+      headStartJobId: null,
+    });
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
-    expect(response.status).toBe(202);
+    expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
-      error: "scan_enrichment_pending",
+      provisional: true,
+      coverage: "quick",
       run_id: "active-run",
     });
     expect(mocks.collect).not.toHaveBeenCalled();
-    expect(mocks.resolvePublicScanFromTrustedQuickScan).not.toHaveBeenCalled();
+    expect(mocks.resolvePublicScanFromTrustedQuickScan).toHaveBeenCalledWith(
+      "DemoDev",
+      expect.objectContaining({ metrics: expect.objectContaining({ username: "DemoDev" }) }),
+      expect.anything(),
+    );
     expect(mocks.kickPublicScanDrain).not.toHaveBeenCalled();
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();
   });
 
-  it("starts one response-side step only when this request created the durable job", async () => {
+  it("starts one response-side worker step after returning a provisional quick result", async () => {
     mocks.requiresDurablePublicScan.mockReturnValue(true);
     mocks.resolvePublicScanFromTrustedQuickScan.mockResolvedValue({
       status: "pending",
@@ -530,7 +474,12 @@ describe("scan route machine auth", () => {
 
     const response = await POST(request({ auth: "Bearer cli-secret" }));
 
-    expect(response.status).toBe(202);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      provisional: true,
+      coverage: "quick",
+      run_id: "new-run",
+    });
     expect(mocks.kickPublicScanDrain).toHaveBeenCalledTimes(1);
     expect(mocks.kickPublicScanDrain).toHaveBeenCalledWith("new-job-id");
     expect(mocks.publishCompleteQuickScan).not.toHaveBeenCalled();

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -10,7 +10,6 @@ import {
 } from "@/lib/db";
 import {
   checkRateLimit,
-  clearCachedScan,
   coalesceScan,
   getCachedScan,
   rateLimitHeaders,
@@ -25,7 +24,6 @@ import {
   type PublicScanResolution,
   requiresDurablePublicScan,
   resolvePublicScanFromTrustedQuickScan,
-  startPublicScan,
 } from "@/lib/public-scan";
 import { kickPublicScanDrain } from "@/lib/public-scan-dispatcher";
 import { LEGACY_READ_FALLBACK, RUNTIME_RELEASE_VERSIONS } from "@/lib/release-versions";
@@ -93,73 +91,20 @@ async function recordSuccessfulLookup(
   ]);
 }
 
-function durableStatusResponse(input: {
-  username: string;
-  resolution: Exclude<PublicScanResolution, { status: "complete" | "stale" }>;
-  headers: Record<string, string>;
-}) {
-  if (input.resolution.status === "pending") {
-    return NextResponse.json(
-      {
-        error: "scan_enrichment_pending",
-        status: "collecting_public_history",
-        username: input.username,
-        run_id: input.resolution.run.id,
-        retry_after: input.resolution.retryAfterSeconds,
-      },
-      {
-        status: 202,
-        headers: {
-          ...input.headers,
-          "Cache-Control": "no-store",
-          "Retry-After": String(input.resolution.retryAfterSeconds),
-        },
-      },
-    );
-  }
-  if (input.resolution.status === "queue_full" || input.resolution.status === "admission_limited") {
-    return apiError(input.resolution.status, {
-      status: 429,
-      headers: {
-        ...input.headers,
-        "Cache-Control": "no-store",
-        "Retry-After": String(input.resolution.retryAfterSeconds),
-      },
-    });
-  }
-  return apiError("github_unavailable", {
-    status: 503,
-    headers: {
-      ...input.headers,
-      "Retry-After": String(input.resolution.retryAfterSeconds),
-    },
-  });
-}
-
 async function staleSnapshotResponse(input: {
-  username: string;
   status: Extract<PublicScanResolution, { status: "stale" }>;
-  admission: ReturnType<typeof publicScanAdmission>;
   headers: Record<string, string>;
 }) {
-  const refresh = input.status.refreshPending
-    ? null
-    : await startPublicScan(input.username, input.admission);
-  const refreshRun = refresh && "run" in refresh ? refresh.run : input.status.refreshRun;
-  const refreshPending = input.status.refreshPending || refresh?.status === "pending";
-  if (refresh?.status === "pending" && refresh.headStartJobId) {
-    kickPublicScanDrain(refresh.headStartJobId);
-  }
   return NextResponse.json(
     {
       ...input.status.scan,
       cached: true,
       coverage: "complete_public",
       stale: true,
-      refresh_pending: refreshPending,
+      refresh_pending: input.status.refreshPending,
       served_collection_version: input.status.servedCollectionVersion,
       target_collection_version: input.status.targetCollectionVersion,
-      ...(refreshRun ? { run_id: refreshRun.id } : {}),
+      ...(input.status.refreshRun ? { run_id: input.status.refreshRun.id } : {}),
     },
     { headers: { ...input.headers, "Cache-Control": "no-store" } },
   );
@@ -167,28 +112,14 @@ async function staleSnapshotResponse(input: {
 
 /**
  * An explicit scan may ask for canonical v9/v4 work, but a verified v5/v5/v3
- * artifact is still immediately useful to the visitor. The refresh attempt is
- * intentionally best-effort: queue or storage pressure must never turn a
- * readable historical profile back into a waiting screen.
+ * artifact is still immediately useful to the visitor. Reading it never starts
+ * full-history work: only a newly collected quick scan can prove that a full
+ * collection is required.
  */
 async function legacyReadFallbackResponse(input: {
-  username: string;
   scan: import("@/lib/types").ScanResult;
-  admission: ReturnType<typeof publicScanAdmission>;
   headers: Record<string, string>;
 }) {
-  let refresh: PublicScanResolution | null = null;
-  try {
-    refresh = await startPublicScan(input.username, input.admission);
-    if (refresh.status === "pending" && refresh.headStartJobId) {
-      kickPublicScanDrain(refresh.headStartJobId);
-    }
-  } catch {
-    // The fallback has already passed provenance validation. A failed refresh
-    // attempt must not withhold it from the visitor.
-    console.error("legacyReadFallback refresh start failed");
-  }
-  const refreshRun = refresh && "run" in refresh ? refresh.run : null;
   return NextResponse.json(
     {
       ...input.scan,
@@ -196,14 +127,13 @@ async function legacyReadFallbackResponse(input: {
       coverage: "complete_public",
       stale: true,
       legacy_read_fallback: true,
-      refresh_pending: refresh?.status === "pending",
+      refresh_pending: false,
       served_score_version: LEGACY_READ_FALLBACK.score,
       served_roast_version: LEGACY_READ_FALLBACK.roast,
       served_collection_version: LEGACY_READ_FALLBACK.collection,
       target_score_version: RUNTIME_RELEASE_VERSIONS.score,
       target_roast_version: RUNTIME_RELEASE_VERSIONS.roast,
       target_collection_version: RUNTIME_RELEASE_VERSIONS.collection,
-      ...(refreshRun ? { run_id: refreshRun.id } : {}),
     },
     { headers: { ...input.headers, "Cache-Control": "no-store" } },
   );
@@ -212,25 +142,13 @@ async function legacyReadFallbackResponse(input: {
 /**
  * A v5/v5 profile can be useful even when the old v3 ScanResult has expired.
  * Return a dedicated handoff rather than inventing a partial scan payload; the
- * profile page reads the persisted artifact while the canonical v9/v4 job runs.
+ * profile page reads the persisted artifact. A later explicit scan collects a
+ * fresh quick result before deciding whether to enqueue canonical v9/v9/v4.
  */
 async function legacyReadFallbackProfileResponse(input: {
   username: string;
-  admission: ReturnType<typeof publicScanAdmission>;
   headers: Record<string, string>;
 }) {
-  let refresh: PublicScanResolution | null = null;
-  try {
-    refresh = await startPublicScan(input.username, input.admission);
-    if (refresh.status === "pending" && refresh.headStartJobId) {
-      kickPublicScanDrain(refresh.headStartJobId);
-    }
-  } catch {
-    // A persisted read-only profile remains useful when the refresh queue is
-    // temporarily unavailable.
-    console.error("legacyReadFallback profile refresh start failed");
-  }
-  const refreshRun = refresh && "run" in refresh ? refresh.run : null;
   return NextResponse.json(
     {
       username: input.username,
@@ -238,22 +156,28 @@ async function legacyReadFallbackProfileResponse(input: {
       stale: true,
       legacy_read_fallback: true,
       legacy_profile: true,
-      refresh_pending: refresh?.status === "pending",
+      refresh_pending: false,
       served_score_version: LEGACY_READ_FALLBACK.score,
       served_roast_version: LEGACY_READ_FALLBACK.roast,
       served_collection_version: LEGACY_READ_FALLBACK.collection,
       target_score_version: RUNTIME_RELEASE_VERSIONS.score,
       target_roast_version: RUNTIME_RELEASE_VERSIONS.roast,
       target_collection_version: RUNTIME_RELEASE_VERSIONS.collection,
-      ...(refreshRun ? { run_id: refreshRun.id } : {}),
     },
     { headers: { ...input.headers, "Cache-Control": "no-store" } },
   );
 }
 
-async function durableResponse(input: {
+/**
+ * Deliver the trusted bounded result immediately, then let the server worker
+ * complete the evidence only when its metrics prove the bounded history is
+ * incomplete. This response is deliberately not a canonical artifact: formal
+ * v9/v9/v4 storage is written only by a complete quick scan or the durable run.
+ */
+async function provisionalQuickResponse(input: {
   username: string;
   scan: import("@/lib/types").ScanResult;
+  cached: boolean;
   headers: Record<string, string>;
   admission: ReturnType<typeof publicScanAdmission>;
 }) {
@@ -266,16 +190,28 @@ async function durableResponse(input: {
     kickPublicScanDrain(resolution.headStartJobId);
   }
   if (resolution.status === "complete") {
+    const scoreWrite = await ensureCanonicalScoreForPublicRun(resolution.run);
+    if (!scoreWrite) return scorePersistenceUnavailable(input.headers);
+    await setCachedScan(resolution.scan.metrics.username, resolution.scan);
     return NextResponse.json(
       { ...resolution.scan, cached: true, coverage: "complete_public" },
       { headers: input.headers },
     );
   }
-  return durableStatusResponse({
-    username: input.username,
-    resolution,
-    headers: input.headers,
-  });
+  return NextResponse.json(
+    {
+      ...input.scan,
+      cached: input.cached,
+      coverage: "quick",
+      provisional: true,
+      refresh_pending: resolution.status === "pending",
+      enrichment_status: resolution.status,
+      ...(resolution.status === "pending"
+        ? { run_id: resolution.run.id, retry_after: resolution.retryAfterSeconds }
+        : { retry_after: resolution.retryAfterSeconds }),
+    },
+    { headers: { ...input.headers, "Cache-Control": "no-store" } },
+  );
 }
 
 export async function POST(req: NextRequest) {
@@ -345,55 +281,27 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // The home flow starts here, before the profile page and /api/roast have a
-  // chance to replay a report. Without this handoff, a known-good v5/v5/v3
-  // artifact was hidden behind a v9/v4 collection wait. An explicit request
-  // may start canonical work, but only after this verified legacy result has
-  // been selected; it is never written into current caches or scores.
-  const legacyScan = await getLegacyReadFallbackScan(username);
-  if (legacyScan) {
-    return legacyReadFallbackResponse({
-      username: legacyScan.metrics.username,
-      scan: legacyScan,
-      admission: durableAdmission,
-      headers: { ...idem, ...rlHeaders },
-    });
-  }
-
-  // A complete old ScanResult is optional for continuity. The normal v5
-  // profile path below has an exact stored v5 score/report but no longer has
-  // its full v3 snapshot, so hand the browser to the profile instead of making
-  // it wait for a v9/v4 crawl or fabricating a scan payload.
-  if (await hasLegacyReadFallbackProfile(username)) {
-    return legacyReadFallbackProfileResponse({
-      username,
-      admission: durableAdmission,
-      headers: { ...idem, ...rlHeaders },
-    });
-  }
-
-  // A cache entry is readable only when Turso has the matching complete run and
-  // canonical score. Pre-deployment quick cache entries have neither a trusted
-  // scan time nor provenance, so they are discarded and collected afresh.
+  // A current-release quick cache is a server-authored bounded snapshot. It is
+  // valid for an immediate provisional roast even while a durable run is
+  // pending; the worker replaces it atomically with the complete v9/v9/v4
+  // snapshot when all evidence arrives.
   const cached = await getCachedScan(username);
-  if (status?.status === "stale") {
-    await recordSuccessfulLookup(status.scan.metrics.username, ip, campaign);
-    return staleSnapshotResponse({
-      username: status.scan.metrics.username,
-      status,
-      admission: durableAdmission,
-      headers: { ...idem, ...rlHeaders },
-    });
+  if (cached) {
+    await recordSuccessfulLookup(cached.metrics.username, ip, campaign);
+    if (requiresDurablePublicScan(cached)) {
+      return provisionalQuickResponse({
+        username: cached.metrics.username,
+        scan: cached,
+        cached: true,
+        headers: { ...idem, ...rlHeaders },
+        admission: durableAdmission,
+      });
+    }
+    return NextResponse.json(
+      { ...cached, cached: true, coverage: "complete_public" },
+      { headers: { ...idem, ...rlHeaders } },
+    );
   }
-  if (status) {
-    await recordSuccessfulLookup(username, ip, campaign);
-    return durableStatusResponse({
-      username,
-      resolution: status,
-      headers: { ...idem, ...rlHeaders },
-    });
-  }
-  if (cached) await clearCachedScan(cached.metrics.username);
 
   try {
     const result = await coalesceScan(username, async () => {
@@ -409,9 +317,10 @@ export async function POST(req: NextRequest) {
     });
     await recordSuccessfulLookup(result.metrics.username, ip, campaign);
     if (requiresDurablePublicScan(result)) {
-      return durableResponse({
+      return provisionalQuickResponse({
         username: result.metrics.username,
         scan: result,
+        cached: false,
         headers: { ...idem, ...rlHeaders },
         admission: durableAdmission,
       });
@@ -424,9 +333,32 @@ export async function POST(req: NextRequest) {
     if (e instanceof ScorePersistenceError) {
       return scorePersistenceUnavailable({ ...idem, ...rlHeaders });
     }
-    const { error, status, retry_after } = scanErrorResponse(e);
+    // A failed fresh quick scan must not hide a verified v5/v5/v3 artifact,
+    // but serving the fallback alone never schedules canonical work. A future
+    // successful quick scan will decide whether the account actually needs it.
+    const legacyScan = await getLegacyReadFallbackScan(username);
+    if (legacyScan) {
+      return legacyReadFallbackResponse({
+        scan: legacyScan,
+        headers: { ...idem, ...rlHeaders },
+      });
+    }
+    if (await hasLegacyReadFallbackProfile(username)) {
+      return legacyReadFallbackProfileResponse({
+        username,
+        headers: { ...idem, ...rlHeaders },
+      });
+    }
+    if (status?.status === "stale") {
+      await recordSuccessfulLookup(status.scan.metrics.username, ip, campaign);
+      return staleSnapshotResponse({
+        status,
+        headers: { ...idem, ...rlHeaders },
+      });
+    }
+    const { error, status: responseStatus, retry_after } = scanErrorResponse(e);
     return apiError(error as Parameters<typeof apiError>[0], {
-      status,
+      status: responseStatus,
       headers: {
         ...idem,
         ...rlHeaders,

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -39,6 +39,13 @@ interface Display {
   delta: number;
 }
 
+interface ScanResponse extends ScanResult {
+  /** A bounded server-authored scan that is usable now but still collecting
+   * evidence for the formal v9/v9/v4 artifact. */
+  provisional?: boolean;
+  run_id?: string;
+}
+
 interface RoasterProps {
   campaign?: CampaignSlug;
   analyticsSource?: "home" | CampaignSlug;
@@ -101,8 +108,15 @@ export function Roaster({
   const reportRef = useRef<HTMLDivElement>(null);
   const lastPrefillRef = useRef<string | null>(null);
   const pollAbortRef = useRef<AbortController | null>(null);
+  const upgradeAbortRef = useRef<AbortController | null>(null);
 
-  useEffect(() => () => pollAbortRef.current?.abort(), []);
+  useEffect(
+    () => () => {
+      pollAbortRef.current?.abort();
+      upgradeAbortRef.current?.abort();
+    },
+    [],
+  );
 
   // Deep-link prefill (?username=): seed the Omnibox; it renders the value and
   // the user hits Enter to roast. (Focus/scroll now live inside the Omnibox.)
@@ -216,10 +230,33 @@ export function Roaster({
       setMetaRoast(null);
       setThinking("");
       setScanning(true);
+      upgradeAbortRef.current?.abort();
       // Funnel top: the user committed to a roast. `source` lets us split the
       // home scanner from other entry points if they get instrumented later.
       trackEvent("scan_start", { source: analyticsSource });
-      const presentScan = (result: ScanResult, refreshRunId?: string) => {
+      const presentScan = (result: ScanResponse, refreshRunId?: string) => {
+        if (result.provisional) {
+          // The bounded server scan already uses the current formula, so let
+          // the visitor see its score and roast now. It is never stored as a
+          // profile artifact; the active page quietly upgrades after the full
+          // scan has atomically materialized formal v9/v9/v4 evidence.
+          trackEvent("scan_complete", { source: analyticsSource, tier: result.scoring.tier });
+          setScan(result);
+          setDisplay({
+            score: result.scoring.final_score,
+            tier: result.scoring.tier,
+            tierLabel: result.scoring.tier_label,
+            delta: 0,
+          });
+          setScanning(false);
+          void runRoast(result);
+          if (refreshRunId) void followCanonicalUpgrade(result.metrics.username, refreshRunId);
+          setTimeout(
+            () => reportRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }),
+            100,
+          );
+          return;
+        }
         const byoKey = loadByoKey();
         const forceProfileHandoff =
           process.env.NODE_ENV !== "production" && searchParams.get("profile") === "1";
@@ -249,6 +286,39 @@ export function Roaster({
           () => reportRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }),
           100,
         );
+      };
+      const followCanonicalUpgrade = async (handle: string, runId: string) => {
+        const controller = new AbortController();
+        upgradeAbortRef.current?.abort();
+        upgradeAbortRef.current = controller;
+        let retrySeconds = 15;
+        try {
+          while (!controller.signal.aborted) {
+            await abortableDelay(retrySeconds * 1_000, controller.signal);
+            if (controller.signal.aborted) return;
+            try {
+              const statusRes = await fetch(
+                `/api/scan-status/${encodeURIComponent(handle)}?run_id=${encodeURIComponent(runId)}`,
+                { signal: controller.signal },
+              );
+              const status = await statusRes.json();
+              if (statusRes.ok && status?.status === "complete_public" && status.scan) {
+                setError("");
+                setPendingMessage("");
+                presentScan(status.scan as ScanResponse);
+                return;
+              }
+              if (status?.status === "failed" || statusRes.status === 404) return;
+              retrySeconds = Math.max(10, Math.min(30, Number(status?.retry_after) || retrySeconds));
+            } catch {
+              if (controller.signal.aborted) return;
+              // The provisional result remains visible while a transient
+              // network failure is retried on this still-open page.
+            }
+          }
+        } finally {
+          if (upgradeAbortRef.current === controller) upgradeAbortRef.current = null;
+        }
       };
       const presentLegacyProfile = (handle: string, refreshRunId?: string) => {
         const profileParams = new URLSearchParams({ roasting: "1" });
@@ -296,7 +366,7 @@ export function Roaster({
                     completed = true;
                     setError("");
                     setPendingMessage("");
-                    presentScan(status.scan as ScanResult);
+                    presentScan(status.scan as ScanResponse);
                     return;
                   }
                   if (status?.status === "failed" || statusRes.status === 404) {
@@ -337,7 +407,7 @@ export function Roaster({
           );
           return;
         }
-        const result = data as ScanResult;
+        const result = data as ScanResponse;
         const refreshRunId = typeof data?.run_id === "string" ? data.run_id : undefined;
         presentScan(result, refreshRunId);
       } catch {

--- a/src/components/__tests__/Roaster.test.ts
+++ b/src/components/__tests__/Roaster.test.ts
@@ -3,11 +3,19 @@ import { describe, expect, it } from "vitest";
 
 const source = readFileSync(new URL("../Roaster.tsx", import.meta.url), "utf8");
 
-describe("Roaster durable scan polling", () => {
+describe("Roaster scan progression", () => {
   it("keeps observing a pending durable run until completion or a terminal state", () => {
     expect(source).toContain('setPendingMessage(t("errScanPending"))');
     expect(source).toContain("while (!controller.signal.aborted)");
     expect(source).toContain('status?.status === "failed" || statusRes.status === 404');
     expect(source).not.toContain("2 * 60 * 1_000");
+  });
+
+  it("streams a provisional quick result on the current page and upgrades only an active page", () => {
+    expect(source).toContain("if (result.provisional)");
+    expect(source).toContain("void runRoast(result)");
+    expect(source).toContain("followCanonicalUpgrade(result.metrics.username, refreshRunId)");
+    expect(source).toContain("const upgradeAbortRef = useRef<AbortController | null>(null)");
+    expect(source).toContain('status?.status === "complete_public" && status.scan');
   });
 });

--- a/src/lib/public-scan.ts
+++ b/src/lib/public-scan.ts
@@ -205,8 +205,9 @@ function previousCollectionVersion(): string | null {
 
 /**
  * The quick collector is intentionally bounded. These signals mean it cannot
- * honestly describe the full public history, so callers must wait for the
- * durable run rather than send a partial score to the writer or leaderboard.
+ * honestly describe the full public history. Callers may show its deterministic
+ * score as a transient quick result, but must wait for the durable run before
+ * writing a formal score, report, or leaderboard row.
  */
 export function requiresDurablePublicScan(scan: ScanResult): boolean {
   const metrics = scan.metrics;

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -123,9 +123,9 @@ export async function setCachedScan(username: string, scan: ScanResult): Promise
   }
 }
 
-/** Remove a bounded quick snapshot when a durable public-history run takes
- * ownership. A partial score must never be replayed into the writer while the
- * complete immutable snapshot is still collecting. */
+/** Remove a bounded quick snapshot when it is corrupt or superseded. A durable
+ * run intentionally keeps its trusted quick snapshot available for immediate
+ * provisional responses; formal writes still require the complete snapshot. */
 export async function clearCachedScan(username: string): Promise<void> {
   const r = getRedis();
   if (!r) return;


### PR DESCRIPTION
## Behavior
- Serve a server-authored bounded quick scan immediately and start durable enrichment only when its evidence is incomplete.
- Stream the current scoring formula and a transient roast from that trusted quick result.
- Keep formal v9/v9/v4 scores and reports limited to complete snapshots.
- Upgrade only a page that remains open after the durable scan completes; do not schedule background LLM regenerations.
- Keep v5 fallback read-only and prevent fallback reads from creating durable work.

## Verification
- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm versions:check
- pnpm build
- Home page checked in light, dark, and auto themes.