### PR TITLE
feat(home): scroll affordances for the projects strip

### DIFF
--- a/src/components/HomeProjectsPreview.tsx
+++ b/src/components/HomeProjectsPreview.tsx
@@ -54,18 +54,30 @@ export async function HomeProjectsPreview() {
           {tCollections("viewAll")} →
         </Link>
       </div>
-      <div className="-mx-5 mt-5 flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-2 sm:-mx-6 sm:px-6">
-        {projects.map((project, index) => (
-          <div
-            key={project.repo.repo_key}
-            className="flex w-[19rem] shrink-0 snap-start sm:w-[21rem]"
-          >
-            <ProjectCard
-              project={project}
-              position={index + 1}
-            />
-          </div>
-        ))}
+      <div className="relative -mx-5 mt-5 sm:-mx-6">
+        <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-3 [scrollbar-color:var(--color-zinc-500)_transparent] [scrollbar-width:thin] sm:px-6 [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-500/50 [&::-webkit-scrollbar-track]:bg-transparent">
+          {projects.map((project, index) => (
+            <div
+              key={project.repo.repo_key}
+              className="flex w-[19rem] shrink-0 snap-start sm:w-[21rem]"
+            >
+              <ProjectCard
+                project={project}
+                position={index + 1}
+              />
+            </div>
+          ))}
+        </div>
+        {/* Edge fades hint that the strip scrolls; they sit on the page
+            background so they track light/dark via --color-background. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 left-0 w-5 bg-gradient-to-r from-background to-transparent sm:w-6"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background to-transparent sm:w-12"
+        />
       </div>
     </section>
   );

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -22,7 +22,7 @@ export function ProjectCard({ project, position }: { project: GoProjectListItem;
             onClick={() =>
               trackEvent("project_card_click", { repo: model.repoKey, position })
             }
-            className="break-all text-lg font-black text-zinc-100 underline-offset-4 hover:text-white hover:underline"
+            className="break-words text-lg font-black text-zinc-100 underline-offset-4 hover:text-white hover:underline"
           >
             {model.title}
           </Link>


### PR DESCRIPTION
Follow-up polish on the homepage projects strip:

- visible thin scrollbar (webkit pseudo + standard `scrollbar-color`/`scrollbar-width`), zinc tone readable in both themes
- left/right edge fades via `from-background` (theme-aware, tracks light/dark)
- card titles `break-all` → `break-words` so long repo names break at hyphens, not mid-word

Verified in a local production build: the prerendered homepage HTML contains the scrollbar styles, fades and break-words. Typecheck/lint clean (one pre-existing unrelated warning).