### PR TITLE
fix(release): clarify roast v10 compatibility

### DIFF
--- a/config/release-versions.json
+++ b/config/release-versions.json
@@ -22,7 +22,7 @@
         "roast": "v10"
       }
     ],
-    "collectionReadOrder": ["v4", "v4"]
+    "collectionReadOrder": ["v4"]
   },
   "legacyReadFallback": {
     "score": "v5",

--- a/docs/releases/v9-v10-v4-rollout.md
+++ b/docs/releases/v9-v10-v4-rollout.md
@@ -10,10 +10,10 @@ that count is absent or zero.
 ## Rollout
 
 1. Deploy with roast cache version `v10`.
-2. Confirm `/api/score/4evour` remains a canonical v9/v4 score and a new roast
-   does not replay the previous v9 report.
-3. Re-roast `4evour`; `Tour-Pass` must not receive Issue-cleanup advice when
-   its verified open-Issue count is zero.
+2. Confirm the affected account remains a canonical v9/v4 score and a new
+   roast does not replay the previous v9 report.
+3. Re-roast the affected account; a repository with zero verified open Issues
+   must not receive Issue-cleanup advice.
 
 ## Rollback
 

--- a/src/lib/__tests__/prompt.test.ts
+++ b/src/lib/__tests__/prompt.test.ts
@@ -41,9 +41,9 @@ describe("buildRoastMessages", () => {
       top_repos: [
         {
           ...scan.top_repos[0],
-          name: "Tour-Pass",
-          owner_login: "4evour",
-          name_with_owner: "4evour/Tour-Pass",
+          name: "example-repo",
+          owner_login: "example-owner",
+          name_with_owner: "example-owner/example-repo",
           // GitHub REST's aggregate can be five open PRs and zero Issues.
           open_issues: 5,
           open_issue_count: 0,

--- a/src/lib/__tests__/release-versions.test.ts
+++ b/src/lib/__tests__/release-versions.test.ts
@@ -56,8 +56,18 @@ describe("release version contract", () => {
     expect(releaseVersionErrors(manifest, manifest.targetRelease)).toEqual([]);
   });
 
-  it("keeps the unchanged v4 collection in both isolated-release read slots", () => {
-    expect(RELEASE_VERSION_MANIFEST.compatibility.collectionReadOrder).toEqual(["v4", "v4"]);
+  it("keeps the unchanged v4 collection in one canonical read slot", () => {
+    expect(RELEASE_VERSION_MANIFEST.compatibility.collectionReadOrder).toEqual(["v4"]);
+  });
+
+  it("includes the previous collection only after a collection-version change", () => {
+    const manifest = manifestCopy();
+    manifest.targetRelease.collection = "v5";
+    manifest.compatibility.collectionReadOrder = ["v5", "v4"];
+
+    expect(
+      releaseVersionErrors(manifest, { ...manifest.targetRelease }),
+    ).toEqual([]);
   });
 
   it("rejects aliases and accidental-version replay paths", () => {

--- a/src/lib/release-versions.ts
+++ b/src/lib/release-versions.ts
@@ -203,13 +203,14 @@ export function releaseVersionErrors(
     if (!exactList(typed.compatibility.publicScoreReadOrder, [targetRelease.score])) {
       errors.push("public score reads must only serve the canonical target release");
     }
-    if (
-      !exactList(typed.compatibility.collectionReadOrder, [
-        targetRelease.collection,
-        previousRelease.collection,
-      ])
-    ) {
-      errors.push("collection reads must prefer target and fall back to the previous release");
+    const collectionReadOrder =
+      targetRelease.collection === previousRelease.collection
+        ? [targetRelease.collection]
+        : [targetRelease.collection, previousRelease.collection];
+    if (!exactList(typed.compatibility.collectionReadOrder, collectionReadOrder)) {
+      errors.push(
+        "collection reads must prefer target and include the previous release only after a collection-version change",
+      );
     }
     const roastReplay = typed.compatibility.roastReplay;
     if (


### PR DESCRIPTION
## Summary
- remove real account and repository identifiers from the roast regression fixture and rollout plan
- represent an unchanged collection version with one canonical `v4` read entry rather than a duplicate `v4` fallback
- require a previous collection entry only when the collection version actually changes

## Non-impact
- does not alter the existing `v5/v5/v3` emergency DB fallback
- does not change scan, persistence, scoring, or roast runtime behavior

## Validation
- `pnpm test` (509 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec tsx scripts/check-release-versions.mts --base-ref upstream/main`
- `git diff --check`