### PR TITLE
feat(home): project assessment strip above the intro

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { DeveloperCount } from "@/components/DeveloperCount";
 import { HomeCollections } from "@/components/HomeCollections";
+import { HomeProjectBoards } from "@/components/HomeProjectBoards";
 import { HomeProjectsPreview } from "@/components/HomeProjectsPreview";
 import { LeaderboardRail } from "@/components/LeaderboardRail";
 import { Roaster } from "@/components/Roaster";
@@ -116,6 +117,12 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
             </div>
           </nav>
         </aside>
+      </div>
+
+      {/* Project assessment band: full-width strip between the directory
+          columns and the intro, previewing the treasure board top. */}
+      <div className="mt-16 w-full max-w-6xl">
+        <HomeProjectBoards locale={locale} />
       </div>
 
       <HomeIntro />

--- a/src/components/HomeProjectBoards.tsx
+++ b/src/components/HomeProjectBoards.tsx
@@ -1,0 +1,79 @@
+import { getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+import { HomeSnapStrip } from "@/components/HomeSnapStrip";
+import {
+  ProjectAssessmentCard,
+  type ProjectAssessmentCardLabels,
+} from "@/components/ProjectAssessmentCard";
+import { getGoPublicData } from "@/lib/go-backend.server";
+import type { ProjectAssessment } from "@/lib/project-analysis-db";
+
+const PREVIEW_LIMIT = 8;
+
+/**
+ * Homepage "project assessment" band — previews the top of the treasure
+ * board (falling back to the all-analyses list while the board is small) as a
+ * horizontal strip of the same assessment cards /projects uses. Reads Go
+ * through an ISR-cached fetch so it survives the force-static homepage
+ * prerender.
+ */
+export async function HomeProjectBoards({ locale }: { locale: string }) {
+  const t = await getTranslations("projectBoards");
+  const tCollections = await getTranslations("collections");
+  let entries: ProjectAssessment[] = [];
+  for (const board of ["treasure", "all"] as const) {
+    const data = await getGoPublicData<{ entries: ProjectAssessment[] }>(
+      `/api/project-boards?board=${board}&limit=${PREVIEW_LIMIT}&offset=0`,
+      { revalidate: 3600 },
+    );
+    entries = data?.entries ?? [];
+    // The treasure board is the editorial surface; only fall back to the
+    // unranked list while treasure has too few entries to fill a strip.
+    if (entries.length >= 4 || board === "all") break;
+  }
+  if (entries.length === 0) return null;
+
+  const labels: ProjectAssessmentCardLabels = {
+    productScore: t("productScore"),
+    confidence: t("confidence"),
+    communityStrength: t("communityStrength"),
+    viewReport: t("viewReport"),
+    treasure: t("boards.treasure"),
+    classic: t("boards.classic"),
+    unranked: t("boards.unranked"),
+  };
+
+  return (
+    <section className="w-full">
+      <div className="flex items-end justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-black tracking-tight text-zinc-100 sm:text-2xl">
+            {t("homeEyebrow")}
+          </h2>
+          <p className="mt-1 text-sm text-zinc-500">{t("boardDescriptions.treasure")}</p>
+        </div>
+        <Link
+          href="/projects"
+          prefetch={false}
+          className="shrink-0 text-sm text-zinc-400 underline-offset-4 transition-colors hover:text-zinc-200 hover:underline"
+        >
+          {tCollections("viewAll")} →
+        </Link>
+      </div>
+      <HomeSnapStrip>
+        {entries.map((assessment) => (
+          <div
+            key={assessment.repoKey}
+            className="flex w-[20rem] shrink-0 snap-start sm:w-[22rem]"
+          >
+            <ProjectAssessmentCard
+              assessment={assessment}
+              labels={labels}
+              locale={locale}
+            />
+          </div>
+        ))}
+      </HomeSnapStrip>
+    </section>
+  );
+}

--- a/src/components/HomeProjectsPreview.tsx
+++ b/src/components/HomeProjectsPreview.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
+import { HomeSnapStrip } from "@/components/HomeSnapStrip";
 import { ProjectCard } from "@/components/ProjectCard";
 import { getGoProjects } from "@/lib/go-projects.server";
 
@@ -54,31 +55,19 @@ export async function HomeProjectsPreview() {
           {tCollections("viewAll")} →
         </Link>
       </div>
-      <div className="relative -mx-5 mt-5 sm:-mx-6">
-        <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-3 [scrollbar-color:var(--color-zinc-500)_transparent] [scrollbar-width:thin] sm:px-6 [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-500/50 [&::-webkit-scrollbar-track]:bg-transparent">
-          {projects.map((project, index) => (
-            <div
-              key={project.repo.repo_key}
-              className="flex w-[19rem] shrink-0 snap-start sm:w-[21rem]"
-            >
-              <ProjectCard
-                project={project}
-                position={index + 1}
-              />
-            </div>
-          ))}
-        </div>
-        {/* Edge fades hint that the strip scrolls; they sit on the page
-            background so they track light/dark via --color-background. */}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 left-0 w-5 bg-gradient-to-r from-background to-transparent sm:w-6"
-        />
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background to-transparent sm:w-12"
-        />
-      </div>
+      <HomeSnapStrip>
+        {projects.map((project, index) => (
+          <div
+            key={project.repo.repo_key}
+            className="flex w-[19rem] shrink-0 snap-start sm:w-[21rem]"
+          >
+            <ProjectCard
+              project={project}
+              position={index + 1}
+            />
+          </div>
+        ))}
+      </HomeSnapStrip>
     </section>
   );
 }

--- a/src/components/HomeSnapStrip.tsx
+++ b/src/components/HomeSnapStrip.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared horizontal snap-scroll strip for homepage content bands: visible
+ * thin scrollbar (webkit + standard properties) and edge fades painted from
+ * the theme-aware --color-background so clipped cards dissolve into the page
+ * in both light and dark themes. Children must be fixed-width snap items.
+ */
+export function HomeSnapStrip({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative -mx-5 mt-5 sm:-mx-6">
+      <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-5 pb-3 [scrollbar-color:var(--color-zinc-500)_transparent] [scrollbar-width:thin] sm:px-6 [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-zinc-500/50 [&::-webkit-scrollbar-track]:bg-transparent">
+        {children}
+      </div>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 left-0 w-5 bg-gradient-to-r from-background to-transparent sm:w-6"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background to-transparent sm:w-12"
+      />
+    </div>
+  );
+}

--- a/src/components/ProjectAssessmentCard.tsx
+++ b/src/components/ProjectAssessmentCard.tsx
@@ -23,7 +23,7 @@ export function ProjectAssessmentCard({
 }) {
   const analysis = assessment.analysis;
   return (
-    <article className="rounded-2xl border border-white/10 bg-white/[0.035] p-5">
+    <article className="h-full w-full rounded-2xl border border-white/10 bg-white/[0.035] p-5">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0">
           <a

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "تقييمات المشاريع",
     "metaTitle": "اكتشف مشاريع GitHub عالية الجودة · ghfind",
     "metaDescription": "اكتشف مشاريع GitHub مرتّبة حسب جودة وزخم المطورين الذين يقفون خلفها.",
     "eyebrow": "اكتشاف المشاريع",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "Project Assessments",
     "metaTitle": "Treasure open-source projects · ghfind",
     "metaDescription": "Find useful open-source projects that solve real problems and deserve more attention.",
     "eyebrow": "Open-source project evaluation",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "Evaluaciones de proyectos",
     "metaTitle": "Descubre proyectos de GitHub de calidad · ghfind",
     "metaDescription": "Descubre proyectos de GitHub rankeados por la calidad y el impulso de los developers que hay detrás.",
     "eyebrow": "Descubrimiento de proyectos",

--- a/src/messages/id.json
+++ b/src/messages/id.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "Penilaian Proyek",
     "metaTitle": "Temukan proyek GitHub berkualitas · ghfind",
     "metaDescription": "Temukan proyek GitHub yang diperingkat berdasar kualitas dan momentum developer di baliknya.",
     "eyebrow": "Penemuan proyek",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "プロジェクト評価",
     "metaTitle": "注目すべきオープンソースプロジェクト · ghfind",
     "metaDescription": "実際の課題を解決し、もっと注目されるべきオープンソースプロジェクトを見つけます。",
     "eyebrow": "オープンソース評価",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "프로젝트 평가",
     "metaTitle": "주목할 오픈소스 프로젝트 · ghfind",
     "metaDescription": "실제 문제를 해결하고 더 많은 관심을 받을 가치가 있는 오픈소스 프로젝트를 찾아보세요.",
     "eyebrow": "오픈소스 프로젝트 평가",

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "Avaliações de projetos",
     "metaTitle": "Descubra projetos de qualidade no GitHub · ghfind",
     "metaDescription": "Descubra projetos do GitHub ranqueados pela qualidade e pelo gás dos desenvolvedores por trás deles.",
     "eyebrow": "Descoberta de projetos",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "Đánh giá dự án",
     "metaTitle": "Khám phá dự án GitHub chất lượng cao · ghfind",
     "metaDescription": "Khám phá các dự án GitHub được xếp hạng theo chất lượng và đà phát triển của những dev đứng sau.",
     "eyebrow": "Khám phá dự án",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -914,6 +914,7 @@
     }
   },
   "projectBoards": {
+    "homeEyebrow": "项目评测",
     "metaTitle": "宝藏开源项目 · ghfind",
     "metaDescription": "发现真正解决问题、值得更多关注的开源项目。",
     "eyebrow": "开源项目评估",


### PR DESCRIPTION
Adds the requested 项目评测 band between the content columns and the intro:

- top of the treasure board as a horizontal snap-scroll strip of the exact `ProjectAssessmentCard` used on /projects (falls back to the all-analyses list while treasure has < 4 entries — currently only mosoo is ranked)
- extracts the strip chrome (thin visible scrollbar, theme-aware edge fades) into a shared `HomeSnapStrip` now used by both homepage bands
- ISR-cached Go read (`revalidate: 3600`) so the section renders inside the force-static homepage; new `homeEyebrow` string in all 9 locales

Verified in a local production build (assessment card present in prerendered HTML); typecheck/lint/607 tests green.