### PR TITLE
fix(worker): redrive parked project analysis runs via delayed retry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,9 @@ PROJECT_ANALYSIS_TIMEOUT_MS=900000
 PROJECT_ANALYSIS_MAX_CONCURRENCY=20
 # The Go worker reads GHFIND_PROJECT_ANALYSIS_CONCURRENCY first and falls back
 # to PROJECT_ANALYSIS_MAX_CONCURRENCY above; both clamp to [1,100]. Jobs beyond
-# the cap wait in the durable queue and are re-driven by the reconcile cron.
+# the cap wait in the durable queue; runs parked on slot contention or a
+# scheduled create retry are re-driven by the worker itself through the delayed
+# retry lane, with the internal reconcile endpoint as a manual backstop.
 # GHFIND_PROJECT_ANALYSIS_CONCURRENCY=3
 # Thread creation retries use exponential backoff and release their concurrency slot.
 PROJECT_ANALYSIS_CREATE_MAX_ATTEMPTS=3

--- a/docs/operations/go-backend-runbook.md
+++ b/docs/operations/go-backend-runbook.md
@@ -192,9 +192,10 @@ The backend also serves the project-analysis surface on staging:
 `POST /api/project-analyses` (submit a repository), `GET
 /api/project-analyses/{id}` (live status/result), `GET /api/project-boards`
 (treasure/classic boards), and the secret-authenticated
-`/api/internal/project-analyses/reconcile` (re-enqueue stalled runs). The
-worker consumes a dedicated `ghfind.project-analysis.v1` queue lane
-(`GHFIND_PROJECT_ANALYSIS_CONCURRENCY`, default 3) and drives the Mosoo
+`/api/internal/project-analyses/reconcile` (manual backstop that re-enqueues
+stalled runs; parked runs re-drive themselves through the delayed retry lane).
+The worker consumes a dedicated `ghfind.project-analysis.v1` queue lane
+(`GHFIND_PROJECT_ANALYSIS_CONCURRENCY`, default 20) and drives the Mosoo
 agent end to end. Without Mosoo credentials submissions still queue and fail
 with the standard `mosoo_*` error codes.
 

--- a/internal/backend/project_analysis_worker.go
+++ b/internal/backend/project_analysis_worker.go
@@ -28,6 +28,11 @@ const (
 	// projectAnalysisDeliveryBuffer keeps the per-delivery context alive past
 	// the run timeout so one last finalize pass can finish.
 	projectAnalysisDeliveryBuffer = time.Minute
+	// projectAnalysisDeferredRedriveDelay is the wake-up interval for a run
+	// parked by slot contention: the delayed retry lane re-enqueues the job
+	// until an execution slot frees. Runs parked on a scheduled create retry
+	// instead wake at their exact retry time.
+	projectAnalysisDeferredRedriveDelay = 15 * time.Second
 )
 
 var mosooRunRetrySuffix = regexp.MustCompile(`-retry-(\d+)$`)
