### PR TITLE
fix(worker): jitter the slot-contention redrive interval

### DIFF
--- a/internal/backend/project_analysis_worker.go
+++ b/internal/backend/project_analysis_worker.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"regexp"
 	"strings"
@@ -33,6 +34,10 @@ const (
 	// until an execution slot frees. Runs parked on a scheduled create retry
 	// instead wake at their exact retry time.
 	projectAnalysisDeferredRedriveDelay = 15 * time.Second
+	// projectAnalysisDeferredRedriveJitter spreads the fixed redrive interval
+	// by ±5s so runs parked by the same event (e.g. a full slot window right
+	// after an outage) do not wake in lockstep and race the slot check.
+	projectAnalysisDeferredRedriveJitter = 5 * time.Second
 )
 
 var mosooRunRetrySuffix = regexp.MustCompile(`-retry-(\d+)$`)
@@ -358,14 +363,16 @@ func (w *ProjectAnalysisWorker) createRetryDelay(attempt int, err *MosooError) t
 
 // deferredRedriveDelayFor picks the wake-up delay for a parked run: a pending
 // create retry wakes at its scheduled time, while slot contention polls on a
-// fixed interval until an execution slot frees.
+// fixed jittered interval until an execution slot frees.
 func deferredRedriveDelayFor(run *ProjectAnalysisRun) time.Duration {
 	if run != nil && run.CreateRetryAt != nil {
 		if delay := time.Until(time.UnixMilli(*run.CreateRetryAt)); delay > 0 {
 			return delay
 		}
 	}
-	return projectAnalysisDeferredRedriveDelay
+	spread := int64(2 * projectAnalysisDeferredRedriveJitter)
+	jitter := time.Duration(rand.Int63n(spread)) - projectAnalysisDeferredRedriveJitter
+	return projectAnalysisDeferredRedriveDelay + jitter
 }
 
 // redriveDeferred republishes a parked job through the delayed retry lane so

--- a/internal/backend/project_analysis_worker_test.go
+++ b/internal/backend/project_analysis_worker_test.go
@@ -425,8 +425,10 @@ func TestProjectAnalysisWorkerRedrivesSlotContentionPark(t *testing.T) {
 	if redrive.job.ID != "analysis-1" || redrive.job.Attempt != 0 {
 		t.Fatalf("redrive job = %#v", redrive.job)
 	}
-	if redrive.delay != projectAnalysisDeferredRedriveDelay {
-		t.Fatalf("redrive delay = %v", redrive.delay)
+	low := projectAnalysisDeferredRedriveDelay - projectAnalysisDeferredRedriveJitter
+	high := projectAnalysisDeferredRedriveDelay + projectAnalysisDeferredRedriveJitter
+	if redrive.delay < low || redrive.delay >= high {
+		t.Fatalf("redrive delay = %v, want within [%v, %v)", redrive.delay, low, high)
 	}
 	// The parked run is untouched: still queued, no create attempt consumed,
 	// and Mosoo was never called.


### PR DESCRIPTION
Follow-up to #189 (merged before this commit landed on the branch).

## Problem

#189 redrives runs parked by execution-slot contention on a fixed 15s interval. Runs parked in the same slot-full window — e.g. a batch of submissions arriving together, or a queue of parked runs right after a Mosoo outage — share the same wake-up clock: they are all redelivered in the same second, race the `COUNT(*) < cap` slot check together, and the losers park again on the same synchronized schedule. A classic lockstep/thundering-herd pattern on the slot check.

## Fix

Spread the fixed interval by ±5s of jitter (uniform in [10s, 20s)) so concurrent waiters stagger their redeliveries. The added latency stays bounded well below the multi-minute runtime of a single analysis.

- Slot-contention parks: 15s ± 5s (this change).
- Scheduled create-retry parks: unchanged — they still wake at their exact `create_retry_at` time, which is already a per-run exponential backoff (5s→10s→20s, 1min cap, honors `Retry-After`).

## Validation

- `go test ./...` passes.
- `TestProjectAnalysisWorkerRedrivesSlotContentionPark` now asserts the redrive delay falls within [10s, 20s) instead of an exact 15s.
