### PR TITLE
fix(score): preserve bounded PR evidence

### DIFF
--- a/internal/backend/github_collector.go
+++ b/internal/backend/github_collector.go
@@ -62,14 +62,12 @@ func (c *GitHubCollector) Collect(ctx context.Context, username string) (ScanRes
 	workflowLanded, _ := c.github.fetchWorkflowLandedPRs(ctx, login, overview.ClosedPRCount)
 	mergedContribs := []ContribRepoAgg{}
 	mergedAggregationIncomplete := overview.MergedPRCount > 300
-	if !mergedAggregationIncomplete {
-		mergedContribs, err = c.github.fetchMergedPRContribRepos(ctx, login, 300)
-		if errors.Is(err, ErrGitHubResourceLimit) {
-			mergedAggregationIncomplete = true
-			mergedContribs = nil
-		} else if err != nil {
-			return ScanResult{}, err
-		}
+	mergedContribs, err = c.github.fetchMergedPRContribRepos(ctx, login, 300)
+	if errors.Is(err, ErrGitHubResourceLimit) {
+		mergedAggregationIncomplete = true
+		mergedContribs = nil
+	} else if err != nil {
+		return ScanResult{}, err
 	}
 	workflowContribs := make([]ContribRepoAgg, 0, len(workflowLanded))
 	workflowIDs := map[string]bool{}

--- a/internal/backend/github_collector_test.go
+++ b/internal/backend/github_collector_test.go
@@ -33,6 +33,10 @@ func TestGitHubCollectorBuildsGoNativeScanResult(t *testing.T) {
 			_, _ = w.Write([]byte(`{"Go":2000}`))
 			return
 		}
+		if request.URL.Path == "/repos/popular/project/languages" {
+			_, _ = w.Write([]byte(`{"Go":2000}`))
+			return
+		}
 		if request.URL.Path != "/graphql" {
 			t.Errorf("unexpected request %s", request.URL)
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/backend/github_collector_test.go
+++ b/internal/backend/github_collector_test.go
@@ -51,7 +51,7 @@ func TestGitHubCollectorBuildsGoNativeScanResult(t *testing.T) {
 		case strings.Contains(body.Query, "labels(first: 20)"):
 			data = `{"user":{"pullRequests":{"nodes":[]}}}`
 		case strings.Contains(body.Query, "states: MERGED, after"):
-			data = `{"user":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}`
+			data = `{"user":{"pullRequests":{"nodes":[{"repository":{"nameWithOwner":"popular/project","stargazerCount":20000,"isPrivate":false,"isFork":false,"owner":{"login":"popular"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}`
 		case strings.Contains(body.Query, "hasIssuesEnabled"):
 			data = `{"repository":{"stargazerCount":40,"hasIssuesEnabled":true,"isMirror":false,"watchers":{"totalCount":2},"issues":{"totalCount":3},"pullRequests":{"totalCount":4}}}`
 		case strings.Contains(body.Query, "issues(states: OPEN)"):
@@ -61,7 +61,7 @@ func TestGitHubCollectorBuildsGoNativeScanResult(t *testing.T) {
 		case strings.Contains(body.Query, "pullRequests(first: $count, orderBy"):
 			data = `{"user":{"pullRequests":{"nodes":[{"title":"fix worker","repository":{"nameWithOwner":"upstream/framework"}}]}}}`
 		case strings.Contains(body.Query, "totalCommitContributions"):
-			data = `{"user":{"pinnedItems":{"nodes":[]},"mergedPRs":{"totalCount":1},"allPRs":{"totalCount":1},"closedPRs":{"totalCount":0,"nodes":[]},"issues":{"totalCount":2},"contributionYears":{"contributionYears":[2025]},"contributionsCollection":{"totalCommitContributions":1,"totalPullRequestContributions":1,"totalIssueContributions":1,"totalPullRequestReviewContributions":0,"contributionCalendar":{"totalContributions":50}}}}`
+			data = `{"user":{"pinnedItems":{"nodes":[]},"mergedPRs":{"totalCount":480},"allPRs":{"totalCount":480},"closedPRs":{"totalCount":0,"nodes":[]},"issues":{"totalCount":2},"contributionYears":{"contributionYears":[2025]},"contributionsCollection":{"totalCommitContributions":1,"totalPullRequestContributions":1,"totalIssueContributions":1,"totalPullRequestReviewContributions":0,"contributionCalendar":{"totalContributions":50}}}}`
 		default:
 			t.Errorf("unhandled GraphQL query: %s", body.Query)
 			data = `{}`
@@ -75,8 +75,11 @@ func TestGitHubCollectorBuildsGoNativeScanResult(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scan.Metrics.Username != "alice" || scan.Metrics.MergedPRCount != 1 || scan.Metrics.RecentMergedPRSample != 1 || scan.Metrics.DaysSinceLastActivity == nil || *scan.Metrics.DaysSinceLastActivity != 2 {
+	if scan.Metrics.Username != "alice" || scan.Metrics.MergedPRCount != 480 || scan.Metrics.RecentMergedPRSample != 1 || scan.Metrics.DaysSinceLastActivity == nil || *scan.Metrics.DaysSinceLastActivity != 2 {
 		t.Fatalf("unexpected metrics: %#v", scan.Metrics)
+	}
+	if !scan.Metrics.MergedPRContributionAggregationIncomplete || scan.Metrics.ImpactPRCount != 1 {
+		t.Fatalf("bounded merged-PR evidence was not preserved: %#v", scan.Metrics)
 	}
 	if len(scan.TopRepos) != 1 || scan.TopRepos[0].Readme == nil || scan.Scoring.FinalScore <= 0 || scan.Scoring.FinalScore != Score(scan.Metrics).FinalScore {
 		t.Fatalf("scan is not a Go-native deterministic result: %#v", scan)


### PR DESCRIPTION
## Description

Accounts with ≤300 PRs currently aggregate up to 300, but one with 301 PRs skips aggregation and turns ecosystem evidence into zero. This can abruptly lower an account's score with just few new PRs.

Proposed solution to make the scoring more fair:

- not only run the bounded 300 aggregation for small accounts, but for large accounts too
- the scan remains bounded with no background job or unbounded history fetch as mentioned in #142.

## Validation

- `go test ./...`
