### PR TITLE
fix(event): isolate verified browsers behind shared NAT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,9 @@ UPSTASH_REDIS_REST_TOKEN=
 # RATE_LIMIT_FAIL_OPEN=1
 
 # ── Human verification (optional but recommended in prod) ─────────────────
-# Cloudflare Turnstile (free). If absent, the human-check is skipped.
+# Cloudflare Turnstile (free). If absent, the human-check is skipped. When set,
+# successful browser scans also receive a short-lived signed anonymous session
+# cookie for per-browser event rate limits behind shared Wi-Fi/NAT.
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -6,7 +6,9 @@ const mocks = vi.hoisted(() => ({
   acquireRoastLock: vi.fn(),
   buildRoastMessages: vi.fn(),
   checkRoastRateLimit: vi.fn(),
+  checkRoastNetworkRateLimit: vi.fn(),
   checkRoastRequestRateLimit: vi.fn(),
+  checkRoastRequestNetworkRateLimit: vi.fn(),
   chat: vi.fn(),
   defaultLlmConfig: vi.fn(),
   fallbackLlmConfig: vi.fn(),
@@ -23,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   setCachedRoast: vi.fn(),
   updateRoast: vi.fn(),
   waitForCachedRoast: vi.fn(),
+  anonymousSessionPrincipal: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -37,7 +40,9 @@ vi.mock("@/lib/rank", () => ({ getRankCached: mocks.getRankCached }));
 vi.mock("@/lib/redis", () => ({
   acquireRoastLock: mocks.acquireRoastLock,
   checkRoastRateLimit: mocks.checkRoastRateLimit,
+  checkRoastNetworkRateLimit: mocks.checkRoastNetworkRateLimit,
   checkRoastRequestRateLimit: mocks.checkRoastRequestRateLimit,
+  checkRoastRequestNetworkRateLimit: mocks.checkRoastRequestNetworkRateLimit,
   clearCachedRoast: vi.fn(),
   getCachedRoast: mocks.getCachedRoast,
   getCachedScan: mocks.getCachedScan,
@@ -45,6 +50,9 @@ vi.mock("@/lib/redis", () => ({
   releaseRoastLock: mocks.releaseRoastLock,
   setCachedRoast: mocks.setCachedRoast,
   waitForCachedRoast: mocks.waitForCachedRoast,
+}));
+vi.mock("@/lib/anonymous-session", () => ({
+  anonymousSessionPrincipal: mocks.anonymousSessionPrincipal,
 }));
 vi.mock("@/lib/prompt", () => ({ buildRoastMessages: mocks.buildRoastMessages }));
 vi.mock("@/lib/llm", () => ({
@@ -68,7 +76,10 @@ describe("POST /api/roast quick score contract", () => {
   beforeEach(() => {
     mocks.checkRoastRequestRateLimit.mockResolvedValue({ success: true });
     mocks.checkRoastRateLimit.mockResolvedValue({ success: true });
+    mocks.checkRoastRequestNetworkRateLimit.mockResolvedValue({ success: true });
+    mocks.checkRoastNetworkRateLimit.mockResolvedValue({ success: true });
     mocks.rateLimitHeaders.mockReturnValue({});
+    mocks.anonymousSessionPrincipal.mockReturnValue(null);
     mocks.defaultLlmConfig.mockReturnValue({ baseURL: "https://llm.example.test", apiKey: "key", model: "model" });
     mocks.fallbackLlmConfig.mockReturnValue(null);
     mocks.getCachedScan.mockResolvedValue(null);
@@ -110,6 +121,42 @@ describe("POST /api/roast quick score contract", () => {
     await new Response(response.body).text();
     expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalled();
     expect(mocks.checkRoastRateLimit).toHaveBeenCalled();
+  });
+
+  it("uses the signed browser session while retaining the shared network budgets", async () => {
+    mocks.anonymousSessionPrincipal.mockReturnValue("anon:session-fixture");
+    const response = await POST(new NextRequest("https://example.test/api/roast", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-for": "198.51.100.10" },
+      body: JSON.stringify({ scan, lang: "zh" }),
+    }));
+
+    expect(response.status).toBe(200);
+    await new Response(response.body).text();
+    expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalledWith("anon:session-fixture");
+    expect(mocks.checkRoastRequestNetworkRateLimit).toHaveBeenCalledWith("198.51.100.10");
+    expect(mocks.checkRoastRateLimit).toHaveBeenCalledWith("anon:session-fixture");
+    expect(mocks.checkRoastNetworkRateLimit).toHaveBeenCalledWith("198.51.100.10");
+  });
+
+  it("keeps machine-authenticated callers on their IP budget", async () => {
+    process.env.GITHUB_ROAST_CLI_API_KEY = "test-key";
+    mocks.anonymousSessionPrincipal.mockReturnValue("anon:session-fixture");
+
+    const response = await POST(new NextRequest("https://example.test/api/roast", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-key",
+        "content-type": "application/json",
+        "x-forwarded-for": "198.51.100.10",
+      },
+      body: JSON.stringify({ scan, lang: "zh" }),
+    }));
+
+    expect(response.status).toBe(200);
+    await new Response(response.body).text();
+    expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalledWith("198.51.100.10");
+    expect(mocks.checkRoastRateLimit).toHaveBeenCalledWith("198.51.100.10");
   });
 
   it("uses the exact server quick snapshot instead of a client handoff", async () => {

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { TIER_LABEL_EN } from "@/lib/badge";
+import { anonymousSessionPrincipal } from "@/lib/anonymous-session";
 import { machineAuth } from "@/lib/machine-auth";
 import {
   getArchivedRoast,
@@ -31,6 +32,8 @@ import {
   acquireRoastLock,
   checkRoastRequestRateLimit,
   checkRoastRateLimit,
+  checkRoastNetworkRateLimit,
+  checkRoastRequestNetworkRateLimit,
   clearCachedRoast,
   getCachedRoast,
   getCachedScan,
@@ -619,17 +622,34 @@ export async function POST(req: NextRequest) {
   if (auth === "invalid") {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
+  const ip = clientIp(req);
+  // CLI/MCP callers retain their IP budget. Only an interactive browser that
+  // completed Turnstile can exchange its shared-NAT IP key for a signed session.
+  const principal = auth === "absent" ? anonymousSessionPrincipal(req) ?? ip : ip;
 
   // This protects every path, including BYO: it runs before the snapshot and
   // scan-cache reads below, while the later roast limiter remains dedicated
   // to operator-paid model generation.
-  const requestLimit = await checkRoastRequestRateLimit(clientIp(req));
+  const requestLimit = await checkRoastRequestRateLimit(principal);
   if (!requestLimit.success) {
     return NextResponse.json(
       { error: requestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
       {
         status: requestLimit.unavailable ? 503 : 429,
         headers: { ...rateLimitHeaders(requestLimit), "Cache-Control": "no-store" },
+      },
+    );
+  }
+  const networkRequestLimit = await checkRoastRequestNetworkRateLimit(ip);
+  if (!networkRequestLimit.success) {
+    return NextResponse.json(
+      {
+        error: networkRequestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+        useByoKey: true,
+      },
+      {
+        status: networkRequestLimit.unavailable ? 503 : 429,
+        headers: { ...rateLimitHeaders(networkRequestLimit), "Cache-Control": "no-store" },
       },
     );
   }
@@ -775,13 +795,26 @@ export async function POST(req: NextRequest) {
         return roastResponse(archivedRoast.report, meta);
       }
     }
-    const generationLimit = await checkRoastRateLimit(clientIp(req));
+    const generationLimit = await checkRoastRateLimit(principal);
     if (!generationLimit.success) {
       return NextResponse.json(
         { error: generationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
         {
           status: generationLimit.unavailable ? 503 : 429,
           headers: { ...rateLimitHeaders(generationLimit), "Cache-Control": "no-store" },
+        },
+      );
+    }
+    const networkGenerationLimit = await checkRoastNetworkRateLimit(ip);
+    if (!networkGenerationLimit.success) {
+      return NextResponse.json(
+        {
+          error: networkGenerationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+          useByoKey: true,
+        },
+        {
+          status: networkGenerationLimit.unavailable ? 503 : 429,
+          headers: { ...rateLimitHeaders(networkGenerationLimit), "Cache-Control": "no-store" },
         },
       );
     }

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -5,6 +5,7 @@ import type { ScanResult } from "@/lib/types";
 const mocks = vi.hoisted(() => ({
   buildScanResult: vi.fn(),
   checkRateLimit: vi.fn(),
+  checkScanNetworkRateLimit: vi.fn(),
   coalesceScan: vi.fn(),
   getCachedScan: vi.fn(),
   getLegacyReadFallbackScan: vi.fn(),
@@ -14,6 +15,9 @@ const mocks = vi.hoisted(() => ({
   recordAccountLookup: vi.fn(),
   recordCampaignParticipant: vi.fn(),
   verifyTurnstile: vi.fn(),
+  anonymousSessionPrincipal: vi.fn(),
+  attachAnonymousSession: vi.fn(),
+  establishAnonymousSession: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -25,12 +29,18 @@ vi.mock("@/lib/db", () => ({
 }));
 vi.mock("@/lib/redis", () => ({
   checkRateLimit: mocks.checkRateLimit,
+  checkScanNetworkRateLimit: mocks.checkScanNetworkRateLimit,
   coalesceScan: mocks.coalesceScan,
   getCachedScan: mocks.getCachedScan,
   rateLimitHeaders: mocks.rateLimitHeaders,
 }));
 vi.mock("@/lib/scan-core", () => ({ buildScanResult: mocks.buildScanResult }));
 vi.mock("@/lib/turnstile", () => ({ verifyTurnstile: mocks.verifyTurnstile }));
+vi.mock("@/lib/anonymous-session", () => ({
+  anonymousSessionPrincipal: mocks.anonymousSessionPrincipal,
+  attachAnonymousSession: mocks.attachAnonymousSession,
+  establishAnonymousSession: mocks.establishAnonymousSession,
+}));
 
 import { POST } from "./route";
 
@@ -51,6 +61,7 @@ describe("POST /api/scan immediate quick contract", () => {
   beforeEach(() => {
     process.env.GITHUB_ROAST_CLI_API_KEY = "test-key";
     mocks.checkRateLimit.mockResolvedValue({ success: true });
+    mocks.checkScanNetworkRateLimit.mockResolvedValue({ success: true });
     mocks.rateLimitHeaders.mockReturnValue({});
     mocks.getCachedScan.mockResolvedValue(null);
     mocks.coalesceScan.mockImplementation(async (_handle: string, produce: () => unknown) => produce());
@@ -60,6 +71,10 @@ describe("POST /api/scan immediate quick contract", () => {
     mocks.recordCampaignParticipant.mockResolvedValue(undefined);
     mocks.getLegacyReadFallbackScan.mockResolvedValue(null);
     mocks.hasLegacyReadFallbackProfile.mockResolvedValue(false);
+    mocks.verifyTurnstile.mockResolvedValue(true);
+    mocks.anonymousSessionPrincipal.mockReturnValue(null);
+    mocks.establishAnonymousSession.mockReturnValue(null);
+    mocks.attachAnonymousSession.mockImplementation((response) => response);
   });
 
   afterEach(() => {
@@ -78,6 +93,7 @@ describe("POST /api/scan immediate quick contract", () => {
       scoring: { final_score: 71 },
     });
     expect(mocks.publishCompleteQuickScan).toHaveBeenCalledWith(quickScan, expect.any(Number));
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith("0.0.0.0");
   });
 
   it("serves v5 only after the quick collector fails", async () => {
@@ -94,5 +110,24 @@ describe("POST /api/scan immediate quick contract", () => {
       served_roast_version: "v5",
       served_collection_version: "v3",
     });
+  });
+
+  it("uses a Turnstile-issued browser session before the shared network budget", async () => {
+    delete process.env.GITHUB_ROAST_CLI_API_KEY;
+    mocks.establishAnonymousSession.mockReturnValue({ id: "session-fixture", issued: true });
+
+    const response = await POST(new NextRequest("https://example.test/api/scan", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-for": "198.51.100.10" },
+      body: JSON.stringify({ username: "DemoDev", turnstileToken: "token" }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith("anon:session-fixture");
+    expect(mocks.checkScanNetworkRateLimit).toHaveBeenCalledWith("198.51.100.10");
+    expect(mocks.attachAnonymousSession).toHaveBeenCalledWith(
+      expect.any(Response),
+      { id: "session-fixture", issued: true },
+    );
   });
 });

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -9,10 +9,16 @@ import {
 } from "@/lib/db";
 import {
   checkRateLimit,
+  checkScanNetworkRateLimit,
   coalesceScan,
   getCachedScan,
   rateLimitHeaders,
 } from "@/lib/redis";
+import {
+  attachAnonymousSession,
+  establishAnonymousSession,
+  type AnonymousSession,
+} from "@/lib/anonymous-session";
 import { apiError } from "@/lib/api-error";
 import { machineAuth } from "@/lib/machine-auth";
 import { buildScanResult, scanErrorResponse } from "@/lib/scan-core";
@@ -157,19 +163,29 @@ export async function POST(req: NextRequest) {
   const ip = clientIp(req);
   const auth = machineAuth(req);
   if (auth === "invalid") return apiError("unauthorized", { status: 401, headers: idem });
+  let anonymousSession: AnonymousSession | null = null;
   if (auth === "absent") {
     const token = typeof body.turnstileToken === "string" ? body.turnstileToken : null;
     if (!(await verifyTurnstile(token, ip))) {
       return apiError("turnstile_failed", { status: 403, headers: idem });
     }
+    anonymousSession = establishAnonymousSession(req);
   }
 
-  const limit = await checkRateLimit(ip);
+  const principal = auth === "absent" && anonymousSession ? `anon:${anonymousSession.id}` : ip;
+  const limit = await checkRateLimit(principal);
   const rlHeaders = rateLimitHeaders(limit);
   if (!limit.success) {
     return apiError(limit.unavailable ? "rate_limit_unavailable" : "rate_limited", {
       status: limit.unavailable ? 503 : 429,
       headers: { ...idem, ...rlHeaders, "Cache-Control": "no-store" },
+    });
+  }
+  const networkLimit = await checkScanNetworkRateLimit(ip);
+  if (!networkLimit.success) {
+    return apiError(networkLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", {
+      status: networkLimit.unavailable ? 503 : 429,
+      headers: { ...idem, ...rateLimitHeaders(networkLimit), "Cache-Control": "no-store" },
     });
   }
 
@@ -179,7 +195,10 @@ export async function POST(req: NextRequest) {
       return scorePersistenceUnavailable({ ...idem, ...rlHeaders });
     }
     await recordSuccessfulLookup(cached.metrics.username, ip, campaign);
-    return immediateResponse({ scan: cached, cached: true, headers: { ...idem, ...rlHeaders } });
+    return attachAnonymousSession(
+      immediateResponse({ scan: cached, cached: true, headers: { ...idem, ...rlHeaders } }),
+      anonymousSession,
+    );
   }
 
   try {
@@ -190,17 +209,26 @@ export async function POST(req: NextRequest) {
       return quickScan;
     });
     await recordSuccessfulLookup(result.metrics.username, ip, campaign);
-    return immediateResponse({ scan: result, cached: false, headers: { ...idem, ...rlHeaders } });
+    return attachAnonymousSession(
+      immediateResponse({ scan: result, cached: false, headers: { ...idem, ...rlHeaders } }),
+      anonymousSession,
+    );
   } catch (error) {
     if (error instanceof ScorePersistenceError) {
       return scorePersistenceUnavailable({ ...idem, ...rlHeaders });
     }
     const legacyScan = await getLegacyReadFallbackScan(username);
     if (legacyScan) {
-      return legacyReadFallbackResponse({ scan: legacyScan, headers: { ...idem, ...rlHeaders } });
+      return attachAnonymousSession(
+        await legacyReadFallbackResponse({ scan: legacyScan, headers: { ...idem, ...rlHeaders } }),
+        anonymousSession,
+      );
     }
     if (await hasLegacyReadFallbackProfile(username)) {
-      return legacyReadFallbackProfileResponse({ username, headers: { ...idem, ...rlHeaders } });
+      return attachAnonymousSession(
+        await legacyReadFallbackProfileResponse({ username, headers: { ...idem, ...rlHeaders } }),
+        anonymousSession,
+      );
     }
     const { error: code, status, retry_after } = scanErrorResponse(error);
     return apiError(code as Parameters<typeof apiError>[0], {

--- a/src/lib/__tests__/anonymous-session.test.ts
+++ b/src/lib/__tests__/anonymous-session.test.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ANONYMOUS_SESSION_COOKIE,
+  anonymousSessionPrincipal,
+  attachAnonymousSession,
+  establishAnonymousSession,
+} from "../anonymous-session";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("anonymous browser session", () => {
+  it("issues a signed HttpOnly session only with a Turnstile server secret", () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "turnstile-test-secret");
+    const request = new NextRequest("https://example.test/api/scan");
+    const session = establishAnonymousSession(request, 1_700_000_000_000);
+    const response = attachAnonymousSession(NextResponse.json({ ok: true }), session);
+
+    const cookie = response.cookies.get(ANONYMOUS_SESSION_COOKIE);
+    expect(session).toMatchObject({ issued: true });
+    expect(cookie?.value).toBe(session?.value);
+    expect(cookie?.httpOnly).toBe(true);
+    expect(cookie?.sameSite).toBe("lax");
+  });
+
+  it("accepts the issued identity and rejects a tampered cookie", () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "turnstile-test-secret");
+    const now = 1_700_000_000_000;
+    const initial = new NextRequest("https://example.test/api/scan");
+    const session = establishAnonymousSession(initial, now);
+    if (!session?.value) throw new Error("expected a session");
+
+    const valid = new NextRequest("https://example.test/api/roast", {
+      headers: { cookie: `${ANONYMOUS_SESSION_COOKIE}=${session.value}` },
+    });
+    const tampered = new NextRequest("https://example.test/api/roast", {
+      headers: { cookie: `${ANONYMOUS_SESSION_COOKIE}=${session.value}x` },
+    });
+
+    expect(anonymousSessionPrincipal(valid, now + 1)).toBe(`anon:${session.id}`);
+    expect(anonymousSessionPrincipal(tampered, now + 1)).toBeNull();
+  });
+
+  it("does not issue a browser identity when Turnstile is not configured", () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "");
+    expect(establishAnonymousSession(new NextRequest("https://example.test/api/scan"))).toBeNull();
+  });
+});

--- a/src/lib/__tests__/redis-rate-limit.test.ts
+++ b/src/lib/__tests__/redis-rate-limit.test.ts
@@ -43,15 +43,21 @@ describe("production rate-limit availability", () => {
     vi.stubEnv("VERCEL_ENV", "production");
     unsetRedisEnv();
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const { checkRateLimit, rateLimitHeaders } = await loadRedis();
+    const { checkRateLimit, checkScanNetworkRateLimit, rateLimitHeaders } = await loadRedis();
 
     const result = await checkRateLimit("198.51.100.10");
+    const networkResult = await checkScanNetworkRateLimit("198.51.100.10");
 
     expect(result).toMatchObject({ success: false, unavailable: true, retryAfter: 15 });
+    expect(networkResult).toMatchObject({ success: false, unavailable: true, retryAfter: 15 });
     expect(rateLimitHeaders(result)).toEqual({ "Retry-After": "15" });
     expect(error).toHaveBeenCalledWith(
       "rate_limit_unavailable",
       expect.objectContaining({ limiter: "scan", reason: "missing_redis_config" }),
+    );
+    expect(error).toHaveBeenCalledWith(
+      "rate_limit_unavailable",
+      expect.objectContaining({ limiter: "scan_network", reason: "missing_redis_config" }),
     );
   });
 

--- a/src/lib/anonymous-session.ts
+++ b/src/lib/anonymous-session.ts
@@ -1,0 +1,106 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { NextRequest, NextResponse } from "next/server";
+
+export const ANONYMOUS_SESSION_COOKIE = "ghfind_anonymous_session";
+
+const SESSION_VERSION = "v1";
+const SESSION_TTL_MS = 12 * 60 * 60 * 1_000;
+const SESSION_MAX_AGE_SECONDS = Math.ceil(SESSION_TTL_MS / 1_000);
+const SESSION_CONTEXT = "ghfind:anonymous-session";
+
+export interface AnonymousSession {
+  id: string;
+  issued: boolean;
+  value?: string;
+}
+
+function configured(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+/**
+ * A browser session is issued only after a real Turnstile verification. Reuse
+ * AUTH_SECRET when available; otherwise the Turnstile server secret is still a
+ * private, high-entropy signing key. No session is issued without Turnstile.
+ */
+function signingSecret(): string | null {
+  const turnstileSecret = configured(process.env.TURNSTILE_SECRET_KEY);
+  if (!turnstileSecret) return null;
+  return configured(process.env.AUTH_SECRET) ?? turnstileSecret;
+}
+
+function signature(payload: string, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(`${SESSION_CONTEXT}:${payload}`)
+    .digest("base64url");
+}
+
+function validSignature(actual: string, expected: string): boolean {
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}
+
+function parseSession(value: string | undefined, now: number): string | null {
+  const secret = signingSecret();
+  if (!secret || !value) return null;
+  const [version, id, rawExpiresAt, suppliedSignature, ...extra] = value.split(".");
+  if (
+    extra.length > 0 ||
+    version !== SESSION_VERSION ||
+    !/^[A-Za-z0-9_-]{24,}$/.test(id ?? "") ||
+    !/^\d{13}$/.test(rawExpiresAt ?? "") ||
+    !/^[A-Za-z0-9_-]{40,}$/.test(suppliedSignature ?? "")
+  ) {
+    return null;
+  }
+  const expiresAt = Number(rawExpiresAt);
+  if (!Number.isSafeInteger(expiresAt) || expiresAt <= now) return null;
+  const payload = `${version}.${id}.${rawExpiresAt}`;
+  return validSignature(suppliedSignature!, signature(payload, secret)) ? id! : null;
+}
+
+/** Return a signed session identity, never an untrusted client identifier. */
+export function anonymousSessionPrincipal(req: NextRequest, now = Date.now()): string | null {
+  const id = parseSession(req.cookies.get(ANONYMOUS_SESSION_COOKIE)?.value, now);
+  return id ? `anon:${id}` : null;
+}
+
+/**
+ * Call only after Turnstile succeeds. Existing valid sessions keep their expiry
+ * so repeated scans cannot perpetually extend a browser budget.
+ */
+export function establishAnonymousSession(req: NextRequest, now = Date.now()): AnonymousSession | null {
+  const existing = anonymousSessionPrincipal(req, now);
+  if (existing) return { id: existing.slice("anon:".length), issued: false };
+
+  const secret = signingSecret();
+  if (!secret) return null;
+  const id = randomBytes(18).toString("base64url");
+  const expiresAt = now + SESSION_TTL_MS;
+  const payload = `${SESSION_VERSION}.${id}.${expiresAt}`;
+  return {
+    id,
+    issued: true,
+    value: `${payload}.${signature(payload, secret)}`,
+  };
+}
+
+/** Attach a short-lived, HttpOnly cookie only when a new session was issued. */
+export function attachAnonymousSession<T extends NextResponse>(
+  response: T,
+  session: AnonymousSession | null,
+): T {
+  if (!session?.issued || !session.value) return response;
+  response.cookies.set({
+    name: ANONYMOUS_SESSION_COOKIE,
+    value: session.value,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production" || process.env.VERCEL_ENV === "production",
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+  return response;
+}

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -31,11 +31,15 @@ import type { RoastJudgeResult, RoastLine, ScanResult } from "./types";
 
 let redis: Redis | null = null;
 let scanLimiter: Ratelimit | null = null;
+let scanNetworkLimiter: Ratelimit | null = null;
 let campaignLeaderboardReadLimiter: Ratelimit | null = null;
 let mcpLimiter: Ratelimit | null = null;
 let roastRequestLimiter: Ratelimit | null = null;
+let roastRequestNetworkLimiter: Ratelimit | null = null;
 let roastMinuteLimiter: Ratelimit | null = null;
 let roastDayLimiter: Ratelimit | null = null;
+let roastNetworkMinuteLimiter: Ratelimit | null = null;
+let roastNetworkDayLimiter: Ratelimit | null = null;
 let verdictMinuteLimiter: Ratelimit | null = null;
 let verdictDayLimiter: Ratelimit | null = null;
 
@@ -244,8 +248,8 @@ export function rateLimitHeaders(result: RateLimitResult): Record<string, string
   return headers;
 }
 
-/** Per-IP sliding-window limiter for scan and bounded public-read routes. */
-export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
+/** Per-principal sliding-window limiter for scan and bounded public-read routes. */
+export async function checkRateLimit(principal: string): Promise<RateLimitResult> {
   const r = getRedis();
   if (!r) return unavailableRateLimitResult("scan", "missing_redis_config");
   if (!scanLimiter) {
@@ -257,11 +261,34 @@ export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
     });
   }
   try {
-    const { success, limit, remaining, reset } = await scanLimiter.limit(ip);
+    const { success, limit, remaining, reset } = await scanLimiter.limit(principal);
     return { success, limit, remaining, reset };
   } catch (error) {
     return unavailableRateLimitResult(
       "scan",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
+  }
+}
+
+/** Wider second-line scan budget for browsers sharing one public network. */
+export async function checkScanNetworkRateLimit(ip: string): Promise<RateLimitResult> {
+  const r = getRedis();
+  if (!r) return unavailableRateLimitResult("scan_network", "missing_redis_config");
+  if (!scanNetworkLimiter) {
+    scanNetworkLimiter = new Ratelimit({
+      redis: r,
+      limiter: Ratelimit.slidingWindow(60, "60 s"),
+      prefix: "rl:scan-network",
+      analytics: false,
+    });
+  }
+  try {
+    const { success, limit, remaining, reset } = await scanNetworkLimiter.limit(ip);
+    return { success, limit, remaining, reset };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "scan_network",
       error instanceof Error ? error.name : "redis_request_failed",
     );
   }
@@ -306,7 +333,7 @@ export async function checkCampaignLeaderboardReadRateLimit(
  * separate from the stricter default-model credit limiter: BYO requests do not
  * spend our model credit, but they still invoke a function and read Turso.
  */
-export async function checkRoastRequestRateLimit(ip: string): Promise<RateLimitResult> {
+export async function checkRoastRequestRateLimit(principal: string): Promise<RateLimitResult> {
   const r = getRedis();
   if (!r) return unavailableRateLimitResult("roast_request", "missing_redis_config");
   if (!roastRequestLimiter) {
@@ -318,11 +345,34 @@ export async function checkRoastRequestRateLimit(ip: string): Promise<RateLimitR
     });
   }
   try {
-    const { success, limit, remaining, reset } = await roastRequestLimiter.limit(ip);
+    const { success, limit, remaining, reset } = await roastRequestLimiter.limit(principal);
     return { success, limit, remaining, reset };
   } catch (error) {
     return unavailableRateLimitResult(
       "roast_request",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
+  }
+}
+
+/** Wider second-line request budget for browsers sharing one public network. */
+export async function checkRoastRequestNetworkRateLimit(ip: string): Promise<RateLimitResult> {
+  const r = getRedis();
+  if (!r) return unavailableRateLimitResult("roast_request_network", "missing_redis_config");
+  if (!roastRequestNetworkLimiter) {
+    roastRequestNetworkLimiter = new Ratelimit({
+      redis: r,
+      limiter: Ratelimit.slidingWindow(120, "60 s"),
+      prefix: "rl:roast-request-network",
+      analytics: false,
+    });
+  }
+  try {
+    const { success, limit, remaining, reset } = await roastRequestNetworkLimiter.limit(ip);
+    return { success, limit, remaining, reset };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "roast_request_network",
       error instanceof Error ? error.name : "redis_request_failed",
     );
   }
@@ -356,11 +406,11 @@ export async function checkMcpRateLimit(ip: string): Promise<RateLimitResult> {
 }
 
 /**
- * Per-IP limiter for the (expensive) roast endpoint — the LLM call burns the
+ * Per-principal limiter for the (expensive) roast endpoint — the LLM call burns the
  * operator's credit, so it's limited tighter than scans: a burst window and a
  * daily cap. Only gates the default model; BYO keys are not limited.
  */
-export async function checkRoastRateLimit(ip: string): Promise<RateLimitResult> {
+export async function checkRoastRateLimit(principal: string): Promise<RateLimitResult> {
   const r = getRedis();
   if (!r) return unavailableRateLimitResult("roast_generation", "missing_redis_config");
   if (!roastMinuteLimiter) {
@@ -381,13 +431,47 @@ export async function checkRoastRateLimit(ip: string): Promise<RateLimitResult> 
   }
   try {
     const [minute, day] = await Promise.all([
-      roastMinuteLimiter.limit(ip),
-      roastDayLimiter.limit(ip),
+      roastMinuteLimiter.limit(principal),
+      roastDayLimiter.limit(principal),
     ]);
     return { success: minute.success && day.success };
   } catch (error) {
     return unavailableRateLimitResult(
       "roast_generation",
+      error instanceof Error ? error.name : "redis_request_failed",
+    );
+  }
+}
+
+/** Wider network-level generation budget, separate from each signed browser. */
+export async function checkRoastNetworkRateLimit(ip: string): Promise<RateLimitResult> {
+  const r = getRedis();
+  if (!r) return unavailableRateLimitResult("roast_generation_network", "missing_redis_config");
+  if (!roastNetworkMinuteLimiter) {
+    roastNetworkMinuteLimiter = new Ratelimit({
+      redis: r,
+      limiter: Ratelimit.slidingWindow(48, "60 s"),
+      prefix: "rl:roast-network:m",
+      analytics: false,
+    });
+  }
+  if (!roastNetworkDayLimiter) {
+    roastNetworkDayLimiter = new Ratelimit({
+      redis: r,
+      limiter: Ratelimit.slidingWindow(480, "1 d"),
+      prefix: "rl:roast-network:d",
+      analytics: false,
+    });
+  }
+  try {
+    const [minute, day] = await Promise.all([
+      roastNetworkMinuteLimiter.limit(ip),
+      roastNetworkDayLimiter.limit(ip),
+    ]);
+    return { success: minute.success && day.success };
+  } catch (error) {
+    return unavailableRateLimitResult(
+      "roast_generation_network",
       error instanceof Error ? error.name : "redis_request_failed",
     );
   }


### PR DESCRIPTION
## Context

At an event, many legitimate browser users can share one public IP. The previous scan and roast limits used that IP as the only identity, so one active participant could consume another participant's scan or default-model roast budget.

## Change

- After `/api/scan` successfully verifies Turnstile, issue a 12-hour signed, `HttpOnly`, `SameSite=Lax` anonymous browser-session cookie.
- Use that verified session as the primary scan, roast-request, and default-model generation limiter key.
- Retain a deliberately wider IP-level budget as the second-line network-abuse control:
  - scan: 60 / minute
  - roast requests: 120 / minute
  - default-model generation: 48 / minute and 480 / day
- Keep CLI/MCP callers on their original IP-based limiter path.
- Reject forged, expired, malformed, or unverified session cookies by falling back to the original IP key.
- When Turnstile is unavailable or not configured, do not mint a session and preserve the original IP-only behavior.

## Scope

No score formula, release version, quick scan, LLM provider, durable work, worker, or Cron behavior changes.

## Verification

- `pnpm exec vitest run src/lib/__tests__/anonymous-session.test.ts src/lib/__tests__/redis-rate-limit.test.ts src/app/api/scan/route.test.ts src/app/api/roast/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm versions:check` (`v9/v9/v4` canonical guard passed)
- `pnpm test` (67 files, 507 tests)
- `pnpm build`

## Rollout check

After deployment, use two separate browser profiles on the same network. Each should complete a Turnstile-backed scan and roast independently; machine-authenticated callers remain IP-limited. Production must retain its existing Turnstile server secret for the per-browser isolation path to activate.
