### PR TITLE
feat(collections): add comment barrage

### DIFF
--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   collectionFeatureJsonLd,
   curatedCollectionJsonLd,
 } from "@/components/JsonLd";
+import { CollectionCommentBubbles } from "@/components/CollectionCommentBubbles";
 import { PostBody } from "@/components/blog/PostBody";
 import { CollectionItemCard } from "@/components/collections/CollectionItemCard";
 import {
@@ -141,7 +142,12 @@ export default async function CollectionPage({
       : null;
 
   return (
-    <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-5 py-14 sm:px-6 sm:py-20">
+    <main className="relative isolate flex w-full flex-1 justify-center px-5 py-14 sm:px-6 sm:py-20">
+      <CollectionCommentBubbles
+        lang={locale === "zh" ? "zh" : "en"}
+        collectionSlug={slug}
+      />
+      <div className="relative z-10 flex w-full max-w-3xl flex-col">
       {featureSubject && article ? (
         <JsonLd
           data={collectionFeatureJsonLd({
@@ -263,6 +269,7 @@ export default async function CollectionPage({
           </p>
         </>
       )}
+      </div>
     </main>
   );
 }

--- a/src/app/api/collection-comments/[slug]/route.test.ts
+++ b/src/app/api/collection-comments/[slug]/route.test.ts
@@ -1,0 +1,171 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommentAuthor } from "@/lib/comments";
+
+interface CreateCollectionCommentInput {
+  collectionSlug: string;
+  text: string;
+  author: CommentAuthor;
+  authorGithubId?: number;
+}
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  authConfigured: vi.fn(() => true),
+  createCollectionComment: vi.fn(),
+  getCollectionComments: vi.fn(),
+  getCollection: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: mocks.auth,
+  authConfigured: mocks.authConfigured,
+}));
+
+vi.mock("@/lib/collections", () => ({
+  getCollection: mocks.getCollection,
+}));
+
+vi.mock("@/lib/db", () => ({
+  createCollectionComment: mocks.createCollectionComment,
+  getCollectionComments: mocks.getCollectionComments,
+}));
+
+import { GET, POST } from "./route";
+
+const context = { params: Promise.resolve({ slug: "lofisu" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.authConfigured.mockReturnValue(true);
+  mocks.auth.mockResolvedValue({
+    user: {
+      githubId: 42,
+      image: "https://avatars.githubusercontent.com/u/42",
+      login: "Commenter",
+    },
+  });
+  mocks.getCollection.mockReturnValue({ slug: "lofisu" });
+  mocks.getCollectionComments.mockResolvedValue([]);
+  mocks.createCollectionComment.mockImplementation(
+    async (input: CreateCollectionCommentInput) => ({
+      id: "comment-1",
+      collectionSlug: input.collectionSlug,
+      author: input.author,
+      text: input.text,
+      createdAt: 1_700_000_000_000,
+    }),
+  );
+});
+
+describe("collection comments API", () => {
+  it("returns the latest visible comments for an existing collection", async () => {
+    mocks.getCollectionComments.mockResolvedValue([
+      {
+        id: "comment-1",
+        collectionSlug: "lofisu",
+        author: { type: "anonymous" },
+        text: "围观",
+        createdAt: 1_700_000_000_000,
+      },
+    ]);
+
+    const response = await GET(
+      new NextRequest("https://example.test/api/collection-comments/lofisu"),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      comments: [
+        expect.objectContaining({ text: "围观", author: { type: "anonymous" } }),
+      ],
+    });
+    expect(mocks.getCollectionComments).toHaveBeenCalledWith("lofisu");
+  });
+
+  it("stores non-anonymous comments with the viewer GitHub identity", async () => {
+    const response = await POST(
+      new NextRequest("https://example.test/api/collection-comments/lofisu", {
+        method: "POST",
+        body: JSON.stringify({ text: "这个合集很有帮助" }),
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.createCollectionComment).toHaveBeenCalledWith({
+      collectionSlug: "lofisu",
+      text: "这个合集很有帮助",
+      author: {
+        type: "github",
+        username: "commenter",
+        avatarUrl: "https://avatars.githubusercontent.com/u/42",
+      },
+      authorGithubId: 42,
+    });
+  });
+
+  it("allows anonymous comments without attempting GitHub authentication", async () => {
+    const response = await POST(
+      new NextRequest("https://example.test/api/collection-comments/lofisu", {
+        method: "POST",
+        body: JSON.stringify({ anonymous: true, text: "匿名围观" }),
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.auth).not.toHaveBeenCalled();
+    expect(mocks.createCollectionComment).toHaveBeenCalledWith({
+      collectionSlug: "lofisu",
+      text: "匿名围观",
+      author: { type: "anonymous" },
+      authorGithubId: undefined,
+    });
+  });
+
+  it("does not silently downgrade an unsigned comment to anonymous", async () => {
+    mocks.auth.mockResolvedValue(null);
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/collection-comments/lofisu", {
+        method: "POST",
+        body: JSON.stringify({ anonymous: false, text: "我要署名" }),
+      }),
+      context,
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "authentication_required" });
+    expect(mocks.createCollectionComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects comments for a collection that does not exist", async () => {
+    mocks.getCollection.mockReturnValue(null);
+    const missingCollectionContext = { params: Promise.resolve({ slug: "missing-collection" }) };
+
+    const response = await POST(
+      new NextRequest("https://example.test/api/collection-comments/missing-collection", {
+        method: "POST",
+        body: JSON.stringify({ anonymous: true, text: "不应保存" }),
+      }),
+      missingCollectionContext,
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.createCollectionComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed encoded collection slug", async () => {
+    const malformedContext = { params: Promise.resolve({ slug: "%" }) };
+
+    const response = await GET(
+      new NextRequest("https://example.test/api/collection-comments/%"),
+      malformedContext,
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.getCollectionComments).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/collection-comments/[slug]/route.ts
+++ b/src/app/api/collection-comments/[slug]/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, authConfigured } from "@/lib/auth";
+import {
+  normalizeBlogSlug,
+  normalizeCommentText,
+  normalizeGitHubUsername,
+  type CollectionCommentsResponse,
+  type CommentAuthor,
+  type CreateCollectionCommentResponse,
+} from "@/lib/comments";
+import { getCollection } from "@/lib/collections";
+import { createCollectionComment, getCollectionComments } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
+
+interface CreateCollectionCommentBody {
+  text?: unknown;
+  anonymous?: unknown;
+}
+
+function jsonNoStore(body: unknown, init?: ResponseInit) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { ...NO_STORE_HEADERS, ...init?.headers },
+  });
+}
+
+function collectionSlugFromParam(value: string | undefined): string | null {
+  try {
+    const slug = normalizeBlogSlug(decodeURIComponent(value ?? ""));
+    return slug && getCollection(slug) ? slug : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug: rawSlug } = await ctx.params;
+  const collectionSlug = collectionSlugFromParam(rawSlug);
+  if (!collectionSlug) {
+    return jsonNoStore({ error: "invalid_collection" }, { status: 404 });
+  }
+
+  const comments = await getCollectionComments(collectionSlug);
+  return jsonNoStore({ comments } satisfies CollectionCommentsResponse);
+}
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  const { slug: rawSlug } = await ctx.params;
+  const collectionSlug = collectionSlugFromParam(rawSlug);
+  if (!collectionSlug) {
+    return jsonNoStore({ error: "invalid_collection" }, { status: 404 });
+  }
+
+  let body: CreateCollectionCommentBody;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonNoStore({ error: "invalid_body" }, { status: 400 });
+  }
+
+  const text = normalizeCommentText(body.text);
+  if (!text) return jsonNoStore({ error: "empty_comment" }, { status: 400 });
+
+  const anonymous = body.anonymous === true;
+  let author: CommentAuthor;
+  let authorGithubId: number | undefined;
+  if (anonymous) {
+    author = { type: "anonymous" };
+  } else {
+    const session = authConfigured() ? await auth() : null;
+    const viewerUsername = normalizeGitHubUsername(session?.user.login ?? "");
+    if (!viewerUsername) {
+      return jsonNoStore({ error: "authentication_required" }, { status: 401 });
+    }
+
+    author = {
+      type: "github",
+      username: viewerUsername,
+      avatarUrl: session?.user.image ?? null,
+    };
+    authorGithubId = session?.user.githubId;
+  }
+
+  const comment = await createCollectionComment({
+    collectionSlug,
+    text,
+    author,
+    authorGithubId,
+  });
+  if (!comment) {
+    return jsonNoStore({ error: "comments_unavailable" }, { status: 503 });
+  }
+
+  return jsonNoStore(
+    { comment } satisfies CreateCollectionCommentResponse,
+    { status: 201 },
+  );
+}

--- a/src/components/CollectionCommentBubbles.tsx
+++ b/src/components/CollectionCommentBubbles.tsx
@@ -1,0 +1,18 @@
+import { CommentBubbles } from "@/components/CommentBubbles";
+
+export function CollectionCommentBubbles({
+  lang,
+  collectionSlug,
+}: {
+  lang: "zh" | "en";
+  collectionSlug: string;
+}) {
+  return (
+    <CommentBubbles
+      commentsEndpoint={`/api/collection-comments/${encodeURIComponent(collectionSlug)}`}
+      contentHalfWidth="24rem"
+      lang={lang}
+      loadOnMount
+    />
+  );
+}

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -2115,6 +2115,47 @@ describe("blog comments", () => {
   });
 });
 
+describe("collection comments", () => {
+  it("uses a collection namespace without mixing in article comments", async () => {
+    const anonymous = await db.createCollectionComment({
+      collectionSlug: "lofisu",
+      text: "硬核 🔥",
+      author: { type: "anonymous" },
+    });
+    const github = await db.createCollectionComment({
+      collectionSlug: "LOFISU",
+      text: "Great collection",
+      author: {
+        type: "github",
+        username: "yyx990803",
+        avatarUrl: "https://avatars.githubusercontent.com/u/499550",
+      },
+      authorGithubId: 499550,
+    });
+
+    expect(anonymous).toMatchObject({
+      collectionSlug: "lofisu",
+      author: { type: "anonymous" },
+      text: "硬核 🔥",
+    });
+    expect(github).toMatchObject({
+      collectionSlug: "lofisu",
+      author: {
+        type: "github",
+        username: "yyx990803",
+        avatarUrl: "https://avatars.githubusercontent.com/u/499550",
+      },
+      text: "Great collection",
+    });
+
+    await expect(db.getCollectionComments("LOFISU")).resolves.toMatchObject([
+      { author: { type: "anonymous" }, text: "硬核 🔥" },
+      { author: { type: "github", username: "yyx990803" }, text: "Great collection" },
+    ]);
+    await expect(db.getBlogComments("lofisu")).resolves.toEqual([]);
+  });
+});
+
 describe("profile reactions", () => {
   it("stores one durable reaction per GitHub user and target profile", async () => {
     await db.setProfileReaction({

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -61,6 +61,22 @@ export interface CreateBlogCommentResponse {
   comment: BlogComment;
 }
 
+export interface CollectionComment {
+  id: string;
+  collectionSlug: string;
+  author: CommentAuthor;
+  text: string;
+  createdAt: number;
+}
+
+export interface CollectionCommentsResponse {
+  comments: CollectionComment[];
+}
+
+export interface CreateCollectionCommentResponse {
+  comment: CollectionComment;
+}
+
 export function normalizeGitHubUsername(input: string): string | null {
   let value = input.trim();
   const profileUrl = value.match(/github\.com\/([^/?#]+)/i);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -24,6 +24,7 @@ import {
   maskSensitiveCommentText,
   type BlogComment,
   type CommentAuthor,
+  type CollectionComment,
   type ProfileComment,
   type ProfileCommentAuthor,
 } from "./comments";
@@ -6388,6 +6389,17 @@ interface CreateBlogCommentInput {
   authorGithubId?: number;
 }
 
+interface CreateCollectionCommentInput {
+  collectionSlug: string;
+  text: string;
+  author: CommentAuthor;
+  authorGithubId?: number;
+}
+
+function collectionCommentKey(slug: string): string {
+  return `collection:${slug}`;
+}
+
 function toBlogComment(row: Record<string, unknown>): BlogComment {
   const authorLogin =
     typeof row.author_login === "string" && row.author_login
@@ -6487,6 +6499,99 @@ export async function createBlogComment(
     };
   } catch (e) {
     console.error("createBlogComment failed:", e);
+    return null;
+  }
+}
+
+export async function getCollectionComments(
+  collectionSlug: string,
+  limit = 24,
+): Promise<CollectionComment[]> {
+  const db = getClient();
+  if (!db) return [];
+  const slug = normalizeBlogSlug(collectionSlug);
+  if (!slug) return [];
+
+  try {
+    await ensureSchema(db);
+    const res = await db.execute({
+      sql: `SELECT id, post_slug, body, author_kind, author_login,
+                   author_avatar_url, created_at
+            FROM (
+              SELECT rowid AS sort_rowid, id, post_slug, body, author_kind,
+                     author_login, author_avatar_url, created_at
+              FROM blog_comments
+              WHERE post_slug = ? AND hidden = 0
+              ORDER BY created_at DESC, rowid DESC
+              LIMIT ?
+            )
+            ORDER BY created_at ASC, sort_rowid ASC`,
+      args: [collectionCommentKey(slug), Math.max(1, Math.min(100, limit))],
+    });
+    return res.rows.map((row) => {
+      const comment = toBlogComment(row as Record<string, unknown>);
+      return {
+        id: comment.id,
+        collectionSlug: slug,
+        author: comment.author,
+        text: comment.text,
+        createdAt: comment.createdAt,
+      };
+    });
+  } catch (e) {
+    console.error("getCollectionComments failed:", e);
+    return [];
+  }
+}
+
+export async function createCollectionComment(
+  input: CreateCollectionCommentInput,
+): Promise<CollectionComment | null> {
+  const db = getClient();
+  if (!db) return null;
+  const slug = normalizeBlogSlug(input.collectionSlug);
+  const text = normalizeCommentText(input.text);
+  if (!slug || !text) return null;
+
+  const githubAuthor =
+    input.author.type === "github"
+      ? normalizeGitHubUsername(input.author.username)
+      : null;
+  const authorKind = githubAuthor ? "github" : "anonymous";
+  const authorAvatarUrl =
+    input.author.type === "github" ? input.author.avatarUrl ?? null : null;
+  const now = Date.now();
+  const id = randomUUID();
+
+  try {
+    await ensureSchema(db);
+    await db.execute({
+      sql: `INSERT INTO blog_comments
+              (id, post_slug, body, author_kind, author_github_id,
+               author_login, author_avatar_url, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        id,
+        collectionCommentKey(slug),
+        text,
+        authorKind,
+        authorKind === "github" ? input.authorGithubId ?? null : null,
+        githubAuthor,
+        authorKind === "github" ? authorAvatarUrl : null,
+        now,
+      ],
+    });
+    return {
+      id,
+      collectionSlug: slug,
+      author: githubAuthor
+        ? { type: "github", username: githubAuthor, avatarUrl: authorAvatarUrl }
+        : { type: "anonymous" },
+      text,
+      createdAt: now,
+    };
+  } catch (e) {
+    console.error("createCollectionComment failed:", e);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- enable the existing comment, anonymous-posting, and barrage UI on collection detail pages
- keep collection comments isolated from article comments with a `collection:<slug>` storage key
- reuse existing sensitive-word masking and add API/storage coverage

## Verification
- `pnpm test` (72 files, 558 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- manual desktop/mobile checks in light, dark, and system themes