@@ -210,7 +215,7 @@ func (w *ProjectAnalysisWorker) process(ctx context.Context, job ProjectAnalysis
 		var disposition workerDisposition
 		var reason string
 		if run.MosooThreadID == nil {
-			disposition, reason, run = w.createOrResumeThread(ctx, run, startedAt)
+			disposition, reason, run = w.createOrResumeThread(ctx, job, run, startedAt)
 		} else {
 			disposition, reason, run = w.pollThread(ctx, run, startedAt)
 		}
@@ -247,8 +252,10 @@ func (w *ProjectAnalysisWorker) failRun(ctx context.Context, analysisID, code, m
 // createOrResumeThread mirrors createOrResumeMosooThread. It returns a
 // completed disposition (with an empty reason) whenever the loop should
 // continue with the returned run, and a parked marker when the delivery is
-// done because the run waits on a slot or a scheduled create retry.
-func (w *ProjectAnalysisWorker) createOrResumeThread(ctx context.Context, run *ProjectAnalysisRun, startedAt time.Time) (workerDisposition, string, *ProjectAnalysisRun) {
+// done because the run waits on a slot or a scheduled create retry. Parked
+// runs are re-driven through the delayed retry lane (see redriveDeferred), so
+// they no longer depend on the external reconcile endpoint to wake up.
+func (w *ProjectAnalysisWorker) createOrResumeThread(ctx context.Context, job ProjectAnalysisJob, run *ProjectAnalysisRun, startedAt time.Time) (workerDisposition, string, *ProjectAnalysisRun) {
 	now := time.Now()
 	if run.MosooThreadID == nil && run.CreateAttempts >= w.config.ProjectAnalysisCreateMaxAttempts &&
 		(run.CreateRetryAt == nil || *run.CreateRetryAt <= now.UnixMilli()) {
@@ -265,10 +272,12 @@ func (w *ProjectAnalysisWorker) createOrResumeThread(ctx context.Context, run *P
 		return workerRetry, "reserve execution slot: " + err.Error(), run
 	}
 	if !reserved {
-		// Slot contention or a pending create retry: park the delivery. The
-		// scheduled reconcile re-enqueues the run when it becomes due.
-		w.metrics.recordWorkerJobCompleted(ProjectAnalysisJobKind, "deferred", time.Since(startedAt))
-		return workerCompleted, "deferred", w.reloadRun(ctx, run)
+		// Slot contention or a pending create retry: park the delivery and
+		// republish the job through the delayed retry lane so the run wakes up
+		// on its own. The reconcile endpoint remains a manual backstop.
+		current := w.reloadRun(ctx, run)
+		disposition, reason := w.redriveDeferred(ctx, job, deferredRedriveDelayFor(current), startedAt)
+		return disposition, reason, current
 	}
 	attemptRun := w.reloadRun(ctx, run)
 	snapshot, err := w.mosoo.CreateProjectAnalysisThread(ctx, attemptRun, w.config.ProjectAnalysisExecutionMode(attemptRun.RepoKey))
@@ -295,8 +304,8 @@ func (w *ProjectAnalysisWorker) createOrResumeThread(ctx context.Context, run *P
 			w.log.Warn("project_analysis.create_retry_scheduled",
 				"analysis_id", pending.ID, "repo_key", pending.RepoKey,
 				"attempt", pending.CreateAttempts, "error_code", mosooErr.Code)
-			w.metrics.recordWorkerJobCompleted(ProjectAnalysisJobKind, "deferred", time.Since(startedAt))
-			return workerCompleted, "deferred", pending
+			disposition, reason := w.redriveDeferred(ctx, job, time.Until(time.UnixMilli(retryAt)), startedAt)
+			return disposition, reason, pending
 		}
 		code := MosooUnavailable
 		message := "Mosoo project analysis failed."
@@ -345,6 +354,39 @@ func (w *ProjectAnalysisWorker) createRetryDelay(attempt int, err *MosooError) t
 		return time.Minute
 	}
 	return delay
+}
+
+// deferredRedriveDelayFor picks the wake-up delay for a parked run: a pending
+// create retry wakes at its scheduled time, while slot contention polls on a
+// fixed interval until an execution slot frees.
+func deferredRedriveDelayFor(run *ProjectAnalysisRun) time.Duration {
+	if run != nil && run.CreateRetryAt != nil {
+		if delay := time.Until(time.UnixMilli(*run.CreateRetryAt)); delay > 0 {
+			return delay
+		}
+	}
+	return projectAnalysisDeferredRedriveDelay
+}
+
+// redriveDeferred republishes a parked job through the delayed retry lane so
+// the run is re-driven without the external reconcile endpoint. The attempt
+// counter is preserved on purpose: parking is waiting, not a failure, so it
+// must not consume the MaxAttempts budget or dead-letter the job. A publish
+// failure falls back to the ordinary workerRetry path.
+func (w *ProjectAnalysisWorker) redriveDeferred(ctx context.Context, job ProjectAnalysisJob, delay time.Duration, startedAt time.Time) (workerDisposition, string) {
+	if delay < time.Second {
+		delay = time.Second
+	}
+	publishCtx, cancel := context.WithTimeout(ctx, workerDeliveryTimeout)
+	err := w.publisher.PublishProjectAnalysisRetry(publishCtx, job, delay)
+	cancel()
+	if err != nil {
+		w.log.Error("redrive deferred project analysis", "job_id", job.ID, "error", err)
+		w.metrics.recordWorkerJobRetry(ProjectAnalysisJobKind, time.Since(startedAt))
+		return workerRetry, "redrive deferred project analysis: " + err.Error()
+	}
+	w.metrics.recordWorkerJobCompleted(ProjectAnalysisJobKind, "deferred", time.Since(startedAt))
+	return workerCompleted, "deferred"
 }
 
 // pollThread mirrors the snapshot-driven half of reconcileProjectAnalysis.

--- a/internal/backend/project_analysis_worker_test.go
+++ b/internal/backend/project_analysis_worker_test.go
@@ -11,6 +11,41 @@ import (
 	"time"
 )
 
+// recordingProjectPublisher captures project analysis publishes for
+// assertions; it never touches a broker.
+type recordingProjectPublisher struct {
+	mu        sync.Mutex
+	published []string
+	retries   []recordedProjectRetry
+	dead      []string
+}
+
+type recordedProjectRetry struct {
+	job   ProjectAnalysisJob
+	delay time.Duration
+}
+
+func (p *recordingProjectPublisher) PublishProjectAnalysis(_ context.Context, job ProjectAnalysisJob) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.published = append(p.published, job.ID)
+	return nil
+}
+
+func (p *recordingProjectPublisher) PublishProjectAnalysisRetry(_ context.Context, job ProjectAnalysisJob, delay time.Duration) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.retries = append(p.retries, recordedProjectRetry{job: job, delay: delay})
+	return nil
+}
+
+func (p *recordingProjectPublisher) PublishProjectAnalysisDead(_ context.Context, job ProjectAnalysisJob, reason string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.dead = append(p.dead, job.ID+":"+reason)
+	return nil
+}
+
 // fakeMosoo is a scripted Mosoo Public Thread API server. Each GET on a
 // thread pops the next scripted run snapshot (the last one repeats), which
 // lets one test walk a run from boot to completion.
@@ -166,7 +201,7 @@ func validWorkerArtifacts(t *testing.T, analysisID, repoKey string) map[string]s
 	}
 }
 
