### PR TITLE
fix(collections): refine homepage recommendation identity

### DIFF
--- a/content/collections/lofisu/meta.json
+++ b/content/collections/lofisu/meta.json
@@ -13,7 +13,7 @@
   "subject": {
     "kind": "developer",
     "id": "LofiSu",
-    "name": "阿酥在coding (LofiSu)",
+    "nickname": "阿酥在coding (LofiSu)",
     "headline": {
       "zh": "Apache Fory Committer · DeerFlow 贡献者 · ghfind 评分 49.9（NPC）",
       "en": "Apache Fory committer · DeerFlow contributor · ghfind score 49.9 (NPC)"

--- a/content/collections/yuxuan-zhang/meta.json
+++ b/content/collections/yuxuan-zhang/meta.json
@@ -13,7 +13,7 @@
   "subject": {
     "kind": "developer",
     "id": "zRzRzRzRzRzRzR",
-    "name": "张昱轩 (Yuxuan Zhang)",
+    "nickname": "张昱轩",
     "headline": {
       "zh": "智谱AI 算法工程师 · GLM-5 / Open-AutoGLM / CogVideoX 核心贡献者",
       "en": "Algorithm engineer at Z.ai · core contributor to GLM-5, Open-AutoGLM and CogVideoX"

--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -82,7 +82,7 @@ async function SubjectCard({
           />
           <div className="min-w-0">
             <div className="break-all text-lg font-black text-zinc-100">
-              {subject.name ?? (isRepo ? subject.id : `@${subject.id}`)}
+              {subject.nickname ?? (isRepo ? subject.id : `@${subject.id}`)}
             </div>
             <div className="text-xs text-zinc-500">
               {isRepo ? subject.id : `@${subject.id}`}
@@ -151,7 +151,7 @@ export default async function CollectionPage({
             description: pickText(collection.intro, locale),
             datePublished: collection.publishedAt,
             subject: {
-              name: featureSubject.name ?? featureSubject.id,
+              name: featureSubject.nickname ?? featureSubject.id,
               githubUrl: `https://github.com/${featureSubject.id}`,
               profilePath: localePath(locale, `/u/${featureSubject.id}`),
             },

--- a/src/components/CollectionPromoCard.tsx
+++ b/src/components/CollectionPromoCard.tsx
@@ -34,27 +34,20 @@ export function CollectionPromoCard({
 
   return (
     <article className="group relative flex flex-col rounded-2xl border border-white/10 bg-white/[0.035] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.055]">
-      <Link
-        href={`/collections/${slug}`}
-        prefetch={false}
-        onClick={() => trackEvent("home_collections_click", { slug, position })}
-        aria-label={title}
-        className="absolute inset-0 rounded-2xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-300"
-      />
       {(avatarUrl || identityName) && (
-        <div className="relative z-10 flex min-w-0 items-center gap-3">
-        <span className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-orange-500/10 text-sm font-bold text-orange-300 ring-2 ring-orange-400/40">
-          <span aria-hidden="true">{avatarInitial}</span>
-          {avatarUrl && !avatarFailed && (
-            // eslint-disable-next-line @next/next/no-img-element -- GitHub avatar; the image optimizer would just add Vercel cost
-            <img
-              src={avatarUrl}
-              alt={`${githubUsername ?? identityName ?? "GitHub"} avatar`}
-              loading="lazy"
-              onError={() => setAvatarFailed(true)}
-              className="absolute inset-0 h-full w-full rounded-full bg-transparent"
-            />
-          )}
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-orange-500/10 text-sm font-bold text-orange-300 ring-2 ring-orange-400/40">
+            <span aria-hidden="true">{avatarInitial}</span>
+            {avatarUrl && !avatarFailed && (
+              // eslint-disable-next-line @next/next/no-img-element -- GitHub avatar; the image optimizer would just add Vercel cost
+              <img
+                src={avatarUrl}
+                alt={`${githubUsername ?? identityName ?? "GitHub"} avatar`}
+                loading="lazy"
+                onError={() => setAvatarFailed(true)}
+                className="absolute inset-0 h-full w-full rounded-full bg-transparent"
+              />
+            )}
           </span>
           {githubUsername ? (
             <a
@@ -75,13 +68,18 @@ export function CollectionPromoCard({
           )}
         </div>
       )}
-      <h3 className="pointer-events-none relative z-10 mt-3 line-clamp-2 text-lg font-bold text-zinc-100 group-hover:text-white">
-        {title}
+      <h3 className="mt-3 line-clamp-2 text-lg font-bold text-zinc-100">
+        <Link
+          href={`/collections/${slug}`}
+          prefetch={false}
+          onClick={() => trackEvent("home_collections_click", { slug, position })}
+          className="rounded-sm outline-offset-4 transition-colors hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-300"
+        >
+          {title}
+        </Link>
       </h3>
-      <p className="pointer-events-none relative z-10 mt-2 line-clamp-2 text-sm leading-relaxed text-zinc-400">
-        {intro}
-      </p>
-      <div className="pointer-events-none relative z-10 mt-auto flex items-center justify-between gap-3 pt-4 text-xs text-zinc-500">
+      <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-zinc-400">{intro}</p>
+      <div className="mt-auto flex items-center justify-between gap-3 pt-4 text-xs text-zinc-500">
         <span>{metaLine}</span>
         <span className="shrink-0 rounded-full bg-orange-500/10 px-2.5 py-1 font-semibold text-orange-200">
           {typeLabel}

--- a/src/components/CollectionPromoCard.tsx
+++ b/src/components/CollectionPromoCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Link } from "@/i18n/navigation";
 import { trackEvent } from "@/lib/track";
 
@@ -13,6 +14,8 @@ export function CollectionPromoCard({
   title,
   intro,
   typeLabel,
+  githubUsername,
+  identityName,
   avatarUrl,
   metaLine,
 }: {
@@ -21,35 +24,69 @@ export function CollectionPromoCard({
   title: string;
   intro: string;
   typeLabel: string;
+  githubUsername: string | null;
+  identityName?: string;
   avatarUrl: string | null;
   metaLine: string;
 }) {
+  const [avatarFailed, setAvatarFailed] = useState(false);
+  const avatarInitial = (githubUsername ?? identityName ?? "?").trim().slice(0, 1);
+
   return (
-    <Link
-      href={`/collections/${slug}`}
-      prefetch={false}
-      onClick={() => trackEvent("home_collections_click", { slug, position })}
-      className="group flex flex-col rounded-2xl border border-white/10 bg-white/[0.035] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.055]"
-    >
-      <div className="flex items-center gap-3">
-        {avatarUrl && (
-          // eslint-disable-next-line @next/next/no-img-element -- GitHub avatar; the image optimizer would just add Vercel cost
-          <img
-            src={avatarUrl}
-            alt=""
-            loading="lazy"
-            className="h-10 w-10 shrink-0 rounded-full ring-2 ring-orange-400/40"
-          />
-        )}
-        <span className="rounded-full bg-orange-500/10 px-2.5 py-1 text-xs font-semibold text-orange-200">
+    <article className="group relative flex flex-col rounded-2xl border border-white/10 bg-white/[0.035] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.055]">
+      <Link
+        href={`/collections/${slug}`}
+        prefetch={false}
+        onClick={() => trackEvent("home_collections_click", { slug, position })}
+        aria-label={title}
+        className="absolute inset-0 rounded-2xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-300"
+      />
+      {(avatarUrl || identityName) && (
+        <div className="relative z-10 flex min-w-0 items-center gap-3">
+        <span className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-orange-500/10 text-sm font-bold text-orange-300 ring-2 ring-orange-400/40">
+          <span aria-hidden="true">{avatarInitial}</span>
+          {avatarUrl && !avatarFailed && (
+            // eslint-disable-next-line @next/next/no-img-element -- GitHub avatar; the image optimizer would just add Vercel cost
+            <img
+              src={avatarUrl}
+              alt={`${githubUsername ?? identityName ?? "GitHub"} avatar`}
+              loading="lazy"
+              onError={() => setAvatarFailed(true)}
+              className="absolute inset-0 h-full w-full rounded-full bg-transparent"
+            />
+          )}
+          </span>
+          {githubUsername ? (
+            <a
+              href={`https://github.com/${githubUsername}`}
+              target="_blank"
+              rel="noreferrer"
+              className="min-w-0 truncate text-sm font-semibold text-zinc-100 underline-offset-4 hover:text-white hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-300"
+            >
+              <span>{githubUsername}</span>
+              {identityName && identityName !== githubUsername && (
+                <span className="font-normal text-zinc-400"> · {identityName}</span>
+              )}
+            </a>
+          ) : (
+            <span className="min-w-0 truncate text-sm font-semibold text-zinc-100">
+              {identityName}
+            </span>
+          )}
+        </div>
+      )}
+      <h3 className="pointer-events-none relative z-10 mt-3 line-clamp-2 text-lg font-bold text-zinc-100 group-hover:text-white">
+        {title}
+      </h3>
+      <p className="pointer-events-none relative z-10 mt-2 line-clamp-2 text-sm leading-relaxed text-zinc-400">
+        {intro}
+      </p>
+      <div className="pointer-events-none relative z-10 mt-auto flex items-center justify-between gap-3 pt-4 text-xs text-zinc-500">
+        <span>{metaLine}</span>
+        <span className="shrink-0 rounded-full bg-orange-500/10 px-2.5 py-1 font-semibold text-orange-200">
           {typeLabel}
         </span>
       </div>
-      <h3 className="mt-3 line-clamp-2 text-lg font-bold text-zinc-100 group-hover:text-white">
-        {title}
-      </h3>
-      <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-zinc-400">{intro}</p>
-      <div className="mt-auto pt-4 text-xs text-zinc-500">{metaLine}</div>
-    </Link>
+    </article>
   );
 }

--- a/src/components/HomeCollections.tsx
+++ b/src/components/HomeCollections.tsx
@@ -1,14 +1,19 @@
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { CollectionPromoCard } from "@/components/CollectionPromoCard";
-import { getCollectionArticle, listCollections, pickText } from "@/lib/collections";
+import {
+  getCollectionArticle,
+  getGitHubNickname,
+  listCollections,
+  pickText,
+} from "@/lib/collections";
 import { bcp47 } from "@/lib/site";
 
 /**
  * Homepage "site-owner picks" band — sits between the scan form and the
  * leaderboard (the slot the continue-exploring strip used to hold). Fully
- * static: collections are fs reads inside the force-static homepage shell, so
- * the editorial surface gets homepage distribution at zero runtime cost.
+ * static: collection content is read from fs; only subjects without an
+ * editorial nickname use GitHub's cached public profile-name fallback.
  */
 export async function HomeCollections({ locale }: { locale: string }) {
   const collections = listCollections().slice(0, 3);
@@ -16,10 +21,20 @@ export async function HomeCollections({ locale }: { locale: string }) {
   const t = await getTranslations("collections");
   const tBlog = await getTranslations("blog");
   const dateFmt = new Intl.DateTimeFormat(bcp47(locale), {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
+    year: "2-digit",
+    month: "numeric",
+    day: "2-digit",
   });
+  const cards = await Promise.all(
+    collections.map(async (collection, index) => {
+      const githubUsername =
+        collection.subject?.kind === "developer" ? collection.subject.id : null;
+      const identityName =
+        collection.subject?.nickname ??
+        (githubUsername ? await getGitHubNickname(githubUsername) : null);
+      return { collection, index, githubUsername, identityName };
+    }),
+  );
 
   return (
     <section className="w-full">
@@ -36,7 +51,7 @@ export async function HomeCollections({ locale }: { locale: string }) {
         </Link>
       </div>
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {collections.map((collection, i) => {
+        {cards.map(({ collection, index, githubUsername, identityName }) => {
           const article =
             collection.bodyLocales.length > 0
               ? getCollectionArticle(collection.slug, locale)
@@ -46,14 +61,20 @@ export async function HomeCollections({ locale }: { locale: string }) {
               ? collection.subject.id.split("/")[0]
               : collection.subject.id
             : null;
+          const title = pickText(collection.title, locale);
+          const titleParts = title.match(/^([^:：]+)\s*[:：]\s*(.+)$/);
+          const displayName =
+            identityName ?? (!collection.subject ? titleParts?.[1] : null);
           return (
             <CollectionPromoCard
               key={collection.slug}
               slug={collection.slug}
-              position={i + 1}
-              title={pickText(collection.title, locale)}
+              position={index + 1}
+              title={displayName ? (titleParts?.[2] ?? title) : title}
               intro={pickText(collection.intro, locale)}
               typeLabel={t(`type.${collection.type}`)}
+              githubUsername={githubUsername}
+              identityName={displayName ?? undefined}
               avatarUrl={
                 avatarOwner ? `https://github.com/${avatarOwner}.png?size=112` : null
               }

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -48,8 +48,8 @@ export type CollectionSubject = {
   kind: "developer" | "repo";
   /** GitHub username or "owner/name". */
   id: string;
-  /** Display name, e.g. "张昱轩 (Yuxuan Zhang)". */
-  name?: string;
+  /** PR-editable display-name override, e.g. "张昱轩 (Yuxuan Zhang)". */
+  nickname?: string;
   headline?: LocalizedText;
 };
 
@@ -135,6 +135,33 @@ export function listCollections(): Collection[] {
 /** Editorial copy ships zh + en; zh readers get zh, everyone else gets en. */
 export function pickText(text: LocalizedText, locale: string): string {
   return locale === "zh" ? text.zh || text.en : text.en;
+}
+
+/**
+ * Public GitHub profile name used only when editorial metadata has no nickname.
+ * The result is revalidated daily, while a PR-supplied `subject.nickname` stays
+ * authoritative and avoids this request entirely.
+ */
+export async function getGitHubNickname(username: string): Promise<string | null> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/users/${encodeURIComponent(username)}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "User-Agent": "ghfind",
+        },
+        next: { revalidate: 86_400 },
+      },
+    );
+    if (!response.ok) return null;
+    const profile = (await response.json()) as { name?: unknown };
+    return typeof profile.name === "string" && profile.name.trim()
+      ? profile.name.trim()
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function collectionPath(locale: string, slug: string): string {


### PR DESCRIPTION
## Summary

- 将固定的集合类型标签移到首页推荐卡片底部。
- GitHub 账号优先展示，昵称支持通过 PR 编辑覆盖；未覆盖时回退到 GitHub 公开资料昵称。
- 保持卡片详情入口与 GitHub 主页外链分离，并为头像增加首字符降级。
- 使用紧凑的、按 locale 格式化的数值日期。

## Validation

- `pnpm typecheck`
- `pnpm lint`（0 errors；保留 `src/components/LiveRoast.tsx` 的既有 warning）
- `pnpm test`（71 files，549 tests）
- 本地首页 `http://127.0.0.1:3003/` 返回 HTTP 200

不包含生成文件或数据库 baseline 更新。