### PR TITLE
chore(codeowners): own main with all three core maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,14 @@
-# Code owners for github-roast.
+# Code owners for ghfind.
 #
-# Every pull request targeting a protected branch (main) requires review from
-# the owner(s) listed here, because the branch ruleset enables
-# "Require review from Code Owners". This enforces "only I decide what lands on
-# main" while collaborators work on feature branches + PRs.
+# Every pull request targeting a protected branch (main) requires an approval
+# from one of the owners listed here, because the branch ruleset enables
+# "Require review from Code Owners" with 1 required approval.
+#
+# GitHub never counts a pull request author's own approval, so listing all
+# three core maintainers means every PR has to be cross-reviewed by one of the
+# other two: whoever opens it cannot be the one who unblocks it.
 #
 # Syntax: <path pattern>  <@owner ...>   (last matching line wins)
 
-# Default: the whole repository is owned by @hikariming.
-*       @hikariming
+# Default: the whole repository is owned by the three core maintainers.
+*       @hikariming @KurosawaGeeker @AsperforMias


### PR DESCRIPTION
## What

`.github/CODEOWNERS` listed only `@hikariming` as the owner of `*`. Combined with the `Protect main` ruleset's **Require review from Code Owners**, that meant every PR — including ones the other two maintainers opened and could have reviewed for each other — was blocked until one specific person approved.

This lists all three core maintainers as owners of the repository.

## Why this gives us cross-review

GitHub never counts a pull request author's own approval, and a code owner cannot satisfy the code-owner requirement on their own PR. So with `* @hikariming @KurosawaGeeker @AsperforMias` and `required_approving_review_count: 1`, whoever opens a PR must get an approval from one of the other two before it can land.

Paired with a ruleset change (applied separately): admin bypass tightened from `always` to `pull_request`, and `require_last_push_approval` turned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)