-func newTestProjectAnalysisWorker(t *testing.T, store *TursoStore, mosooURL string, mutate func(*Config)) *ProjectAnalysisWorker {
+func newTestProjectAnalysisWorker(t *testing.T, store *TursoStore, mosooURL string, mutate func(*Config)) (*ProjectAnalysisWorker, *recordingProjectPublisher) {
 	t.Helper()
 	config := Config{
 		MosooAPIBase:                     mosooURL,
@@ -182,9 +217,10 @@ func newTestProjectAnalysisWorker(t *testing.T, store *TursoStore, mosooURL stri
 	if mutate != nil {
 		mutate(&config)
 	}
-	worker := NewProjectAnalysisWorker(config, store, NewMosooClient(config), nil, nil, nil)
+	publisher := &recordingProjectPublisher{}
+	worker := NewProjectAnalysisWorker(config, store, NewMosooClient(config), nil, publisher, nil)
 	worker.poll = time.Millisecond
-	return worker
+	return worker, publisher
 }
 
 func TestProjectAnalysisWorkerCompletesRun(t *testing.T) {
@@ -205,7 +241,7 @@ func TestProjectAnalysisWorkerCompletesRun(t *testing.T) {
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
 
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, nil)
+	worker, _ := newTestProjectAnalysisWorker(t, store, server.URL, nil)
 	disposition, reason := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
 	if disposition != workerCompleted || reason != "" {
 		t.Fatalf("disposition = %v reason = %q", disposition, reason)
@@ -263,7 +299,7 @@ func TestProjectAnalysisWorkerUsesAllowlistedRuntimeMode(t *testing.T) {
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
 
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, func(config *Config) {
+	worker, _ := newTestProjectAnalysisWorker(t, store, server.URL, func(config *Config) {
 		config.ProjectAnalysisRuntimeAllowlist = []string{"owner/useful-tool"}
 	})
 	disposition, _ := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
@@ -295,7 +331,7 @@ func TestProjectAnalysisWorkerCreateRetryBackoffAndExhaustion(t *testing.T) {
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
 
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, func(config *Config) {
+	worker, publisher := newTestProjectAnalysisWorker(t, store, server.URL, func(config *Config) {
 		config.ProjectAnalysisCreateMaxAttempts = 2
 		config.ProjectAnalysisCreateRetryBase = time.Second
 	})
@@ -313,6 +349,19 @@ func TestProjectAnalysisWorkerCreateRetryBackoffAndExhaustion(t *testing.T) {
 	}
 	if *run.CreateRetryAt <= time.Now().UnixMilli() {
 		t.Fatalf("create retry is not in the future: %d", *run.CreateRetryAt)
+	}
+	// The parked delivery redrives itself through the delayed retry lane,
+	// waking at the scheduled retry time without consuming the job's attempt
+	// budget.
+	if len(publisher.retries) != 1 {
+		t.Fatalf("redrives = %#v", publisher.retries)
+	}
+	redrive := publisher.retries[0]
+	if redrive.job.ID != "analysis-1" || redrive.job.Attempt != 0 {
+		t.Fatalf("redrive job = %#v", redrive.job)
+	}
+	if redrive.delay <= 0 || redrive.delay > time.Second {
+		t.Fatalf("redrive delay = %v", redrive.delay)
 	}
 
 	// Fast-forward the scheduled backoff: the next pass reclaims the slot and
@@ -337,6 +386,59 @@ func TestProjectAnalysisWorkerCreateRetryBackoffAndExhaustion(t *testing.T) {
 	}
 	if mosoo.createCalls != 2 {
 		t.Fatalf("create calls = %d", mosoo.createCalls)
+	}
+	// Exhaustion is terminal: no further redrive is published.
+	if len(publisher.retries) != 1 {
+		t.Fatalf("redrives after exhaustion = %#v", publisher.retries)
+	}
+}
+
+func TestProjectAnalysisWorkerRedrivesSlotContentionPark(t *testing.T) {
+	store := openProjectAnalysisTestStore(t)
+	// Occupy every execution slot with a running analysis.
+	for _, id := range []string{"busy-1", "busy-2", "busy-3"} {
+		createTestRun(t, store, id, "owner/"+id, nil)
+		if err := store.AttachMosooThread(context.Background(), AttachMosooThreadInput{
+			AnalysisID: id, AgentID: "agent-1", ThreadID: "thread-" + id, RunID: "run-" + id,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	createTestRun(t, store, "analysis-1", "owner/useful-tool", nil)
+
+	mosoo := newFakeMosoo(t)
+	server := httptest.NewServer(mosoo.handler())
+	defer server.Close()
+
+	worker, publisher := newTestProjectAnalysisWorker(t, store, server.URL, nil)
+	disposition, reason := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
+	if disposition != workerCompleted || reason != "deferred" {
+		t.Fatalf("disposition = %v reason = %q", disposition, reason)
+	}
+	// The run could not reserve a slot, so the delivery parks and republishes
+	// the job on the fixed redrive interval instead of waiting for the
+	// reconcile endpoint.
+	if len(publisher.retries) != 1 {
+		t.Fatalf("redrives = %#v", publisher.retries)
+	}
+	redrive := publisher.retries[0]
+	if redrive.job.ID != "analysis-1" || redrive.job.Attempt != 0 {
+		t.Fatalf("redrive job = %#v", redrive.job)
+	}
+	if redrive.delay != projectAnalysisDeferredRedriveDelay {
+		t.Fatalf("redrive delay = %v", redrive.delay)
+	}
+	// The parked run is untouched: still queued, no create attempt consumed,
+	// and Mosoo was never called.
+	run, err := store.GetProjectAnalysisRun(context.Background(), "analysis-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != ProjectAnalysisStatusQueued || run.CreateAttempts != 0 {
+		t.Fatalf("run = status %q attempts %d", run.Status, run.CreateAttempts)
+	}
+	if mosoo.createCalls != 0 {
+		t.Fatalf("mosoo create calls = %d", mosoo.createCalls)
 	}
 }
 
@@ -367,7 +469,7 @@ func TestProjectAnalysisWorkerRetriesInactiveRuntimeOnce(t *testing.T) {
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
 
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, nil)
+	worker, _ := newTestProjectAnalysisWorker(t, store, server.URL, nil)
 	disposition, _ := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
 	if disposition != workerCompleted {
 		t.Fatalf("disposition = %v", disposition)
@@ -406,7 +508,7 @@ func TestProjectAnalysisWorkerExpiresTimedOutRun(t *testing.T) {
 	mosoo := newFakeMosoo(t)
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, nil)
+	worker, _ := newTestProjectAnalysisWorker(t, store, server.URL, nil)
 	disposition, _ := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
 	if disposition != workerCompleted {
 		t.Fatalf("disposition = %v", disposition)
@@ -444,7 +546,7 @@ func TestProjectAnalysisWorkerFailsInvalidArtifacts(t *testing.T) {
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
 
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, nil)
+	worker, _ := newTestProjectAnalysisWorker(t, store, server.URL, nil)
 	disposition, _ := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
 	if disposition != workerCompleted {
 		t.Fatalf("disposition = %v", disposition)
@@ -473,7 +575,7 @@ func TestProjectAnalysisWorkerFailsWaitingInput(t *testing.T) {
 	}
 	server := httptest.NewServer(mosoo.handler())
 	defer server.Close()
-	worker := newTestProjectAnalysisWorker(t, store, server.URL, nil)
+	worker, _ := newTestProjectAnalysisWorker(t, store, server.URL, nil)
 	disposition, _ := worker.process(context.Background(), ProjectAnalysisJob{ID: "analysis-1"})
 	if disposition != workerCompleted {
 		t.Fatalf("disposition = %v", disposition)


### PR DESCRIPTION
## Problem

When the project-analysis worker cannot start a run immediately, it parks the delivery: the RabbitMQ message is acked and the run waits in Turso for something to re-enqueue it. That "something" was designed to be the internal reconcile endpoint (`.env.example` said jobs are "re-driven by the reconcile cron") — **but no such cron exists**: no Vercel cron (no vercel.json), no scheduled GitHub workflow, no Railway `cronSchedule`, no ticker in the Go services, and no startup recovery scan in the worker.

Two park paths are affected, both in `createOrResumeThread`:

1. **Execution-slot contention** (`ReserveProjectAnalysisExecutionSlot` returns false): the run stays `queued` forever.
2. **Scheduled Mosoo create retry** (`ScheduleProjectAnalysisCreateRetry`): the run stays `creating_thread`/`queued` with `create_retry_at` in the past, forever — it never even hits the 15-minute analysis timeout, because the timeout check only runs inside a live worker delivery.

The cascade that makes this a full stall rather than a leak: parked `creating_thread` runs still count toward the DB execution-slot cap. During a Mosoo outage, create failures park runs until all slots are held by parked runs; new submissions then park on slot contention too; when Mosoo recovers, nothing wakes anyone up until a human calls reconcile.

## Fix

Republish the parked job through the **existing delayed retry lane** (`PublishProjectAnalysisRetry`, per-message TTL dead-lettered back to the jobs exchange — the same mechanism `workerRetry` already uses):

- Runs parked on a **scheduled create retry** wake at their exact `create_retry_at` time.
- Runs parked on **slot contention** are republished on a fixed 15s interval (±5s jitter, so runs parked in the same window do not wake in lockstep and race the slot check) until a slot frees.
- The job's `Attempt` counter is **preserved**: parking is waiting, not a failure, so it never consumes the `MaxAttempts` budget or dead-letters the job. A redrive publish failure falls back to the ordinary `workerRetry` path.
- The reconcile endpoint remains as a manual backstop.

Behavioral side effect (intended): parked runs now also reach the existing terminal conditions — a run stuck in create retries will hit `analysis_timeout` expiry instead of becoming an invisible zombie.

## Scope notes

- Go worker only. The legacy TypeScript inline service (`src/lib/project-analysis-service.ts`) has the same park-without-redrive shape, but production routes `/api/project-analyses*` and `/api/internal/*` to the Go backend, and the TS path has no broker to republish to; left unchanged.
- Duplicate-delivery window is unchanged in kind: a manual reconcile racing a delayed redrive can attach a second poller to the same run, which the existing conditional DB transitions (`AttachMosooThread` / `FinalizeProjectAnalysis`) already tolerate.
- Also corrected the runbook's stale `default 3` for `GHFIND_PROJECT_ANALYSIS_CONCURRENCY` (code default is 20).

## Validation

- `go test ./...` — full suite passes.
- New test `TestProjectAnalysisWorkerRedrivesSlotContentionPark`: with all execution slots occupied, a fresh run parks, exactly one delayed redrive is published (delay = `projectAnalysisDeferredRedriveDelay`), the job attempt stays 0, no create attempt is consumed, and Mosoo is never called.
- Extended `TestProjectAnalysisWorkerCreateRetryBackoffAndExhaustion`: the first failed create parks with a redrive delayed to the scheduled retry time; after exhaustion the run fails with `mosoo_create_retry_exhausted` and no further redrive is published.
