### PR TITLE
fix(stats): retain all-time developer count

### DIFF
--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -2226,6 +2226,25 @@ describe("getRank", () => {
   });
 });
 
+describe("getScoreCount", () => {
+  it("counts every evaluated account, including accounts from prior score versions", async () => {
+    const before = await db.getScoreCount();
+    expect(before).not.toBeNull();
+    if (before === null) throw new Error("expected a configured test database");
+
+    await db.recordScore({ ...entry, username: "all-time-count-current" });
+    await db.recordScore({ ...entry, username: "all-time-count-legacy" });
+
+    const client = createClient({ url: process.env.TURSO_DATABASE_URL! });
+    await client.execute({
+      sql: "UPDATE scores SET score_version = ? WHERE username = ?",
+      args: [`${SCORE_CACHE_VERSION}-previous`, "all-time-count-legacy"],
+    });
+
+    await expect(db.getScoreCount()).resolves.toBe(before + 2);
+  });
+});
+
 describe("recordRepoGraph + updateInfluenceStats", () => {
   const raw = () => createClient({ url: process.env.TURSO_DATABASE_URL! });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4626,15 +4626,17 @@ export async function getFacetRank(
   }
 }
 
-/** Total number of accounts ever evaluated (for the "N developers" counter). */
+/**
+ * Total number of GitHub accounts ever evaluated (for the homepage's
+ * "N developers" counter). This is an all-time adoption metric, unlike public
+ * ranking reads, so it must include accounts retained from prior releases.
+ */
 export async function getScoreCount(): Promise<number | null> {
   const db = getClient();
   if (!db) return null;
   try {
     await ensureSchema(db);
-    const res = await db.execute(
-      `SELECT COUNT(*) AS n FROM scores WHERE ${canonicalPublicScorePredicate("scores")}`,
-    );
+    const res = await db.execute("SELECT COUNT(*) AS n FROM scores");
     return Number(res.rows[0]?.n ?? 0);
   } catch (e) {
     console.error("getScoreCount failed:", e);


### PR DESCRIPTION
## Summary
- Restore the homepage developer counter to the all-time evaluated-account total.
- Keep public leaderboard reads scoped to the current score version.
- Add regression coverage for prior-version accounts.

## Verification
- pnpm test
- pnpm typecheck
- pnpm lint
- Local E2E with current, legacy, hidden, and rescanned accounts