### PR TITLE
ci(deploy): railway upload retry + manual gate trigger

### DIFF
--- a/.github/scripts/deploy-gate.mjs
+++ b/.github/scripts/deploy-gate.mjs
@@ -98,7 +98,11 @@ async function railwayLatestSuccess(serviceId) {
 }
 
 async function commandAnchors() {
-  const beforeSha = env("BEFORE_SHA");
+  // workflow_dispatch runs have no event.before; the previous main commit is
+  // the first parent of the merge at HEAD.
+  const beforeSha =
+    process.env.BEFORE_SHA ||
+    execFileSync("git", ["rev-parse", "HEAD~1"]).toString().trim();
   const currentSha = env("GITHUB_SHA");
 
   // Staleness guard: queued runs execute FIFO, so an older run can start
@@ -144,11 +148,17 @@ async function commandAnchors() {
 }
 
 function railwayUp(serviceId) {
-  execFileSync(
-    "railway",
-    ["up", "--service", serviceId, "--environment", "production", "--ci", "-y"],
-    { stdio: "inherit", env: process.env },
-  );
+  const args = ["up", "--service", serviceId, "--environment", "production", "--ci", "-y"];
+  try {
+    execFileSync("railway", args, { stdio: "inherit", env: process.env });
+  } catch (first) {
+    // The CLI's built-in upload retry gives up after ~5 attempts; a Railway
+    // control-plane 503 can outlast that. One full retry absorbs it without
+    // masking persistent failures.
+    console.error(`railway up for ${serviceId} failed (${first.message}); retrying once in 30s`);
+    execFileSync("sleep", ["30"]);
+    execFileSync("railway", args, { stdio: "inherit", env: process.env });
+  }
 }
 
 async function waitRailwaySuccess(serviceId, previousId, timeoutMs) {

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,6 +23,9 @@ name: Deploy production gate
 on:
   push:
     branches: [main]
+  # Manual escape hatch: when a push trigger is lost (e.g. an Actions outage)
+  # the gate for the current main head can be started by hand.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up from the first real gate run (which validated anchors → Railway api deploy → Vercel wait → verdict → dual rollback end to end):

- the worker deploy died on a transient Railway control-plane 503 during upload; `railway up` now retries once after 30s so a blip does not force a full rollback cycle
- `workflow_dispatch:` lets us start the gate manually for current main when a push trigger is lost (as happened during today's Actions outage); anchors fall back to `HEAD~1` for the previous commit in that mode