### PR TITLE
fix(sdk): expose verified open issue counts

### DIFF
--- a/packages/ghfind-js/src/types.ts
+++ b/packages/ghfind-js/src/types.ts
@@ -41,7 +41,11 @@ export interface TopRepo {
   name_with_owner?: string;
   stars: number;
   forks: number;
+  /** GitHub REST's aggregate, which includes open pull requests. */
   open_issues: number;
+  /** Verified open GitHub Issues only; excludes pull requests and may be absent
+   * when bounded enrichment is unavailable. */
+  open_issue_count?: number;
   size: number;
   language: string | null;
   description: string | null;


### PR DESCRIPTION
## Summary
- expose the optional verified `open_issue_count` field in the JS SDK scan contract
- clarify that the existing REST `open_issues` field includes open pull requests

## Verification
- pnpm --dir packages/ghfind-js typecheck
- pnpm --dir packages/ghfind-js test
- pnpm typecheck