### PR TITLE
fix(home): render Go-backed homepage sections + horizontal project strip

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,9 +13,9 @@ import type { TierKey } from "@/lib/tier";
 
 // ISR: the homepage shell is fully static (the scan form, tier pills and copy are
 // locale-only; DeveloperCount fetches client-side; the leaderboard rail and
-// projects preview read Redis-cached boards). Serving it from the CDN instead of
-// rendering a function on every visit is what frees the serverless pool for the
-// LLM scan/roast traffic.
+// projects preview read the Go API through ISR-cached fetches). Serving it
+// from the CDN instead of rendering a function on every visit is what frees
+// the serverless pool for the LLM scan/roast traffic.
 // Keep the durable snapshot for an hour: minute-level regeneration only creates
 // repeated ISR writes.
 // Pin the homepage to static + ISR. Next 16's "auto" heuristic otherwise renders

--- a/src/components/HomeProjectsPreview.tsx
+++ b/src/components/HomeProjectsPreview.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/i18n/navigation";
 import { ProjectCard } from "@/components/ProjectCard";
 import { getGoProjects } from "@/lib/go-projects.server";
 
-const PREVIEW_LIMIT = 4;
+const PREVIEW_LIMIT = 8;
 
 /**
  * 项目推流分析 slot — this section is reserved for the upcoming personalized
@@ -11,16 +11,30 @@ const PREVIEW_LIMIT = 4;
  * /projects data (momentum sort, so the cards rotate as attention shifts),
  * which means the layout, the Redis cache path and the click tracking are
  * already real when the feed lands here.
+ *
+ * Rendered as a horizontal snap-scroll strip so the band fills the width of
+ * the main column without stacking empty vertical space; falls back to the
+ * quality board when momentum has no ranked repos yet.
  */
 export async function HomeProjectsPreview() {
   const t = await getTranslations("projects");
   const tCollections = await getTranslations("collections");
-  const projects = await getGoProjects({
+  let projects = await getGoProjects({
     sort: "momentum",
     language: null,
     limit: PREVIEW_LIMIT,
     offset: 0,
+    revalidate: 3600,
   });
+  if (projects.length === 0) {
+    projects = await getGoProjects({
+      sort: "quality",
+      language: null,
+      limit: PREVIEW_LIMIT,
+      offset: 0,
+      revalidate: 3600,
+    });
+  }
   if (projects.length === 0) return null;
 
   return (
@@ -40,13 +54,17 @@ export async function HomeProjectsPreview() {
           {tCollections("viewAll")} →
         </Link>
       </div>
-      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+      <div className="-mx-5 mt-5 flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-2 sm:-mx-6 sm:px-6">
         {projects.map((project, index) => (
-          <ProjectCard
+          <div
             key={project.repo.repo_key}
-            project={project}
-            position={index + 1}
-          />
+            className="flex w-[19rem] shrink-0 snap-start sm:w-[21rem]"
+          >
+            <ProjectCard
+              project={project}
+              position={index + 1}
+            />
+          </div>
         ))}
       </div>
     </section>

--- a/src/components/LeaderboardRail.tsx
+++ b/src/components/LeaderboardRail.tsx
@@ -78,17 +78,18 @@ function RailBoard({
 /**
  * Homepage right-rail leaderboard teaser with view tabs (trending/score/heat —
  * the same boards as /leaderboard). All three boards are server-rendered into
- * the force-static shell from the Redis payloads /leaderboard already caches,
- * so tab switching is purely local: no API call, no function invocation, no DB
- * read per click. Each board ships RAIL_LIMIT rows; the interactive board
- * (time windows, pagination, VS) still lives at /leaderboard.
+ * the force-static shell from the Go API through an ISR-compatible cached
+ * fetch (hourly revalidate, matching the page), so tab switching is purely
+ * local: no API call, no function invocation, no DB read per click. Each
+ * board ships RAIL_LIMIT rows; the interactive board (time windows,
+ * pagination, VS) still lives at /leaderboard.
  */
 export async function LeaderboardRail() {
   const t = await getTranslations("home");
   const tBoard = await getTranslations("leaderboard");
   const boards = await Promise.all(
     RAIL_VIEWS.map(async ({ view, labelKey }) => {
-      const entries = await getGoLeaderboard(view);
+      const entries = await getGoLeaderboard(view, "all", 500, 3600);
       const rows = withDevLeaderboardPreview(view, entries.slice(0, RAIL_LIMIT));
       return { view, label: tBoard(labelKey), rows };
     }),

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -13,7 +13,7 @@ export function ProjectCard({ project, position }: { project: GoProjectListItem;
   const t = useTranslations("projects");
   const model = projectCardViewModel(project);
   return (
-    <article className="rounded-2xl border border-white/10 bg-white/[0.035] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.055]">
+    <article className="h-full w-full rounded-2xl border border-white/10 bg-white/[0.035] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.055]">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <Link

--- a/src/lib/go-backend.server.ts
+++ b/src/lib/go-backend.server.ts
@@ -16,13 +16,23 @@ export function goBackendOrigin(): string | null {
 /**
  * Reads a public presentation model from Go for a Next-owned renderer. No
  * secret is sent: these are the same public score fields the embed exposes.
+ *
+ * Default `no-store` only works on dynamically rendered routes: inside a
+ * `force-static`/ISR page (the homepage) a no-store fetch never runs during
+ * prerender, so sections built on it silently render empty. Pass
+ * `opts.revalidate` from static pages to get an ISR-compatible cached fetch.
  */
-export async function getGoPublicData<T>(path: string): Promise<T | null> {
+export async function getGoPublicData<T>(
+  path: string,
+  opts?: { revalidate?: number },
+): Promise<T | null> {
   const origin = goBackendOrigin();
   if (!origin || !path.startsWith("/")) return null;
   try {
     const response = await fetch(new URL(path, origin), {
-      cache: "no-store",
+      ...(opts?.revalidate
+        ? { next: { revalidate: opts.revalidate } }
+        : { cache: "no-store" }),
       headers: { Accept: "application/json" },
       signal: AbortSignal.timeout(4_000),
     });

--- a/src/lib/go-leaderboard.server.ts
+++ b/src/lib/go-leaderboard.server.ts
@@ -9,10 +9,12 @@ export async function getGoLeaderboard(
   view: LeaderboardView = "trending",
   window: LeaderboardWindow = "all",
   limit = 500,
+  revalidate?: number,
 ) {
   const query = new URLSearchParams({ view, window, limit: String(limit) });
   const data = await getGoPublicData<{ entries: PresentationLeaderboardEntry[] }>(
     `/api/leaderboard?${query.toString()}`,
+    revalidate ? { revalidate } : undefined,
   );
   return data?.entries ?? [];
 }

--- a/src/lib/go-projects.server.ts
+++ b/src/lib/go-projects.server.ts
@@ -54,6 +54,7 @@ export async function getGoProjects(options: {
   language: string | null;
   limit: number;
   offset: number;
+  revalidate?: number;
 }) {
   const query = new URLSearchParams({
     sort: options.sort,
@@ -63,6 +64,7 @@ export async function getGoProjects(options: {
   if (options.language) query.set("language", options.language);
   const data = await getGoPublicData<{ projects: GoProjectListItem[] }>(
     `/api/projects?${query.toString()}`,
+    options.revalidate ? { revalidate: options.revalidate } : undefined,
   );
   return (data?.projects ?? []).map((project) => ({
     ...project,


### PR DESCRIPTION
Two homepage content-zone fixes on top of the Go cutover:

1. **Regression fix**: `getGoPublicData` used `cache: no-store`, which Next never executes while prerendering a `force-static` page — the leaderboard rail and projects preview silently rendered empty on the live ISR homepage. Both sections now read Go through an ISR-compatible cached fetch (`revalidate: 3600`, matching the page). Verified in a local production build: the prerendered HTML now contains the leaderboard board and all 8 project cards.
2. **Layout**: the projects preview becomes a horizontal snap-scroll strip (8 cards, momentum sort with quality fallback) filling the main column, with equal-height cards.

Typecheck/lint clean (one pre-existing warning in LiveRoast.tsx). No new color/border classes — strip reuses the existing ProjectCard theming.