### PR TITLE
Revert "fix(comments): store original text, mask sensitive words only on read"

### DIFF
--- a/src/lib/__tests__/comments.test.ts
+++ b/src/lib/__tests__/comments.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { maskSensitiveCommentText, normalizeCommentText } from "@/lib/comments";
+
+describe("comment sensitive-word masking", () => {
+  it("replaces every configured keyword with same-width asterisks", () => {
+    expect(
+      maskSensitiveCommentText("习近平 毛泽东 习大大 大大 八九六四 六四 天安门 8964 64 中国 共产党 党 人民"),
+    ).toBe("*** *** *** ** **** ** *** **** ** ** *** * **");
+  });
+
+  it("masks text as part of comment normalization before persistence", () => {
+    expect(normalizeCommentText("  我来自中国共产党，编号是8964。  ")).toBe(
+      "我来自*****，编号是****。",
+    );
+  });
+
+  it("keeps non-sensitive text unchanged", () => {
+    expect(normalizeCommentText("开源项目写得不错 🔥")).toBe("开源项目写得不错 🔥");
+  });
+});

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -2073,7 +2073,6 @@ describe("profile comments", () => {
       { author: { type: "github", username: "yyx990803" }, text: "Legend status" },
     ]);
   });
-
 });
 
 describe("blog comments", () => {
@@ -2114,7 +2113,6 @@ describe("blog comments", () => {
       { author: { type: "github", username: "yyx990803" }, text: "Great breakdown" },
     ]);
   });
-
 });
 
 describe("profile reactions", () => {

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -81,10 +81,9 @@ export function maskSensitiveCommentText(text: string): string {
   return text.replace(SENSITIVE_COMMENT_PATTERN, (match) => "*".repeat(Array.from(match).length));
 }
 
-/** Persistence keeps the original text; sensitive words are masked only when comments are read. */
 export function normalizeCommentText(input: unknown): string | null {
   if (typeof input !== "string") return null;
   const compact = input.replace(/\s+/g, " ").trim();
   const text = Array.from(compact).slice(0, COMMENT_MAX_LENGTH).join("");
-  return text.length > 0 ? text : null;
+  return text.length > 0 ? maskSensitiveCommentText(text) : null;
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -6372,7 +6372,7 @@ export async function createProfileComment(
       author: githubAuthor
         ? { type: "github", username: githubAuthor, avatarUrl: authorAvatarUrl }
         : { type: "anonymous" },
-      text: maskSensitiveCommentText(text),
+      text,
       createdAt: now,
     };
   } catch (e) {
@@ -6482,7 +6482,7 @@ export async function createBlogComment(
       author: githubAuthor
         ? { type: "github", username: githubAuthor, avatarUrl: authorAvatarUrl }
         : { type: "anonymous" },
-      text: maskSensitiveCommentText(text),
+      text,
       createdAt: now,
     };
   } catch (e) {


### PR DESCRIPTION
## Summary
Reverts #166. Comment text is masked at write time again (pre-#166 behavior from #165), and the masking test file is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)