### PR TITLE
feat(home): refine homepage product copy

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -47,7 +47,7 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
         <p className="mb-3 text-sm font-bold tracking-wide text-zinc-400">
           {t("brand")} <span className="text-orange-500">GitHub</span>
         </p>
-        <h1 className="max-w-2xl text-balance text-4xl font-black tracking-tight sm:text-5xl">
+        <h1 className="max-w-2xl whitespace-pre-line text-balance text-3xl font-black tracking-tight sm:text-5xl">
           {t("headline")}
         </h1>
         <p className="mt-3 max-w-md text-base font-semibold tracking-wide text-zinc-300 sm:text-lg">

--- a/src/components/DeveloperCount.tsx
+++ b/src/components/DeveloperCount.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
 /**
- * "已经有 N 名开发者参与战斗 ⚔️" — fetches the evaluated-account count and counts
+ * "已经有 N 名开发者惨遭锐评。" — fetches the evaluated-account count and counts
  * up from 0 to N on mount. Renders nothing until there is a positive count (so a
  * cold / DB-less environment shows no broken state).
  */

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -73,8 +73,8 @@
   },
   "home": {
     "brand": "毒舌",
-    "headline": "发现最佳开发者，也成为其中之一",
-    "subtitle": "先来一发 0–100 分的毒舌成色检测，看清你在哪，知道往哪走。",
+    "headline": "让“我为人人”的开发者被人人看见",
+    "subtitle": "从夯到拉锐评 GitHub 账号",
     "boardHeading": "🏆 发现最佳开发者",
     "openBoard": "打开完整榜单 →",
     "disclaimer1": "本站仅基于 GitHub <b>公开数据</b>自动生成评分与点评，吐槽的是账号的公开行为与数据，非针对个人。结果不构成对任何人的事实认定，请勿用于骚扰。",
@@ -410,7 +410,7 @@
     "cancel": "取消",
     "saveContinue": "保存并继续"
   },
-  "developerCount": "已经有 <n>{count, number}</n> 名开发者参与战斗 ⚔️",
+  "developerCount": "已经有 <n>{count, number}</n> 名开发者惨遭锐评。",
   "shareCard": {
     "beatLabel": "超越的开发者",
     "brand": "🔥 ghfind · 来测测你的含金量"

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -73,7 +73,7 @@
   },
   "home": {
     "brand": "毒舌",
-    "headline": "让“我为人人”的开发者被人人看见",
+    "headline": "让“我为人人”的开发者\n被人人看见",
     "subtitle": "从夯到拉锐评 GitHub 账号",
     "boardHeading": "🏆 发现最佳开发者",
     "openBoard": "打开完整榜单 →",


### PR DESCRIPTION
## Preview

<img width="1706" height="1044" alt="GHFind Chinese homepage preview with the revised two-line headline" src="https://github.com/user-attachments/assets/9becb8c2-55e0-4218-b1bd-95279f70f729" />

## Summary

- replace the ranking-driven homepage headline with `让“我为人人”的开发者被人人看见`
- shorten the supporting line to `从夯到拉锐评 GitHub 账号`
- align the developer-count social proof with the roast voice: `已经有 N 名开发者惨遭锐评。`
- update the nearby component comment so it does not repeat stale UI copy

## Why

The previous copy leaned on generic growth and competition language. This change gives the Chinese homepage a clearer, more distinctive product voice while keeping the wording concise and user-facing.

## Validation

- `pnpm test -- src/messages/__tests__/messages.test.ts` (5 tests passed)
- `pnpm typecheck`
- `pnpm lint`
- visible-copy leakage scanner: no findings
- manually checked the homepage in Light, Dark, and Auto themes
- checked the headline and subtitle at a 390 px mobile viewport with no horizontal overflow

## Generated artifacts

- No generated files included
- No GraphQL codegen updates
- No DB baseline updates
