### PR TITLE
fix(roast): remove BotID availability gate

### DIFF
--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -5,7 +5,6 @@ import type { ScanResult } from "@/lib/types";
 const mocks = vi.hoisted(() => ({
   acquireRoastLock: vi.fn(),
   buildRoastMessages: vi.fn(),
-  checkBotId: vi.fn(),
   checkRoastRateLimit: vi.fn(),
   checkRoastRequestRateLimit: vi.fn(),
   chat: vi.fn(),
@@ -26,7 +25,6 @@ const mocks = vi.hoisted(() => ({
   waitForCachedRoast: vi.fn(),
 }));
 
-vi.mock("botid/server", () => ({ checkBotId: mocks.checkBotId }));
 vi.mock("@/lib/db", () => ({
   getArchivedRoast: mocks.getArchivedRoast,
   getCanonicalScoreWriteIdentity: mocks.getCanonicalScoreWriteIdentity,
@@ -68,7 +66,6 @@ const scan = {
 
 describe("POST /api/roast quick score contract", () => {
   beforeEach(() => {
-    mocks.checkBotId.mockResolvedValue({ isBot: false, isVerifiedBot: false });
     mocks.checkRoastRequestRateLimit.mockResolvedValue({ success: true });
     mocks.checkRoastRateLimit.mockResolvedValue({ success: true });
     mocks.rateLimitHeaders.mockReturnValue({});
@@ -100,6 +97,19 @@ describe("POST /api/roast quick score contract", () => {
     await new Response(response.body).text();
     expect(mocks.getCanonicalScoreWriteIdentity).toHaveBeenCalledWith("DemoDev", expect.stringMatching(/^[a-f0-9]{64}$/));
     expect(mocks.updateRoast).toHaveBeenCalled();
+  });
+
+  it("accepts an interactive roast without a BotID availability gate", async () => {
+    const response = await POST(new NextRequest("https://example.test/api/roast", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scan, lang: "zh" }),
+    }));
+
+    expect(response.status).toBe(200);
+    await new Response(response.body).text();
+    expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalled();
+    expect(mocks.checkRoastRateLimit).toHaveBeenCalled();
   });
 
   it("uses the exact server quick snapshot instead of a client handoff", async () => {

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { checkBotId } from "botid/server";
 import { TIER_LABEL_EN } from "@/lib/badge";
 import { machineAuth } from "@/lib/machine-auth";
 import {
@@ -613,13 +612,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "missing_scan" }, { status: 400 });
   }
 
-  // Human/agent gate, before any cache or LLM work — but ONLY for the paths that
-  // spend the operator's LLM credit. Anonymous agents keep two open lanes: byoKey
-  // (their own model, their own bill) and the Bearer key. Verified
-  // crawlers/assistants (googlebot, chatgpt-user, claude…) pass as agents;
-  // browsers must pass BotID's invisible human check. Only the impersonator
-  // remainder — headless farms on rotating proxies — is refused, and the refusal
-  // advertises the documented agent surface instead.
+  // Invalid machine credentials still fail closed. Interactive browser roasts
+  // are protected by the request and generation rate limits below; a heuristic
+  // bot classifier must not gate this primary user-facing flow.
   const auth = machineAuth(req);
   if (auth === "invalid") {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
@@ -673,22 +668,6 @@ export async function POST(req: NextRequest) {
   }
   const { config, isDefault } = resolved;
 
-  // The gate keys on the RESOLVED config, not on whether a byoKey field was
-  // sent: an empty/partial byoKey (e.g. `byoKey: {}`) falls back to the
-  // default config in resolveConfig, so checking `body.byoKey` here would let
-  // it skip BotID and burn the operator's credit anyway.
-  if (auth === "absent" && isDefault) {
-    const verification = await checkBotId();
-    if (verification.isBot && !verification.isVerifiedBot) {
-      return NextResponse.json(
-        {
-          error: "bot_detected",
-          hint: "Automated clients are welcome: use the documented API and MCP server at https://ghfind.com/docs (free, no headless browser required).",
-        },
-        { status: 403 },
-      );
-    }
-  }
   // Default path fails over to the operator's fallback provider (DeepSeek) when
   // the primary drops/queues the connection before any answer text. BYO keys
   // never fail over — the user supplied a single key and pays their own way.

--- a/src/app/api/vs-verdict/route.ts
+++ b/src/app/api/vs-verdict/route.ts
@@ -38,8 +38,7 @@ function canonicalize(a: string, b: string): { a: string; b: string } | null {
 /**
  * Generate (or return the cached) bilingual LLM PK verdict + self-improvement
  * advice for a matchup. Auto-fired by the /vs page on mount, so crawlers that
- * run JS reach it too — BotID gates them before anything is written or spent
- * (mirrors /api/roast: verified crawlers pass, headless farms are refused).
+ * run JS reach it too — BotID gates them before anything is written or spent.
  * Guardrails: both sides must clear VS_MIN_SCORE, per-IP rate limit,
  * single-flight lock, and a ~5-day cache — so one pair costs at most one LLM
  * call per window. The matchup row + view count are written only after the bot

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,15 +19,12 @@ const GA_MEASUREMENT_ID =
   process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? "G-GHXRYBFZEN";
 
 /**
- * Routes whose fetches get a BotID signature attached client-side, so the server
- * can invisibly tell humans from headless farms via checkBotId(). Only the
- * credit-spending LLM routes need this — /api/scan keeps its Turnstile gate, and
- * agents skip BotID entirely by authenticating with a Bearer key (or by being a
- * verified bot). vs-verdict is here because the /vs page auto-fires it on mount,
- * which any JS-running crawler would otherwise trigger.
+ * The verdict route gets a BotID signature because /vs auto-fires it on mount,
+ * which any JS-running crawler could otherwise trigger. Interactive roasts rely
+ * on scan Turnstile plus server-side request and generation rate limits instead:
+ * BotID classifications are not reliable enough to gate the primary user flow.
  */
 const BOTID_PROTECTED_ROUTES = [
-  { path: "/api/roast", method: "POST" as const },
   { path: "/api/vs-verdict", method: "POST" as const },
 ];
 

--- a/src/lib/machine-auth.ts
+++ b/src/lib/machine-auth.ts
@@ -2,9 +2,9 @@ import type { NextRequest } from "next/server";
 
 /** Presence + validity of the Authorization header, kept separate so an invalid
  *  key returns a spec-shaped 401 (with WWW-Authenticate) instead of falling
- *  through to the browser human-verification path. Shared by the credit-spending
- *  endpoints (/api/scan, /api/roast) — agents authenticate here, humans are
- *  verified by Turnstile (scan) or BotID (roast). */
+ *  through to the normal browser path. Shared by the credit-spending endpoints
+ *  (/api/scan, /api/roast): agents authenticate here; browser traffic is guarded
+ *  by Turnstile on scan and server-side rate limits on roast. */
 export function machineAuth(req: NextRequest): "valid" | "invalid" | "absent" {
   const value = req.headers.get("authorization") ?? "";
   if (!value) return "absent";


### PR DESCRIPTION
## Incident

Production BotID classified real interactive browser requests to `POST /api/roast` as bots and returned `403 bot_detected` before the roast route reached its LLM, cache, or trace logging. This presented as an indefinitely preheating roast modal even though the model provider was healthy.

## Change

- Remove the BotID client signature and server-side hard rejection from `POST /api/roast` only.
- Keep BotID protection for `POST /api/vs-verdict`.
- Preserve invalid Bearer credential rejection, scan Turnstile, roast request and generation rate limits, canonical v9 snapshot validation, cached replay, fallback-provider behavior, and the singleflight lock.
- Add route coverage proving an anonymous interactive roast is accepted while both roast limiters still execute.

## Scope

No score formula, score/roast/collection version, quick-scan behavior, legacy fallback, queue/worker behavior, database schema, or cache policy changes.

## Verification

- `pnpm exec vitest run src/app/api/roast/route.test.ts src/app/api/vs-verdict/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm versions:check` (`v9/v9/v4`, canonical)
- `pnpm build`
- `pnpm test` (66 files, 501 tests)
- `git diff --check`

## Production smoke after deployment

From a normal browser, submit a roast and confirm `POST /api/roast` returns `200` and the event stream completes. A `403 bot_detected` must no longer be possible on this endpoint; it remains expected only for the VS verdict endpoint.
