### PR TITLE
feat(blog): publish LobeHub evolution research post

### DIFF
--- a/content/blog/lobehub-evolution/en.md
+++ b/content/blog/lobehub-evolution/en.md
@@ -1,0 +1,294 @@
+---
+title: "LobeHub: From Open-Source Chat Tool to Chief Agent Operator"
+description: "LobeHub began in 2023 as the open-source chat tool LobeChat, went through three major architectural overhauls and two repositionings, and became a multi-agent collaboration platform built around the \"Chief Agent Operator\" (CAO). This report traces its full trajectory: architecture, business model, and ecosystem."
+date: "2026-08-07"
+tags: ["ai-agent", "open-source", "research", "product"]
+---
+
+LobeHub's evolution is a highly representative case of transformation in AI application development. The project started as LobeChat, a single-purpose chat tool, and through three major architectural overhauls and two brand repositionings ultimately became a multi-agent collaboration platform built around the "Chief Agent Operator" (CAO). As of August 2026, LobeHub has earned more than 81,200 stars and 15,800 forks on GitHub, with open-source community activity and product iteration speed both at the front of the industry. This report systematically traces LobeHub's full trajectory since its birth in 2023, analyzes in depth the three-stage transformation logic that took it from "open-source ChatGPT client" to "agent collaboration platform" to "Chief Agent Operator", and examines its core strategies in architectural evolution, business model exploration, and ecosystem building — offering a reference sample for understanding how AI application platforms develop.
+
+## Origins and Founding Background
+
+### Founder Arvin Xu: Background and Philosophy
+
+LobeHub's founder Arvin Xu is a former experience designer at Ant Group; before joining Ant Group he had already become a core member of Ant Design. Ant Design is the enterprise-grade UI design language and React component library that Ant Group released in 2015; by 2020 it had gathered more than 57,000 stars on GitHub and cumulatively served over 3 million designers and developers worldwide. Xu's work at Ant Group (April 2021 to May 2025) gave him a deep understanding of design methodology and architectural principles for enterprise products, laying a solid foundation for founding LobeHub later. In May 2025, Xu formally founded LobeHub, moving from in-house enterprise designer to open-source AI platform entrepreneur.
+
+Xu's self-description on the social platform X reads "Design Engineer / Founder of @LobeHub / core member of @AntDesignUI / ex AntGroup", a label that sketches his career path clearly. In a post published in July 2026 he looked back: "At Ant Design I didn't just systematically learn design, front-end, and human-computer interaction — I experienced first-hand how an excellent open-source project actually operates." This deep grasp of open-source culture directly shaped LobeHub's product philosophy: an open-source path from day one, with core functionality kept open source throughout its subsequent development.
+
+The brand name "LobeHub" carries the founder's deeper thinking about the architecture of the AI application layer. As Xu explained on X, "Lobe" refers to a lobe of the brain — the brain's basic organizational unit — while "Hub" means a nexus or connection point. "LobeHub" therefore signifies becoming, at the application end (the UI layer), the connection hub for all kinds of large language models (LLMs). This naming philosophy runs through the entire product history, from a single-model chat tool to a comprehensive AI platform supporting multiple models, multiple agents, and multiple modalities.
+
+### The Birth of LobeChat
+
+The LobeChat project was born in 2023, right at the explosion of large language model technology. According to technical documentation, LobeChat is an AI conversation application built on the Next.js framework, intended to provide an AI productivity platform where users interact with AI in natural language. The project's initial positioning was very clear: to be an "open-source, modern-design ChatGPT/LLMs UI/framework" supporting speech synthesis, multimodal interaction, and an extensible plugin system.
+
+By December 2023, detailed introductory articles about LobeChat had already appeared on Zhihu, noting that its GitHub star count had passed 11,000 and emphasizing its role as a "free way to deploy a private ChatGPT". This shows the project won broad attention from the developer community within a short time of launch. LobeChat's early core selling points included support for multiple AI providers (OpenAI, Claude 3, Gemini, and others), text-to-speech, multimodal input (text, images, audio), and an extensible function-calling plugin system.
+
+The project's open-source nature was the key factor behind its rapid market acceptance. LobeChat was released under the MIT license, so any developer could download, modify, and deploy it for free. That openness attracted a large number of individual developers and enterprise users, who could not only self-host LobeChat to build private AI chat applications but also build on its code. As technical blogs recorded, LobeChat supported one-click deployment to Vercel, Zeabur, Sealos, Alibaba Cloud and other platforms — with only an OpenAI API key required, deployment took a few minutes.
+
+## The 0.x Era: The Local-First Exploration (2023 – early 2024)
+
+### Architectural Design Philosophy
+
+In LobeChat 0.x, the development team followed the principle "if not necessary, do not add entities" and adopted a Local First implementation with no server-side database. This decision rested on three core considerations. First, responsiveness: local storage eliminates network latency and makes interaction immediate. Second, data privacy: user data lives in the local browser, with no worry about cloud leakage. Third, deployment simplicity: no database configuration is needed to get started quickly.
+
+That architecture had obvious limits, however. Because data and state were bound to a single browser, features such as cross-device message sync, knowledge-base/document conversations, high-quality sharing of a session, scheduled tasks, and assistant-initiated messages were all impossible. Late in the 0.x era these limits gradually became the main theme of user feedback, and they planted the seeds for the architectural transition that followed.
+
+Another notable characteristic of 0.x was its use of React Server Components (RSC). RSC is a server-rendering technology introduced by the Next.js framework to improve first-paint performance and SEO. In LobeChat's actual usage patterns, though, the high frequency of interaction meant even lightweight operations triggered a server round trip, producing network latency and micro-stutters that could not be engineered away. The team formally acknowledged this problem in later versions, and it became an important driver of the 2.0 rebuild.
+
+### Feature Evolution and Community Building
+
+Despite the architectural limits, LobeChat kept iterating on features during the 0.x era, gradually building a rich product surface. The project established a multi-model support strategy early, working with mainstream large language models including OpenAI, Anthropic Claude, Google Gemini, Mistral, and LLaMA2. This "model-agnostic" design philosophy let it connect to whatever LLM providers the market offered and gave users more choice.
+
+The plugin system was another core capability of the 0.x era. LobeChat's plugin ecosystem is built on the function call mechanism, letting developers create extensions that fetch real-time information, search documents, interact with third-party services, and more. According to official figures, as of 2026 LobeHub's Skills and MCP marketplace has connected more than 10,000 skill plugins, and the Agent marketplace offers more than 256,000 ready-to-use agents. These plugins greatly increased the platform's practicality and flexibility, turning LobeChat from a pure chat tool into an AI assistant platform capable of executing complex tasks.
+
+Multimodal interaction was also fully realized in the 0.x era. LobeChat supports text-to-speech (TTS) and speech-to-text (STT), so users can hold natural spoken conversations with the AI. The platform also supports image recognition and generation, handling image input and calling text-to-image models. These capabilities put LobeChat's user experience ahead of most open-source chat tools of the time and closer to the full ChatGPT Plus experience.
+
+On community building, the LobeHub team actively maintained the project on GitHub and responded promptly to user feedback. By December 2024, Zhihu articles were reporting that LobeChat had 45,000+ GitHub stars, showing the project's continued growth in influence within the open-source community. The team also built a developer community through a Discord channel, providing technical support and a place to talk.
+
+## The 1.0 Era: The Move to Cloud Architecture (2024)
+
+### Towards 1.0: The Decision to Change Architecture
+
+On 28 March 2024, the LobeHub team formally published the blog post "Towards LobeHub 1.0", announcing a major upcoming architectural upgrade. The post stated plainly that while the 0.x Local First architecture offered fast responses, data privacy, and simple deployment, it capped the product's capability ceiling and could not meet user demand for cross-device sync, knowledge bases, and scheduled tasks. Version 1.0 would therefore introduce server-side database support, laying the infrastructure groundwork for the next stage.
+
+This decision marked the start of LobeHub's transformation at the architectural level, evolving from a purely client-side application into a cloud service. Notably, the team stressed that its "open-source founding intent remains unchanged", promising that all core functionality would stay open source. This hybrid model — open-source core plus cloud-service value-add — both guaranteed continued community development and left room for later commercial exploration.
+
+After a little over two months of development, LobeChat 1.0 was formally released on 19 June 2024. The new version brought a server-side database and user authentication management as a wholly new architecture and feature set, opening up new possibilities. On that basis, LobeHub Cloud simultaneously entered Beta, offering users an officially hosted service.
+
+### License Change and Commercial Exploration
+
+Alongside the 1.0 release, LobeHub's open-source license changed in an important way. Starting with 1.0, the license was updated from MIT to Apache 2.0, with a supplementary commercial-licensing clause added. The change had three effects: stronger patent protection, clearer contributor responsibilities, and more flexibility to encourage commercial use.
+
+According to the official explanation, the license change affects most users not at all. Individual users, internal team use, and self-deployment remain free; building on LobeHub without commercializing (internal enterprise use, public-interest services) also remains free; even running the unmodified original LobeHub as a multi-tenant commercial service (various API relay stations, for instance) requires no additional license. Only when a user builds on LobeHub *and* commercializes the result — hiding the official logo, altering official links, and the like — is a commercial license from the team required.
+
+The team also announced it would try opening a "free commercial license program" for open-source contributors: submit a pull request meeting the quality bar and receive a commercial license for free. This mechanism both incentivizes community contribution and gives the project a foundation for a sustainable business model.
+
+### Knowledge Base and Marketplace Ecosystem
+
+Another important milestone of the 1.0 version was the launch of the knowledge base. On 31 August 2024, LobeHub formally released file upload and knowledge base functionality, bringing an entirely new knowledge-conversation experience. Knowledge Base 2.0 supports connecting third-party data sources such as Notion, Google Drive, Feishu Docs, and Yuque, breaking down the wall between the product and users' existing knowledge systems. Based on RAG (retrieval-augmented generation), the model retrieves relevant content from the knowledge base before generating an answer, markedly improving accuracy and relevance.
+
+At the same time, LobeHub began building an Agent marketplace ecosystem. Developers can publish agents with specific capabilities and run them on LobeHub's servers, creating a thriving agent ecosystem. As of 2026, the Agent marketplace offers more than 256,000 ready-to-use agents spanning writing, Q&A, images, video, voice, and workflows. This "platform plus ecosystem" model turned LobeHub from a single product into infrastructure for AI application development.
+
+## Brand Upgrade and the 2.0 Rebuild (2025 – 2026)
+
+### From LobeChat to LobeHub: Rebranding
+
+On 3 November 2025, founder Arvin Xu published a long post in a GitHub Discussion titled "Starting 2.0 of LobeHub(LobeChat): A System Reconstruction and Reflection", formally announcing that the product would be upgraded from "LobeChat" to "LobeHub". The rebrand was not merely a name change; it represented a fundamental shift in product positioning — from "open-source ChatGPT client" to "agent collaboration platform".
+
+As the team explained, "the next generation of AI applications will evolve into a 'hub' connecting users, diverse agents, vast knowledge, and external services, building an open, modular, extensible AI ecosystem platform." In the new product framing, an agent is no longer an auxiliary tool but the smallest unit of work within LobeHub. Users can create teams of multiple specialized agents that divide the labor and collaborate on complex tasks.
+
+In 2026 the project completed the actual migration of the brand upgrade, moving the GitHub repository from lobehub/lobe-chat to lobehub/lobehub. The official description of LobeHub was updated to "a workspace and life space for discovering, building, and collaborating with agent teammates that grow with you." This positioning elevates the AI assistant from "tool" to "teammate", emphasizing a value proposition of long-term collaboration and shared growth.
+
+### Fundamental Architectural Change: Server at the Core
+
+The heart of the 2.0 rebuild is a fundamental change in architecture. Reviewing the three stages of architectural evolution: the 0.x era was purely client-side, with data and state bound to a single browser, incapable of persistence or cross-device sync; the 1.x era was an exploration of and compromise with hybrid architecture, with browser, server, and desktop coexisting, which fractured the product experience and complicated the technical architecture; 2.0 turns to a server-centric design, unifying all agent state, memory, knowledge bases, and task execution on the server, and adopting an asynchronous architecture for efficient human-AI collaboration.
+
+Another major technical decision was a full return to SPA (single-page application) architecture. In its reflection the team noted that the RSC (React Server Components) architecture introduced in the 0.x period performed poorly in LobeChat's high-frequency interaction scenarios, where even lightweight operations triggered server round trips and produced network latency and micro-stutters that could not be eliminated. Based on long practice and deep reflection on the relationship between technology and product, 2.0 therefore returns fully to SPA architecture to make the user experience smoother.
+
+Version 2.0 also introduced several core pillars: Agent Runtime, a wholly new runtime designed for agents that gives them powerful tool-calling ability; AI Team, which supports creating collaborative teams composed of multiple specialized agents; personal memory and agent memory systems that dynamically capture user preferences for a personalized experience; and the release of the desktop stable version and mobile app, which closes the loop on an all-platform experience.
+
+### Market Positioning and Competitive Landscape
+
+After the brand upgrade, LobeHub faces a new competitive landscape. In 2026, strong competitors such as OpenClaw and Manus emerged in the AI agent space. LobeHub seeks a breakthrough through differentiated positioning: against OpenClaw, LobeHub emphasizes being open source, self-hostable, and multi-device synced, and completely free when using your own configured models; against Manus, LobeHub highlights agent team collaboration, the Skills and MCP marketplace ecosystem, and broader open-source community support.
+
+According to technical reviews, LobeHub's core advantages are: a multi-agent collaboration network in which different agents communicate and divide work in real time; Deep Agents with planning capability, a file system, task lists, and Bash access, able to execute long-horizon complex tasks; a long-term memory system designed around three cognitive models — semantic memory, episodic memory, and procedural memory; and a deep lineage with Ant Design that keeps its UI/UX quality high.
+
+## The CAO Era: The Chief Agent Operator Innovation (May 2026)
+
+### Introducing the CAO Concept
+
+On 18 May 2026, LobeHub published a major update simultaneously on X and GitHub, formally launching CAO (Chief Agent Operator). This is the third major repositioning in LobeHub's history, marking the product's evolution from "agent collaboration platform" to "agent operations management platform".
+
+As officially described, a CAO is "an agent that reviews its own work, can assemble sub-agents when needed, and stops only when you need to make the call." Unlike traditional chatbots that need the user to guide each step, a CAO can drive itself forward: it reviews what it has finished, decides the next step, and continues, without waiting for the user to say "next" every time. When it hits something that genuinely requires a user decision, it stops, reports what it has already tried, and asks a clear question.
+
+Media reviews likened CAO to a "cyber foreman": the user describes a need in one sentence, and CAO automatically creates multiple agents, designs logos, names the group, and organizes the agent team to collaborate on the task. Every agent's prompt and skills are visible and editable, so users can adjust them at any time. This "assemble an AI team in one click" capability substantially lowers the barrier to multi-agent collaboration.
+
+### Technical Implementation and Features
+
+CAO's technical implementation is built on LobeHub 2.0's server-core architecture. When a task is large, CAO can assemble a squad of sub-agents and hand out assignments; the primary agent always controls the overall pace, and the user can open any sub-agent's conversation at any time to check progress. This hierarchical task-scheduling mechanism makes managing complex projects orderly and controllable.
+
+Another important CAO feature is support for round-the-clock, 7×24 operation. As LobeHub's official site puts it, the platform "organizes your agents into 7×24 operations. It handles hiring, scheduling, and reporting for your entire AI team. You stay in control — without having to be online all the time." This asynchronous-collaboration model breaks the constraint that traditional chat tools require real-time interaction, making the AI assistant a genuine "digital employee" that can work independently.
+
+The changelog published on 19 May 2026 lists numerous improvements in the CAO release: project skills moved into the work sidebar with built-in Markdown preview; model selection by suggestion type; the chat input box's action buttons restyled as "icon plus label"; more stable recurring tasks with a limit on total executions; and the desktop client no longer logging users out because of a background token refresh. These detail-level refinements reflect the team's sustained attention to user experience.
+
+### Market Reception and Industry Impact
+
+The launch of CAO sparked wide discussion in the developer community and the tech press. On 19 May 2026, 36Kr published a review titled "AI Gets Promoted to Manager? Testing CAO on the Job: Four Minutes to Assemble a Team, a Full Day of Wreckage", vividly describing both CAO's capabilities and its limits. The article noted that while CAO performs excellently at assembling agent teams, stability problems remain in actually executing complex tasks.
+
+Even so, the CAO concept represents an important direction for AI applications: the shift from "using AI" to "managing AI". As one technical blogger put it, "LobeHub takes you from 'using AI' to 'managing an AI team', and it's fully private — your data is yours to control." This new paradigm of human-machine collaboration elevates the human role from operator to manager and may reshape how we work in the future.
+
+As of August 2026, LobeHub has 81,200 stars on GitHub and has been listed as a case study by cloud providers including AWS and Google Cloud. Its Product Hunt listing positions LobeHub as "Your Chief Agent Operator", underscoring its role as the core of a human-machine collaboration system.
+
+## Commercialization and Ecosystem Building
+
+### Pricing Strategy and Service Model
+
+LobeHub commercializes through a freemium model: core functionality stays open source and free, while advanced features and services are charged by subscription. According to the official pricing page, LobeHub Cloud offers four individual tiers: Free ($0/month), Basic ($9.9/month), Premium ($19.9/month), and Ultimate ($39.9/month).
+
+The free tier provides 500,000 compute credits per month, enough for roughly 200 conversations on DeepSeek V4 Pro or about 100 on Grok 4.5, and includes unlimited pages, image generation, video generation, and curated Agent marketplace picks. The Basic tier provides 5 million credits per month and supports more advanced model calls plus agent memory. The enterprise tier offers customization such as private deployment, branded theming, user management, self-hosted providers, and private models, with pricing available by contacting the sales team.
+
+LobeHub's billing runs on a Credits system. Consumption per million tokens converts to different numbers of credits depending on the model: 1 million input tokens on DeepSeek V4 Pro consumes 957,000 credits, while 1 million input tokens on Claude Opus 5 consumes 5 million credits. This fine-grained billing lets users control costs flexibly.
+
+### Enterprise Partnerships and Cloud Provider Integration
+
+LobeHub has built deep partnerships with several cloud providers. In 2024, Amazon Web Services (AWS) listed LobeHub as a case study, describing how it uses AWS services to build an AI platform oriented toward multi-agent collaboration. The AWS case study notes that LobeHub's solution focuses on creating and coordinating multiple agents, suited to enterprise-grade complex task processing.
+
+In July 2024, Master Concept and LobeHub announced a strategic partnership, with Master Concept becoming a gold sponsor of the LobeHub product. Master Concept is a Google Platinum Partner serving more than 3,000 Chinese companies expanding overseas. The partnership covers enterprise-grade customization and integration services, semi-managed service support, and professional technical support for the Google Cloud Gemini API.
+
+These partnerships bring LobeHub commercial revenue and also strengthen its credibility in the enterprise market. Through integration with mainstream cloud platforms such as AWS and Google Cloud, LobeHub can offer enterprise users a more stable, secure, and compliant service.
+
+### Open-Source Ecosystem and Community Governance
+
+LobeHub has consistently treated open source as core strategy. Even after launching a commercial cloud service, all core functionality remains permanently open source, and users can still choose self-hosting for free. The project uses the LobeHub Community License, a customized license based on Apache 2.0 with a supplementary commercial-licensing clause.
+
+The team actively maintains several open-source projects on GitHub, including the main repository lobehub/lobehub, the agent index repository lobehub/lobe-chat-agents, and a plugin SDK. As of 2026, the core repository has received 15,800 forks and 12,600 commits. Community contributors can participate through pull requests, and outstanding contributors can receive a free commercial license.
+
+LobeHub also maintains thorough developer documentation and a blog, regularly publishing product updates, technical articles, and industry insight. The official Discord community and GitHub Discussion board give developers a place to communicate and collaborate. This open, transparent governance model lets LobeHub keep attracting developers worldwide into ecosystem building.
+
+## Industry Impact and Outlook
+
+### Lessons for AI Application Development
+
+LobeHub's trajectory offers lessons at several levels for AI application development. First, architecturally, its evolution from Local First to Server Core reflects the inevitable transition of AI applications from "tool" to "platform". As agent capability grows and task complexity rises, client-side architecture cannot satisfy state persistence, cross-device sync, or team collaboration, and cloud architecture becomes the general trend.
+
+Second, in terms of product positioning, LobeHub's path shows the evolution logic of AI applications from "chat tool" to "collaboration platform" to "operations system". When single-turn dialogue cannot meet the demands of complex tasks, multi-agent collaboration becomes the natural choice; and when agents multiply and task cycles lengthen, centralized operations management (CAO) becomes a hard requirement. This progressive expansion of capability lets the product keep delivering incremental value to users.
+
+Third, on business model, LobeHub's "open-source core plus cloud value-add" approach proves that commercializing an open-source project is viable. By keeping core functionality open source, the project gained a broad user base and community contributions; by offering hosting, enterprise customization, and other value-added services, it achieved sustainable commercial revenue. This model avoids the open-source trap of running on goodwill alone while keeping the open-source community healthy.
+
+### Competitive Landscape and Market Position
+
+In the AI agent platform space, LobeHub faces competition from OpenClaw, Manus, Claude Cowork, and others. Against these rivals, LobeHub's core differentiation is: open source and self-hostable, support for multiple model providers, a rich Agent marketplace ecosystem, and the excellent user experience it inherits from Ant Design.
+
+LobeHub faces challenges too. Technical reviews point out that compared with OpenClaw's raw capability, LobeHub still has room to improve on stability in complex tasks. Moreover, as major model vendors (OpenAI, Anthropic) ship official agent features, LobeHub must keep innovating to hold its differentiated edge.
+
+Taking a longer view, the "Chief Agent Operator" (CAO) concept LobeHub has staked out represents an important direction for AI applications. As AI agent capability keeps growing, the human user's role will shift from "operator" to "manager", and platforms that can efficiently coordinate, schedule, and monitor AI teams will become key infrastructure. LobeHub's early positioning in this direction may win it a long-term competitive advantage.
+
+### Future Trends
+
+Based on LobeHub's trajectory and the overall trend of the AI industry, several directions of continued evolution can be anticipated. First, further strengthening of agent capability. As underlying model capability improves and the tool-calling ecosystem matures, LobeHub's agents will gain stronger planning, reasoning, and execution ability, handling more complex long-horizon tasks.
+
+Second, the fusion of multimodality with embodied intelligence. LobeHub already supports text, image, and voice modalities; in future it may further integrate video understanding, code execution, and hardware control, letting agents interact more richly with the physical world.
+
+Third, deepening enterprise-grade features. As Workspace (team space) and API support mature, LobeHub will embed further into enterprise workflows and become part of organizational digital infrastructure. Integration with enterprise systems such as ERP, CRM, and OA will be a key direction.
+
+Fourth, continued expansion of the open-source ecosystem. LobeHub has built an initial developer ecosystem through its plugin system, Agent marketplace, and Skills marketplace; in future it may open lower-level interfaces further, attracting more third-party developers to create applications and services on top of LobeHub.
+
+## Conclusion
+
+From the 2023 open-source chat tool LobeChat, through the 0.x era's local-first exploration, the 1.0 era's move to cloud architecture, and the 2.0 era's brand upgrade and Server Core rebuild, LobeHub finally established the "Chief Agent Operator" (CAO) as its core positioning in 2026, completing a three-stage evolution from "chat tool" to "agent collaboration platform" to "agent operations management platform". This trajectory is not merely one product's iteration history; it is a microcosm of AI applications moving from "single-turn dialogue" to "long-term collaboration", and from "humans operating AI" to "humans managing AI teams".
+
+Continuous architectural innovation is the foundation of LobeHub's competitiveness. The shift from Local First to Server Core, and the return from RSC to SPA, reflect the team's deep reflection on matching technology choices to product needs. Balancing open-source strategy with business model lets LobeHub reconcile community influence with sustainable development, and its model — core functionality permanently open source, value-added services paid — offers a template other open-source AI projects can learn from.
+
+At the product level, LobeHub's evolution clearly shows the expansion path of AI application capability boundaries: first solve "can it converse" (0.x), then "can it collaborate" (1.x–2.0), and finally "can it be managed" (CAO). Each repositioning came with a change in the user's role — from operator to collaborator to manager — and this progressive value creation lets the product keep attracting a wider user base.
+
+Looking ahead, as AI agent technology matures and enterprise digital transformation deepens, agent operations platforms like LobeHub may well become key infrastructure for the era of human-machine collaboration. Its vision of "democratizing AI capability" is gradually becoming reality through open-source ecosystem building and the CAO innovation. For researchers and practitioners tracking the trajectory of AI applications, LobeHub's history offers a rich sample for observation and practical insight.
+
+## References
+
+[1. LobeHub - 你的首席Agent 运营官](https://lobehub.com/zh) -
+
+[2. LobeHub vs Manus：哪个AI Agent 平台更适合你？（2026）](https://lobehub.com/zh/blog/lobehub-vs-manus) -
+
+[3. Agent 助理市场](https://lobehub.com/zh/agent) -
+
+[4. 从“应用”到“平台”，亚马逊云科技赋能LobeHub，提升多智能体协作能力 ...](https://aws.amazon.com/cn/solutions/case-studies/lobehub/) -
+
+[5. LobeHub: Your Chief Agent Operator](https://www.producthunt.com/products/lobehub) -
+
+[6. GitHub 63.4K开源神器Lobe Chat能这么轻松构建你的私人AI聊天Agent](https://cloud.tencent.com/developer/article/2552901) -
+
+[7. AI-12-Lobe Chat 开源项目介绍](https://houbb.github.io/2024/02/20/ai-12-lobe-chat) -
+
+[8. Lobe Chat ： 一个开源、现代设计的LLM/AI 聊天框架](https://docs.feishu.cn/v/wiki/YASjwFqUCisMH4kLuKvcoZfwnhg/a1) -
+
+[9. 本地部署高颜值开源AI聊天工具LobeChat\_就念 - 魔乐社区](https://modelers.csdn.net/69a7b2467bbde9200b9d73c6.html) -
+
+[10. 架构设计](https://lobehub.com/zh/docs/development/basic/architecture) -
+
+[11. Lobe Chat - 免费开源的高性能AI聊天机器人框架](https://ai-bot.cn/lobe-chat/) -
+
+[12. LobeChat 聊天机器人框架](https://zhuanlan.zhihu.com/p/704343524) -
+
+[13. LobeHub | AI工具导航](https://www.aig123.com/sites/3106.html) -
+
+[14. LobeHub 智能AI聚合神器！ 内置ChatGPT、 Gemini Pro ...](https://www.youtube.com/watch?v=6MDLVd583oI\&vl=zh) -
+
+[15. 空谷Arvin Xu on X: "感觉是时候提一下我们的组织名为啥叫LobeHub 了。 ...](https://x.com/arvin17x/status/1819221250113503410?lang=zh) -
+
+[16. 用lobehub打造一个永久免费的AI个人助理 - 腾讯云](https://cloud.tencent.com/developer/article/2431275) -
+
+[17. LobeHub](https://docs.aihubmix.com/cn/clients/lobe-hub) -
+
+[18. LobeHub 智能AI聚合神器！ 内置ChatGPT、 Gemini Pro ...](https://www.youtube.com/watch?v=6MDLVd583oI\&vl=zh-Hant) -
+
+[19. LobeHub - AIHubMix](https://docs.aihubmix.com/cn/clients/lobe-hub) -
+
+[20. GitHub - lobehub/lobehub:  LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. · GitHub](https://github.com/lobehub/lobehub) -
+
+[21. About · LobeHub](https://lobehub.com/zh/about) -
+
+[22. 迈向 LobeHub 1.0 · LobeHub](https://lobehub.com/zh/blog/towards-lobe-chat-v1) -
+
+[23. 徐文彬- 设计工程师](https://cn.linkedin.com/in/arvinx/zh-cn) -
+
+[24. 基于LobeChat 构建企业内部LLM 知识库平台](https://aws.amazon.com/cn/blogs/china/building-an-internal-llm-knowledge-base-platform-based-on-lobechat/) -
+
+[25. 空谷Arvin Xu (@arvin17x) / Posts / X](https://x.com/arvin17x) -
+
+[26. 迈向LobeChat 1.0 #1768](https://github.com/lobehub/lobehub/discussions/1768) -
+
+[27. Towards LobeHub 1.0](https://lobehub.com/blog/towards-lobe-chat-v1) -
+
+[28. AI 可以取代运维了吗? - 东风微鸣](https://www.cnblogs.com/east4ming/p/19807710) -
+
+[29. 45k+ Star 超火项目！LobeChat：你的专属开源AI 助手！](https://zhuanlan.zhihu.com/p/11320533139) -
+
+[30. Starting 2.0 of LobeHub(LobeChat): A System Reconstruction and Reflection · lobehub/lobehub · Discussion #10007 · GitHub](https://github.com/lobehub/lobehub/discussions/10007) -
+
+[31. 产品 | 博客 · LobeHub](https://lobehub.com/zh/blog/category/product) -
+
+[32. AI翻身做主管？CAO上岗实测：组队4分钟，翻车一整天 - 知乎](https://zhuanlan.zhihu.com/p/2040204259023643495) -
+
+[33. LobeHub 1.0：新的架构与新的可能 · LobeHub](https://lobehub.com/zh/blog/release-lobe-chat-v1) -
+
+[34. 我在Ant Design 不仅系统地学到了设计、前端、人机交互的专业知识 ...](https://x.com/arvin17x/status/1938103843524632972) -
+
+[35. LobeHub - Your Chief Agent Operator](https://lobehub.com/) -
+
+[36. CAO：你的首席智能体运营官](https://lobehub.com/zh/changelog/2026-05-19-chief-agent-operator) -
+
+[37. AI翻身做主管？CAO上岗实测：组队4分钟，翻车一整天 - 腾讯新闻](https://view.inews.qq.com/k/20260519A09B2B00?scene=wap\&no-redirect=1) -
+
+[38. 开箱即用，简单上手，体验LobeChat搭建私人ChatGPT](https://www.cpolar.com/blog/out-of-the-box-easy-to-use-experience-lobechat-to-build-a-private-chatgpt) -
+
+[39. LobeChat下载和安装教程（附安装包）](https://c.biancheng.net/view/ilduff2.html) -
+
+[40. 知识库-大模型服务平台百炼(Model Studio) - 阿里云帮助文档](https://help.aliyun.com/zh/model-studio/rag-knowledge-base) -
+
+[41. Lobe Chat-21.3k Star开源LLMs 开发框架](https://zhuanlan.zhihu.com/p/685307878) -
+
+[42. 在OpenClaw大行其道的当下，LobeHub还能被用来作什么 - 知乎](https://zhuanlan.zhihu.com/p/2004515077370439540) -
+
+[43. CAO：你的首席智能体运营官 · LobeHub](https://lobehub.com/zh/changelog/2026-05-19-chief-agent-operator) -
+
+[44. lobe-chat/README.zh-CN.md at main](https://github.com/AIDotNet/lobe-chat/blob/main/README.zh-CN.md) -
+
+[45. 高颜值AI聊天应用LobeChat本地部署与远程多人访问使用详细 ...](https://cloud.tencent.com/developer/article/2472970) -
+
+[46. 赛博包工头来了，CAO上岗实测：组建团队4分钟，翻车一整天](https://m.36kr.com/p/3816272707280904) -
+
+[47. 11K+ star！免费部署私人ChatGPT的项目：LobeChat](https://zhuanlan.zhihu.com/p/672800267) -
+
+[48. LobeHub 开源协议调整为Apache 2.0](https://lobehub.com/zh/blog/lobe-chat-v1-license-update) -
+
+[49. 携手共创未来：思想科技Master Concept与LobeHub达成战... · LobeHub](https://lobehub.com/zh/blog/lobehub-and-master-concept-announce-partnership) -
+
+[50. 方案与定价 · LobeHub](https://lobehub.com/zh/pricing) -
+
+[51. Ant Design 再次出手！AIGC UI 组件发布！](https://www.51cto.com/article/823959.html) -
+
+[52. 原创两年磨一剑，Ant Design核心作者解答开发者关心问题](https://www.sohu.com/a/379316014_99940985) -
+
+[53. lobehub/lobe-chat-agents: 🤖 / 🏪 Agent Index - This is the agent index for ...](https://github.com/lobehub/lobe-chat-agents) -
+
+[54. 开源高性能聊天机器人框架LobeChat](https://xugaoxiang.com/2024/05/04/lobechat/) -

--- a/content/blog/lobehub-evolution/zh.md
+++ b/content/blog/lobehub-evolution/zh.md
@@ -1,0 +1,294 @@
+---
+title: "LobeHub：从开源聊天工具到首席Agent官的演进之路"
+description: "LobeHub 从 2023 年的开源聊天工具 LobeChat 起步，历经三次重大架构变革与两次品牌定位转型，最终发展为以「首席 Agent 运营官」（CAO）为核心的多智能体协作平台。本报告系统梳理其完整发展脉络、技术架构演进、商业模式探索与生态系统建设。"
+date: "2026-08-07"
+tags: ["ai-agent", "open-source", "research", "product"]
+---
+
+LobeHub的演进历程是人工智能应用开发领域一个极具代表性的转型案例。该项目从最初的单一聊天工具LobeChat起步，历经三次重大架构变革与两次品牌定位转型，最终发展为以"首席Agent运营官"（Chief Agent Operator，简称CAO）为核心的多智能体协作平台。截至2026年8月，LobeHub在GitHub平台已获得超过8.12万颗星标与1.58万次分支，其开源社区活跃度与产品迭代速度均处于行业领先地位。本报告将系统梳理LobeHub自2023年诞生以来的完整发展脉络，深入分析其从"开源ChatGPT客户端"到"Agent协作平台"再到"首席Agent运营官"的三阶段转型逻辑，探讨其技术架构演进、商业模式探索与生态系统建设的核心策略，为理解AI应用平台的发展规律提供参考样本。
+
+## 起源与创始背景
+
+### 创始人徐文彬的背景与理念
+
+LobeHub的创始人徐文彬（Arvin Xu）是蚂蚁集团前体验设计师，在加入蚂蚁集团之前，他已成为Ant Design核心成员。Ant Design是蚂蚁集团于2015年推出的企业级UI设计语言和React组件库，截至2020年已在GitHub收获超过5.7万颗星标，累计服务全球超过300万设计师与开发者。徐文彬在蚂蚁集团的工作经历（2021年4月至2025年5月）使其深入理解了企业级产品的设计方法论与技术架构原则，这为其后来创建LobeHub奠定了坚实基础。2025年5月，徐文彬正式创立LobeHub，从一名企业内部设计师转型为开源AI平台创业者。
+
+徐文彬在社交媒体平台X上的自我介绍为"Design Engineer / Founder of @LobeHub / core member of @AntDesignUI / ex AntGroup"，这一身份标签清晰地勾勒出其职业轨迹。他在2026年7月发布的一条推文中回顾道："我在Ant Design不仅系统地学到了设计、前端、人机交互的专业知识，更亲身体会到一个优秀的开源项目如何运作"。这种对开源文化的深刻理解直接影响了LobeHub的产品哲学——从诞生之初就坚持开源路线，并在后续发展中始终保持核心功能的开源属性。
+
+"LobeHub"这一品牌名称蕴含着创始人对AI应用层架构的深层思考。据徐文彬在X平台上的解释，"Lobe"在英文中指"脑叶"，即大脑的基本组织形式；"Hub"则意为枢纽或连结点。因此，"LobeHub"的寓意是在应用端（UI界面层）成为各种大语言模型（LLM）的连结枢纽。这一命名理念贯穿于产品的整个发展历程，从最初的单一模型聊天工具，逐步演变为支持多模型、多Agent、多模态的综合性AI平台。
+
+### LobeChat的诞生
+
+LobeChat项目诞生于2023年，正值大语言模型技术爆发期。根据技术文档记录，LobeChat是一个基于Next.js框架构建的AI会话应用，旨在提供一个AI生产力平台，使用户能够与AI进行自然语言交互。项目最初的定位非常明确：成为一个"开源、现代设计的ChatGPT/LLMs用户界面/框架"，支持语音合成、多模态交互以及可扩展的插件系统。
+
+2023年12月，知乎平台上已经出现了关于LobeChat的详细介绍文章，称其GitHub星标数已突破1.1万，并强调其作为"免费部署私人ChatGPT"的解决方案。这表明项目在推出后的短时间内就获得了开发者社区的广泛关注。LobeChat早期的核心卖点包括：支持多种AI提供商（如OpenAI、Claude 3、Gemini等）、提供语音合成功能（Text-to-Speech）、支持多模态输入（文字、图片、音频）以及可扩展的函数调用插件系统。
+
+项目的开源属性是其快速获得市场认可的关键因素。LobeChat采用MIT许可证发布，任何开发者都可以免费下载、修改和部署。这种开放性吸引了大量个人开发者和企业用户，他们不仅可以自托管LobeChat来构建私有AI聊天应用，还可以基于其代码进行二次开发。据技术博客记录，LobeChat支持一键部署到Vercel、Zeabur、Sealos、阿里云等平台，仅需准备OpenAI API Key即可在几分钟内完成部署。
+
+## 0.x时代：本地优先的探索（2023-2024年初）
+
+### 架构设计理念
+
+在LobeChat 0.x版本中，开发团队秉持"如无必要，勿添实体"（If not necessary, do not add entities）的原则，采用了一种无服务端数据库的Local First实现方案。这一设计决策基于三个核心考量：首先，响应速度，本地存储消除了网络延迟，使得交互更加即时；其次，数据隐私，用户数据存储在本地浏览器中，无需担心云端泄露风险；最后，部署简单，无需配置数据库即可快速启动。
+
+然而，这种架构也存在明显的局限性。由于数据和状态绑定单个浏览器，无法实现跨设备消息同步、知识库/文档会话、高质量体验分享、运行定时任务或助手主动发送消息等功能。这些限制在0.x时代后期逐渐成为用户反馈的主要痛点，也为后续的架构转型埋下了伏笔。
+
+0.x版本的另一个重要特点是采用了React Server Components（RSC）架构。RSC是Next.js框架引入的一种服务端渲染技术，旨在提升首屏加载性能和SEO效果。但在LobeChat的实际应用场景中，高频交互特性使得轻量级操作也会触发服务器往返请求，带来无法根除的网络延迟与微卡顿。这一问题在后续版本中被团队正式承认，并成为2.0重构的重要动因。
+
+### 功能演进与社区建设
+
+尽管架构存在局限，0.x时代的LobeChat在功能层面持续迭代，逐步构建起丰富的产品特性。项目早期就确立了多模型支持策略，兼容OpenAI、Anthropic Claude、Google Gemini、Mistral、LLaMA2等主流大语言模型。这种"模型无关"的设计理念使其能够与市场上各种LLM提供商对接，为用户提供更多选择。
+
+插件系统是0.x时代的另一大核心功能。LobeChat的插件生态系统基于函数调用（Function Call）机制构建，允许开发者创建各种扩展功能，如获取实时信息、搜索文档、与第三方服务交互等。据官方数据，截至2026年，LobeHub的Skills与MCP市集已连接超过1万个技能插件，Agent市场提供超过25.6万个开箱即用的Agents。这些插件极大地增强了平台的实用性和灵活性，使LobeChat从单纯的聊天工具进化为可执行复杂任务的AI助手平台。
+
+多模态交互能力也在0.x时代得到充分体现。LobeChat支持语音合成（Text-to-Speech，TTS）和语音转文字（Speech-to-Text，STT）技术，用户可以通过语音与AI进行自然对话。此外，平台还支持图像识别与生成，能够处理图片输入并调用文生图模型。这些功能使LobeChat在用户体验上超越了当时大多数开源聊天工具，更接近ChatGPT Plus的完整体验。
+
+社区建设方面，LobeHub团队在GitHub上积极维护项目，及时响应用户反馈。截至2024年12月，知乎上已有文章称LobeChat获得4.5万+ GitHub stars，表明项目在开源社区的影响力持续扩大。团队还通过Discord频道建立开发者社区，为用户提供技术支持和交流平台。
+
+## 1.0时代：云端架构转型（2024年）
+
+### 迈向1.0：架构变革的决策
+
+2024年3月28日，LobeHub团队正式发布博客文章《迈向LobeHub 1.0》，宣告即将进行重大架构升级。文章明确指出，0.x版本的Local First架构虽然具有响应迅速、数据隐私、部署简单等优势，但限制了产品能力上限，无法满足用户对跨端同步、知识库、定时任务等功能的需求。因此，1.0版本将引入服务端数据库支持，为下一阶段发展做好基础设施铺垫。
+
+这一决策标志着LobeHub从技术架构层面开始转型，从纯粹的客户端应用向云端服务演进。值得注意的是，团队强调"保持开源初心不变"，承诺所有核心功能仍将保持开源。这种"开源核心+云服务增值"的混合模式，既保证了社区的持续发展，也为后续商业化探索预留了空间。
+
+经过两个多月的开发，LobeChat 1.0于2024年6月19日正式发布。新版本带来了服务端数据库、用户鉴权管理的全新架构与特性，开启了新的可能性。在此基础上，LobeHub Cloud同步开启Beta版测试，为用户提供官方托管服务。
+
+### 开源协议调整与商业化探索
+
+伴随1.0版本的发布，LobeHub的开源协议也发生了重要变化。从1.0开始，开源协议从MIT许可证更新为Apache 2.0协议，并增加了一项商业化授权补充条款。这一变更带来了三方面影响：更强的专利保护、明确的贡献者责任、以及促进商业使用的灵活性。
+
+根据官方说明，协议变更对大部分用户没有影响。个人用户、团队内部使用、自行部署的场景仍然免费；在LobeHub上进行二次开发但不用于商业化的场景（如企业内部使用、提供公益服务）也保持免费；甚至直接使用原版LobeHub进行多租户商业化（如各类API中转站）也无需额外授权。只有当用户在LobeHub上进行二次开发并进行商业化（如隐去官方Logo、修改官方链接等）时，才需要向团队获取商业化授权。
+
+团队还宣布将尝试开放针对开源贡献者的"免费商业化授权计划"，提交符合质量要求的Pull Request即可免费获得商业化授权。这一机制既激励了社区贡献，又为项目建立了可持续的商业模式基础。
+
+### 知识库与市场生态
+
+1.0版本的另一重要里程碑是知识库功能的上线。2024年8月31日，LobeHub正式发布文件上传与知识库功能，带来全新的知识对话体验。知识库2.0支持接入Notion、Google Drive、飞书文档、语雀等第三方数据源，打破了与用户现有知识体系的壁垒。基于RAG（检索增强生成）技术，大模型在生成回答前会先从知识库中检索相关内容，显著提升了回答的准确性和相关性。
+
+与此同时，LobeHub开始构建Agent市场生态。开发者可以发布具备特定能力的Agent并在LobeHub服务端运行，构建繁荣的Agent生态。截至2026年，Agent市场已提供超过25.6万个开箱即用的Agents，涵盖写作、问答、图像、视频、语音和工作流等多个领域。这种"平台+生态"的模式使LobeHub从单一产品进化为AI应用开发的基础设施。
+
+## 品牌升级与2.0重构（2025-2026年）
+
+### 从LobeChat到LobeHub：品牌重塑
+
+2025年11月3日，LobeHub创始人徐文彬在GitHub Discussion中发布长文《Starting 2.0 of LobeHub(LobeChat): A System Reconstruction and Reflection》，正式宣布产品将从"LobeChat"升级为"LobeHub"。这一品牌重塑不仅是名称变更，更代表着产品定位的根本转变——从"开源的ChatGPT客户端"转向"Agent协作平台"。
+
+根据官方解释，"下一代AI应用将演变为连接用户、多元化Agent、海量知识与外部服务的'枢纽'，打造开放、模块化、可扩展的AI生态平台"。在新的产品语境下，Agent不再是辅助工具，而是LobeHub中最小的工作单元。用户可以创建由多个专用Agent组成的团队，分工协作完成复杂任务。
+
+2026年，项目完成品牌升级的实际迁移，GitHub仓库从lobehub/lobe-chat迁移至lobehub/lobehub。官方对LobeHub的描述更新为"一个工作与生活空间，用于发现、构建并与会随着您一起成长的Agent队友协作"。这一定位将AI助手从"工具"提升为"队友"，强调了长期协作与共同成长的价值主张。
+
+### 架构根本变革：以Server为核心
+
+2.0重构的核心是架构的根本性变革。回顾三个阶段的架构演进：0.x时代是纯粹的客户端形态，数据和状态绑定单个浏览器，无法持久化与跨设备同步；1.x时代是混合架构的探索与妥协，浏览器、服务端、桌面端并存，造成产品体验割裂与技术架构复杂化；2.0则转向以Server为核心，将所有Agent的状态、记忆、知识库以及任务执行统一到服务端执行，采用异步架构实现人与AI高效协作。
+
+另一个重大技术决策是全面回归SPA（Single Page Application，单页应用）架构。团队在反思中指出，0.x时期引入的RSC（React Server Components）架构在LobeChat的高频交互场景中表现不佳，轻量级操作也会触发服务器往返请求，带来无法根除的网络延迟与微卡顿。因此，2.0版本基于长期实践与技术产品关系的深度反思，决定全面回归SPA架构，以提升用户体验的流畅度。
+
+2.0版本还引入了多项核心功能支柱：Agent Runtime为Agent设计的全新运行时，赋予Agent强大的工具调用能力；AI团队（AI Team）支持创建由多个专用Agent组成的协作团队；个人记忆与Agent记忆系统动态捕捉用户偏好，实现个性化体验；桌面端正式版与移动端App的发布实现了全平台体验闭环。
+
+### 市场定位与竞争格局
+
+品牌升级后的LobeHub面临着新的市场竞争格局。2026年，AI Agent领域涌现出OpenClaw、Manus等强劲竞争对手。LobeHub通过差异化定位寻求突破：与OpenClaw相比，LobeHub强调开源、可自托管、支持多设备同步，且在使用自配置模型时完全免费；与Manus相比，LobeHub突出Agent团队协作能力、Skills与MCP市集生态、以及更广泛的开源社区支持。
+
+据技术评测文章分析，LobeHub的核心优势在于：多Agent协作网络让不同Agent之间实时沟通与分工；Deep Agents具备规划能力、文件系统、任务清单和Bash访问权限，可执行长程复杂任务；长期记忆系统基于语义记忆、情景记忆和程序记忆三类认知模型设计；与Ant Design的深厚渊源使其在UI/UX设计上保持高水准。
+
+## CAO时代：首席Agent官的创新（2026年5月）
+
+### CAO概念的推出
+
+2026年5月18日，LobeHub在X平台和GitHub同步发布重大更新，正式推出CAO（Chief Agent Operator，首席智能体运营官）功能。这是LobeHub发展历程中的第三次重大定位转型，标志着产品从"Agent协作平台"进化为"Agent运营管理平台"。
+
+根据官方描述，CAO是一种"会自己复盘、需要时能组建子智能体、只在需要你拍板时才停下来的智能体"。与传统聊天机器人需要用户逐步引导不同，CAO具备自主推进能力：它会复盘已完成的部分，决定下一步，并继续执行，不必每一步都等用户说"下一步"。当遇到真正需要用户决策的事项时，它会停下来告知已尝试的方案并提出清晰的问题。
+
+媒体评测将CAO比喻为"赛博包工头"，用户只需一句话描述需求，CAO就能自动创建多个Agent、设计Logo、命名群组，并组织Agent团队协作完成任务。每个Agent的Prompt、技能都可见可编辑，用户可以根据需要随时调整。这种"一键组建AI团队"的能力大幅降低了多Agent协作的使用门槛。
+
+### 技术实现与功能特性
+
+CAO的技术实现基于LobeHub 2.0的Server核心架构。任务较大时，CAO可以组建一支子智能体小队并分派工作，主智能体始终掌控整体节奏，用户可以随时打开任意子智能体的对话查看进展。这种层级化的任务调度机制使得复杂项目的管理变得有序可控。
+
+CAO的另一重要特性是支持7×24小时不间断运营。根据LobeHub官网的描述，平台"将你的Agent组织成7×24小时运作。它会为你的整个AI团队进行招聘、排班并生成报告。你始终掌控全局——无需一直在线"。这种"异步协作"模式突破了传统聊天工具需要实时交互的限制，使AI助手真正成为可独立工作的"数字员工"。
+
+2026年5月19日发布的更新日志详细列出了CAO版本的多项改进：项目技能进入工作侧栏并自带Markdown预览；按建议类型选择模型；聊天输入框的动作按钮调整为"图标+标签"样式；周期性任务更稳定，可限制总执行次数；桌面端不再因为后台刷新token而踢出登录等。这些细节优化体现了团队对用户体验的持续关注。
+
+### 市场反响与行业影响
+
+CAO功能的推出在开发者社区和媒体圈引发了广泛讨论。36氪于2026年5月19日发布的评测文章标题为《AI翻身做主管？CAO上岗实测：组队4分钟，翻车一整天》，生动描述了CAO的能力与局限。文章指出，虽然CAO在组建Agent团队方面表现出色，但在复杂任务的实际执行中仍存在稳定性问题。
+
+尽管如此，CAO概念的提出代表了AI应用发展的一个重要方向：从"使用AI"到"管理AI"的转变。正如技术博主所言，"LobeHub让你从'使用AI'变成'管理AI团队'，而且完全私有化，数据自己说了算"。这种"人机协同"的新范式，将人类角色从操作者提升为管理者，有望重塑未来的工作方式。
+
+截至2026年8月，LobeHub在GitHub已获得8.12万颗星标，被AWS、Google Cloud等云服务商列为典型案例。Product Hunt上的产品介绍将LobeHub定位为"Your Chief Agent Operator"，强调其作为人机协作系统的核心地位。
+
+## 商业化进程与生态构建
+
+### 定价策略与服务模式
+
+LobeHub的商业化采取"免费增值"（Freemium）模式，核心功能保持开源免费，高级功能和服务通过订阅收费。根据官方定价页面，LobeHub Cloud提供四档个人套餐：免费版（ $0/月）、基础版（$9.9/月）、高级版（ $19.9/月）和终极版（$39.9/月）。
+
+免费版每月提供50万计算积分，可支持DeepSeek V4 Pro约200条对话或Grok 4.5约100条对话，包含无限页面、图像生成、视频生成、Agent市场精选等功能。基础版每月提供500万积分，支持更多高级模型调用和Agent记忆功能。企业版则提供私有化部署、品牌主题、用户管理、自托管提供方、私有模型等定制化服务，需联系销售团队询价。
+
+LobeHub的计费体系基于Credits（计算积分）系统。每100万token的消耗根据模型不同折算为不同数量的Credits，如DeepSeek V4 Pro输入100万tokens消耗95.7万Credits，Claude Opus 5输入100万tokens则消耗500万Credits。这种精细化的计费方式使用户能够灵活控制成本。
+
+### 企业合作与云服务商集成
+
+LobeHub与多家云服务商建立了深度合作关系。2024年，亚马逊云科技（AWS）将LobeHub列为案例研究，介绍其如何利用AWS服务构建面向多智能体协作的AI平台。AWS案例研究指出，LobeHub的解决方案聚焦于多智能体的创建与协同，适用于企业级复杂任务处理场景。
+
+2024年7月，思想科技集团（Master Concept）与LobeHub宣布建立战略合作伙伴关系，成为LobeHub产品的金牌赞助商。思想科技是Google的白金级合作伙伴，服务超过3000家中国出海企业。双方合作内容包括：企业级定制和集成服务、半托管服务支持、以及Google Cloud Gemini API的专业技术支持。
+
+这些合作关系不仅为LobeHub带来了商业收入，也增强了其在企业级市场的可信度。通过与AWS、Google Cloud等主流云平台的集成，LobeHub能够为企业用户提供更稳定、安全、合规的服务。
+
+### 开源生态与社区治理
+
+LobeHub始终将开源作为核心战略。尽管推出了商业化云服务，但所有核心功能永久保持开源，用户仍可选择自托管模式免费使用。项目采用LobeHub Community License开源协议，这是基于Apache 2.0的定制协议，增加了商业化授权补充条款。
+
+团队在GitHub上积极维护多个开源项目，包括主仓库lobehub/lobehub、Agent索引仓库lobehub/lobe-chat-agents、插件SDK等。截至2026年，核心仓库已获得1.58万次分支（Fork）和1.26万次提交（Commits）。社区贡献者可以通过提交Pull Request参与项目开发，优秀贡献者还可获得免费商业化授权。
+
+LobeHub还维护着完善的开发者文档和博客体系，定期发布产品更新、技术文章和行业洞察。官方Discord社区和GitHub Discussion板块为开发者提供了交流协作的平台。这种开放透明的社区治理模式，使LobeHub能够持续吸引全球开发者参与生态建设。
+
+## 行业影响与未来展望
+
+### 对AI应用开发的启示
+
+LobeHub的发展历程为AI应用开发提供了多个层面的启示。首先，在架构设计层面，其从Local First到Server Core的演进反映了AI应用从"工具"到"平台"的必然转型。随着Agent能力的增强和任务复杂度的提升，客户端架构难以满足状态持久化、跨设备同步、团队协作等需求，云端架构成为大势所趋。
+
+其次，在产品定位层面，LobeHub的转型路径展示了AI应用从"聊天工具"到"协作平台"再到"运营系统"的演进逻辑。当单轮对话无法满足复杂任务需求时，多Agent协作成为自然选择；而当Agent数量增多、任务周期延长时，集中化的运营管理（CAO）又成为刚需。这种递进式的功能扩展，使产品能够持续为用户提供增量价值。
+
+第三，在商业模式层面，LobeHub的"开源核心+云服务增值"模式证明了开源项目商业化的可行性。通过保持核心功能开源，项目获得了广泛的用户基础和社区贡献；通过提供托管服务、企业定制等增值服务，项目实现了可持续的商业收入。这种模式既避免了开源项目的"用爱发电"困境，又维护了开源社区的健康发展。
+
+### 竞争格局与市场定位
+
+在AI Agent平台领域，LobeHub面临着来自OpenClaw、Manus、Claude Cowork等产品的竞争。与这些竞争对手相比，LobeHub的核心差异化优势在于：开源可自托管、支持多模型提供商、拥有丰富的Agent市场生态、以及与Ant Design一脉相承的优异用户体验。
+
+然而，LobeHub也面临着挑战。技术评测指出，相比OpenClaw的强大功能，LobeHub在复杂任务的稳定性方面仍有提升空间。此外，随着各大模型厂商（如OpenAI、Anthropic）推出官方Agent功能，LobeHub需要持续创新以保持差异化竞争力。
+
+从更长远的视角看，LobeHub定位的"首席Agent运营官"（CAO）概念代表了AI应用的一个重要发展方向。随着AI Agent能力的不断增强，人类用户的角色将从"操作者"转变为"管理者"，而能够高效协调、调度、监控AI团队的平台将成为关键基础设施。LobeHub在这一方向上的早期布局，有望为其赢得长期竞争优势。
+
+### 未来发展趋势
+
+基于LobeHub的发展轨迹和AI行业的整体趋势，可以预判其未来可能在以下方向持续演进。第一，Agent能力的进一步增强。随着底层大模型能力的提升和工具调用生态的完善，LobeHub的Agent将具备更强的规划、推理和执行能力，能够处理更复杂的长期任务。
+
+第二，多模态与具身智能的融合。目前LobeHub已支持文本、图像、语音等多种模态，未来可能进一步整合视频理解、代码执行、硬件控制等能力，使Agent能够与现实世界进行更丰富的交互。
+
+第三，企业级功能的深化。随着Workspace（团队空间）和API支持的完善，LobeHub将更深入地融入企业工作流，成为组织数字化基础设施的组成部分。与ERP、CRM、OA等企业系统的集成将成为重点发展方向。
+
+第四，开源生态的持续扩张。LobeHub已通过插件系统、Agent市场、Skills市集等构建了初步的开发者生态，未来可能进一步开放底层接口，吸引更多第三方开发者创建基于LobeHub的应用和服务。
+
+## 结论
+
+LobeHub从2023年的开源聊天工具LobeChat，历经0.x时代的本地优先探索、1.0时代的云端架构转型、2.0时代的品牌升级与Server Core重构，最终在2026年确立了"首席Agent运营官"（CAO）的核心定位，完成了从"聊天工具"到"Agent协作平台"再到"Agent运营管理平台"的三阶段演进。这一发展历程不仅是一个产品的迭代史，更是AI应用从"单轮对话"走向"长期协作"、从"人操作AI"走向"人管理AI团队"的缩影。
+
+技术架构的持续革新是LobeHub保持竞争力的基础。从Local First到Server Core的转变，从RSC到SPA的回归，体现了团队对技术选型与产品需求匹配的深刻反思。开源战略与商业模式的平衡使LobeHub能够兼顾社区影响力与可持续发展，其核心功能永久开源、增值服务收费的模式为开源AI项目提供了可借鉴的范例。
+
+在产品层面，LobeHub的演进逻辑清晰呈现了AI应用能力边界的扩展路径：先解决"能对话"的问题（0.x），再解决"能协作"的问题（1.x-2.0），最后解决"能管理"的问题（CAO）。每一次定位升级都伴随着用户角色的转变——从操作者到协作者，再到管理者——这种递进式的价值创造使产品能够持续吸引更广泛的用户群体。
+
+展望未来，随着AI Agent技术的成熟和企业数字化转型的深入，像LobeHub这样的Agent运营平台有望成为人机协作时代的关键基础设施。其"让AI能力大众化"的愿景，正在通过开源生态的建设和CAO模式的创新逐步成为现实。对于关注AI应用发展趋势的研究者和从业者而言，LobeHub的发展历程提供了丰富的观察样本和实践启示。
+
+## 参考资料
+
+[1. LobeHub - 你的首席Agent 运营官](https://lobehub.com/zh) -
+
+[2. LobeHub vs Manus：哪个AI Agent 平台更适合你？（2026）](https://lobehub.com/zh/blog/lobehub-vs-manus) -
+
+[3. Agent 助理市场](https://lobehub.com/zh/agent) -
+
+[4. 从“应用”到“平台”，亚马逊云科技赋能LobeHub，提升多智能体协作能力 ...](https://aws.amazon.com/cn/solutions/case-studies/lobehub/) -
+
+[5. LobeHub: Your Chief Agent Operator](https://www.producthunt.com/products/lobehub) -
+
+[6. GitHub 63.4K开源神器Lobe Chat能这么轻松构建你的私人AI聊天Agent](https://cloud.tencent.com/developer/article/2552901) -
+
+[7. AI-12-Lobe Chat 开源项目介绍](https://houbb.github.io/2024/02/20/ai-12-lobe-chat) -
+
+[8. Lobe Chat ： 一个开源、现代设计的LLM/AI 聊天框架](https://docs.feishu.cn/v/wiki/YASjwFqUCisMH4kLuKvcoZfwnhg/a1) -
+
+[9. 本地部署高颜值开源AI聊天工具LobeChat\_就念 - 魔乐社区](https://modelers.csdn.net/69a7b2467bbde9200b9d73c6.html) -
+
+[10. 架构设计](https://lobehub.com/zh/docs/development/basic/architecture) -
+
+[11. Lobe Chat - 免费开源的高性能AI聊天机器人框架](https://ai-bot.cn/lobe-chat/) -
+
+[12. LobeChat 聊天机器人框架](https://zhuanlan.zhihu.com/p/704343524) -
+
+[13. LobeHub | AI工具导航](https://www.aig123.com/sites/3106.html) -
+
+[14. LobeHub 智能AI聚合神器！ 内置ChatGPT、 Gemini Pro ...](https://www.youtube.com/watch?v=6MDLVd583oI\&vl=zh) -
+
+[15. 空谷Arvin Xu on X: "感觉是时候提一下我们的组织名为啥叫LobeHub 了。 ...](https://x.com/arvin17x/status/1819221250113503410?lang=zh) -
+
+[16. 用lobehub打造一个永久免费的AI个人助理 - 腾讯云](https://cloud.tencent.com/developer/article/2431275) -
+
+[17. LobeHub](https://docs.aihubmix.com/cn/clients/lobe-hub) -
+
+[18. LobeHub 智能AI聚合神器！ 内置ChatGPT、 Gemini Pro ...](https://www.youtube.com/watch?v=6MDLVd583oI\&vl=zh-Hant) -
+
+[19. LobeHub - AIHubMix](https://docs.aihubmix.com/cn/clients/lobe-hub) -
+
+[20. GitHub - lobehub/lobehub:  LobeHub is your Chief Agent Operator, organizing your agents into 7×24 operations by hiring, scheduling, and reporting on your entire AI team. · GitHub](https://github.com/lobehub/lobehub) -
+
+[21. About · LobeHub](https://lobehub.com/zh/about) -
+
+[22. 迈向 LobeHub 1.0 · LobeHub](https://lobehub.com/zh/blog/towards-lobe-chat-v1) -
+
+[23. 徐文彬- 设计工程师](https://cn.linkedin.com/in/arvinx/zh-cn) -
+
+[24. 基于LobeChat 构建企业内部LLM 知识库平台](https://aws.amazon.com/cn/blogs/china/building-an-internal-llm-knowledge-base-platform-based-on-lobechat/) -
+
+[25. 空谷Arvin Xu (@arvin17x) / Posts / X](https://x.com/arvin17x) -
+
+[26. 迈向LobeChat 1.0 #1768](https://github.com/lobehub/lobehub/discussions/1768) -
+
+[27. Towards LobeHub 1.0](https://lobehub.com/blog/towards-lobe-chat-v1) -
+
+[28. AI 可以取代运维了吗? - 东风微鸣](https://www.cnblogs.com/east4ming/p/19807710) -
+
+[29. 45k+ Star 超火项目！LobeChat：你的专属开源AI 助手！](https://zhuanlan.zhihu.com/p/11320533139) -
+
+[30. Starting 2.0 of LobeHub(LobeChat): A System Reconstruction and Reflection · lobehub/lobehub · Discussion #10007 · GitHub](https://github.com/lobehub/lobehub/discussions/10007) -
+
+[31. 产品 | 博客 · LobeHub](https://lobehub.com/zh/blog/category/product) -
+
+[32. AI翻身做主管？CAO上岗实测：组队4分钟，翻车一整天 - 知乎](https://zhuanlan.zhihu.com/p/2040204259023643495) -
+
+[33. LobeHub 1.0：新的架构与新的可能 · LobeHub](https://lobehub.com/zh/blog/release-lobe-chat-v1) -
+
+[34. 我在Ant Design 不仅系统地学到了设计、前端、人机交互的专业知识 ...](https://x.com/arvin17x/status/1938103843524632972) -
+
+[35. LobeHub - Your Chief Agent Operator](https://lobehub.com/) -
+
+[36. CAO：你的首席智能体运营官](https://lobehub.com/zh/changelog/2026-05-19-chief-agent-operator) -
+
+[37. AI翻身做主管？CAO上岗实测：组队4分钟，翻车一整天 - 腾讯新闻](https://view.inews.qq.com/k/20260519A09B2B00?scene=wap\&no-redirect=1) -
+
+[38. 开箱即用，简单上手，体验LobeChat搭建私人ChatGPT](https://www.cpolar.com/blog/out-of-the-box-easy-to-use-experience-lobechat-to-build-a-private-chatgpt) -
+
+[39. LobeChat下载和安装教程（附安装包）](https://c.biancheng.net/view/ilduff2.html) -
+
+[40. 知识库-大模型服务平台百炼(Model Studio) - 阿里云帮助文档](https://help.aliyun.com/zh/model-studio/rag-knowledge-base) -
+
+[41. Lobe Chat-21.3k Star开源LLMs 开发框架](https://zhuanlan.zhihu.com/p/685307878) -
+
+[42. 在OpenClaw大行其道的当下，LobeHub还能被用来作什么 - 知乎](https://zhuanlan.zhihu.com/p/2004515077370439540) -
+
+[43. CAO：你的首席智能体运营官 · LobeHub](https://lobehub.com/zh/changelog/2026-05-19-chief-agent-operator) -
+
+[44. lobe-chat/README.zh-CN.md at main](https://github.com/AIDotNet/lobe-chat/blob/main/README.zh-CN.md) -
+
+[45. 高颜值AI聊天应用LobeChat本地部署与远程多人访问使用详细 ...](https://cloud.tencent.com/developer/article/2472970) -
+
+[46. 赛博包工头来了，CAO上岗实测：组建团队4分钟，翻车一整天](https://m.36kr.com/p/3816272707280904) -
+
+[47. 11K+ star！免费部署私人ChatGPT的项目：LobeChat](https://zhuanlan.zhihu.com/p/672800267) -
+
+[48. LobeHub 开源协议调整为Apache 2.0](https://lobehub.com/zh/blog/lobe-chat-v1-license-update) -
+
+[49. 携手共创未来：思想科技Master Concept与LobeHub达成战... · LobeHub](https://lobehub.com/zh/blog/lobehub-and-master-concept-announce-partnership) -
+
+[50. 方案与定价 · LobeHub](https://lobehub.com/zh/pricing) -
+
+[51. Ant Design 再次出手！AIGC UI 组件发布！](https://www.51cto.com/article/823959.html) -
+
+[52. 原创两年磨一剑，Ant Design核心作者解答开发者关心问题](https://www.sohu.com/a/379316014_99940985) -
+
+[53. lobehub/lobe-chat-agents: 🤖 / 🏪 Agent Index - This is the agent index for ...](https://github.com/lobehub/lobe-chat-agents) -
+
+[54. 开源高性能聊天机器人框架LobeChat](https://xugaoxiang.com/2024/05/04/lobechat/) -


### PR DESCRIPTION
新研报：《LobeHub：从开源聊天工具到首席Agent官的演进之路》。

- `content/blog/lobehub-evolution/`（zh.md + en.md），纯内容，不动代码。
- 中文正文为作者原文，一字未改；标题按 blog 约定放进 frontmatter（页面模板自己渲染 H1，正文不留 H1）。
- 英文版为翻译，标题层级、54 条参考文献与全部 URL 与中文版逐条对齐。

合并后 `/blog/lobehub-evolution` 与 `/en/blog/lobehub-evolution` 上线并进 sitemap。

🤖 Generated with [Claude Code](https://claude.com/claude-code)