### PR TITLE
feat(collections): 编辑推荐第一期——三种 Agent 形态 (zh/en)

### DIFF
--- a/content/collections/agents-heart-hands-body/en.md
+++ b/content/collections/agents-heart-hands-body/en.md
@@ -1,0 +1,147 @@
+> This is the first issue of our "Editor's Picks" column. We didn't want to put together a perfunctory list; we wanted to seriously engage with one question: when AI is no longer just a chat box that talks, what else can it be? For this issue, we picked three open-source projects that couldn't be more different in style, yet resonate deeply with one another — one that gives AI a "life," one that gives AI "hands," and one that gives AI a scalable "body."
+
+## Editor's note: why these three
+
+In 2026, the word "agent" has gone from buzzword to engineering reality. But when most people talk about agents, they're still asking "can it answer me better?" For this issue we want to flip the angle: **an agent shouldn't be a tool that's only summoned on demand — it should be an entity that persists, keeps operating, and even keeps living.**
+
+Following that thread, we picked three stars that happen to form a three-layer map of the agent, from the inside out:
+
+- **yuiju** (yixiaojiu/yuiju) — lets an AI character eat, attend school, take walks, and keep a diary in a world of her own, living a life that exists independently of the user. This is the agent's 「心」 ("heart").
+- **lathe** (initiated by samzong, now maintained under the lathe-cli organization) — turns existing APIs, in one shot, into CLI contracts and Skills that agents can safely call, giving agents 「手」 ("hands") that can operate real systems.
+- **mosoo** (langgenius/mosoo) — runs coding agents such as Codex, the Claude Agent SDK, and OpenCode at scale inside Cloudflare-native isolated sandboxes. This is the agent's 「身体」 ("body").
+
+A heart that knows how to live, a pair of hands that can do real work, a body that can actually run — each answers one fundamental question about "the next form of AI." Here is our deep dive.
+
+## 1. yuiju: not an AI assistant, but a "person" with a life of her own
+
+![Avatar of Yuu-chan, the yuiju character](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-avatar.webp "Figure: avatar of Yuu-chan, the yuiju project character, from the repo's packages/source/picture/ directory")
+
+### A one-line recommendation (from the author)
+
+Before we unpack it, let's quote the recommendation the project's author wrote for yuiju himself — we think it captures the soul of the project precisely:
+
+> yuiju is an AI companionship project built around simulating a character's life in a virtual world. By constructing a virtual world that runs continuously, it gives the character her own life trajectory, social relationships, and growth experiences, rather than merely holding conversations that revolve around the user. Drawing on game-design thinking, the project upgrades AI companionship from a "chat tool" into "a world you can experience over the long term," letting users enjoy exploration, nurturing, interaction, and growing together within that companionship.
+
+### What is it actually doing
+
+Mainstream AI companion products are, at their core, "user-centric persona engines": the character is on call around the clock, and every reply is generated on the spot from a fixed persona prompt. yuiju turns that logic completely upside down — **the world exists before the conversation does.**
+
+This is an LLM-driven "autonomous character life simulation" project, blending AI chat with "AI town" thinking. The character perceives time, weather, place, and her own state inside a continuously advancing virtual world; she makes her own decisions and carries out actions, leaving behind a traceable life trajectory, memories, diary entries, and plans. Users can talk to the character through messaging front ends like QQ and Feishu, but chat is only a window through which the user observes and steps into her life; her replies, her recent updates, and the things she shares on her own initiative all come from experiences that **actually happened** to her in the world — not from text improvised on the spot. The project's philosophy states it plainly: don't build an AI assistant, build a "person" with a life of her own.
+
+### Deep dive: what makes her come "alive"
+
+After reading through its technical documentation, we believe the most commendable thing about yuiju isn't the surface-level fact that "the character speaks up on her own," but the remarkably restrained engineering philosophy underneath:
+
+**First, the world engine advances by tick, not by conversation.** The core module `@yuiju/world` maintains two continuously running processes at once: world-state advancement (time, weather, scene availability, resource quantities — ticking at fixed intervals like a game engine) and character-behavior advancement (reading the character's state, the world state, and her history to compute the actions currently available to her). **Neither process depends on user messages** — even if no one talks to the character, the world keeps running and she keeps living. This is where the phrase "a world that runs continuously" lands in actual engineering.
+
+**Second, the LLM only makes "decisions"; it never "mutates state."** This is the cleverest trade-off in the whole system. "Life" is too continuous to be handed over to a large model for free-form improvisation. yuiju breaks complex behavior down into atomic Actions; the LLM only picks among the candidate Actions whose preconditions are met and returns a structured decision (which one, and why). The actual state changes are carried out by the Action execution logic and settled into behavioral records, which later feed memory, the diary, and message replies. In other words, the model is "the one who chooses on the road of life," while the system is "the ledger that records life as fact" — this both keeps the character's behavior from spinning out of control and makes every experience traceable and replayable.
+
+**Third, memory isn't a pile of chat logs; it's layered.** The message context isn't concatenated indefinitely: the system maintains recent raw messages, a rolling summary, and a natural conversation window at the same time, and the conversation window settles into Memory Episodes at appropriate boundaries, updating the character's memory in the process. The character can therefore "remember today" instead of re-introducing herself from scratch every time. The author also admits frankly in his blog that the memory module is still stored as JSON and self-updated by the LLM, and occasionally gets things wrong — that kind of honesty is exactly what's most moving about open-source projects.
+
+**Fourth, game-design thinking permeates everything.** A dynamic weather system keeps daily life from being a fixed script; the character can hold long-term and short-term plans rather than passively responding to whatever the user just typed; and when something worth telling happens in her life, she shares it at the right moment instead of forever waiting for you to speak first. The author himself describes the project as "an AI character system with state, actions, memory, and a rhythm of life" — the most concise definition of "virtual life" we've seen.
+
+![yuiju system architecture](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-architecture.png "Figure: yuiju system architecture — the @yuiju/world engine advances world state and character behavior in parallel, while the LLM only makes Action decisions")
+
+### Editor's take
+
+yuiju answers a question many AI companion projects dodge: **can an AI have a life of its own when you're not around?** It upgrades companionship from "you summon me" to "we each live our own lives and meet occasionally," grounding the emotional connection in genuinely shared experience rather than sweet talk generated on the fly. The project is still early, and pieces like the memory module are still being polished, but the direction it offers — using a game-engine-style deterministic framework to constrain and carry the LLM's freedom — is enormously valuable reference material for the entire AI-character field. If you love Animal Crossing, or love the feeling of nurturing and companionship, it's worth heading straight to its web page and experiencing it once (`yuiju-web.yixiaojiu.top`). To close, here's a Yuu-chan sticker, so you can get a feel for her little temper:
+
+![Yuu-chan sticker: hmph](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-hmph.png "Yuu-chan sticker: hmph")
+
+## 2. lathe: growing an agent's 「hands」 from your APIs in one shot
+
+![lathe logo](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-logo.png "Figure: the lathe project logo, from the repo's docs/images/ directory")
+
+### What it is
+
+lathe is an API-to-CLI generator built for agents: from Swagger 2.0, OpenAPI 3, protobuf with `google.api.http` annotations, or even a GraphQL schema, it generates a **single-binary, production-grade** Cobra CLI, complete with a structured command catalog and a generated Skill guide. The project was initiated by samzong, is now maintained under the lathe-cli organization, is MIT-licensed, and is still young — but iterating extremely fast.
+
+The author's motivation is plain, and rather touching — "plug the old world's existing systems directly into agents." Most teams don't lack APIs; they have piles of legacy APIs and no safe, reliable way to let AI operate them.
+
+### Core philosophy: the spec is the truth, the catalog is the contract
+
+lathe's entire design condenses into two sentences:
+
+1. **The API specification is the single source of truth.** You declare the pinned upstream spec (fixed by tag, resolved to a commit SHA, floating branches rejected), declare the CLI identity (`cli.yaml`) and module sources (`specs/sources.yaml`), and add overlays when needed to polish help text; when the API changes, just regenerate. Gone is the fate of "hand-write a CLI, then spend the rest of your life fighting drift."
+2. **The generated CLI isn't just a shell — it's a contract that agents can consume mechanically.** That's the essential difference between lathe and an ordinary API-wrapping tool.
+
+### Deep dive: a complete protocol designed so agents "never have to guess"
+
+Read its README and you'll find that lathe has decomposed "how an agent safely uses a CLI" with unusual care:
+
+- **Discovery**: `search "<intent>" --json` finds candidate commands by natural-language intent; `commands --json` outputs the full command catalog; `commands show <path>` shows a given command's flags, body, auth, HTTP method, and output hints — all as structured JSON.
+- **Preflight**: `auth status --hostname <host>` confirms credentials before calling a protected command; `--dry-run` prints the request that would be sent (with redacted headers and body) without actually sending it, letting the agent verify everything before execution.
+- **Execution**: `--file` / `--set` / `--set-str` construct request bodies, `-o table|json|yaml|raw` provides machine-readable output, and enum validation, pagination, and streaming are all covered.
+- **Generated Skill**: codegen writes out a `skills/<cli-name>/` directory by default — effectively an "agent operator's manual for this CLI" (how to discover commands, inspect the catalog, preflight auth, construct bodies, pick output formats) — and it can even be packed into the binary (`<cli> skill install`). The runtime catalog remains the source of truth; the Skill is the onboarding guide that teaches the agent how to use it.
+
+Three engineering details are also worth mentioning: all generated modules share **the same runtime** (auth, request construction, output, pagination, streaming, and error handling behave consistently); the **overlay layer** lets you hide/ignore commands, fix parameters, and add shortcut commands without touching the upstream spec or the generated Go code; and the two-stage pipeline (`specsync` fetches and pins the spec → `codegen` normalizes it into a unified IR and renders) guarantees reproducibility.
+
+![lathe architecture diagram](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-architecture.png "Figure: the lathe generation flow — spec pinned and synced → codegen normalizes and renders → CLI plus companion Skill generated")
+
+### Why now: the CLI is becoming the de facto interface for agents
+
+lathe is riding a very interesting industry wave. Vercel's CEO has said outright that "CLIs are the de-facto MCPs for agents," Perplexity's CTO and Y Combinator president Garry Tan have publicly backed the CLI route around the same time, and the Chinese community at one point went as far as chanting "MCP is dead." Meanwhile, vendors like Feishu maintain both a CLI and an MCP Server as open-source projects at the same time. At this crossroads of the "agent interface wars," lathe's choice is smart: **it doesn't argue over whether CLI or MCP wins — it turns "generate an agent-friendly CLI from an API" itself into an automated pipeline, and generates the companion Skill along with it.**
+
+### Editor's take
+
+lathe suits two kinds of people. The first is teams sitting on a pile of Swagger/OpenAPI/proto/GraphQL who want to plug their existing systems into agents — it's one of the tools that pushes the cost of "connecting the old world to the new" closest to zero. The second is developers who appreciate the engineering aesthetic of "one binary that humans can use and agents can safety-check." It turns "agents shouldn't have to guess" from a slogan into an executable six-step loop (search → inspect → preflight auth → dry-run → execute → structured output), and that is its most solid contribution.
+
+## 3. mosoo: giving coding agents a scalable 「body」 to run in
+
+![mosoo banner](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/mosoo-banner.png "Figure: the official mosoo banner (2400×1260), from the repo's docs/assets/ directory")
+
+### What it is
+
+mosoo is an open-source, Cloudflare-native **coding-agent runtime**: it runs coding agents such as OpenAI Codex, the Claude Agent SDK, and OpenCode inside mutually isolated AI-agent sandboxes behind an API endpoint, and provides execution records that can be inspected, replayed, and resumed. It comes from **LangGenius (the team behind Dify)** — the open-source LLM application platform — which determined its engineering orientation from day one: not a toy for hobbyists, but infrastructure for developers who want to integrate agents into their own products. Apache 2.0 licensed.
+
+### Which layer of pain it solves
+
+If you want to use coding agents in your own product, you usually hit the same wall: you have to maintain the agent runtime, the sandbox service, session storage, file pipelines, and the Agent API yourself — and every time you onboard a new agent harness (Codex, Claude, OpenCode...), you do it all over again. mosoo's positioning is to fold that whole block into a single **control plane**: your application belongs to you and owns the product behavior and the end-user experience; mosoo only handles agent execution and lifecycle. It positions itself with restraint — "app deployment is another Alpha surface, not part of the core product contract."
+
+### Deep dive: the agent goes from "one call" to "a persistent execution line"
+
+mosoo's five core capabilities map one-to-one onto every link needed to "productize an agent":
+
+- **Unified runtime and control plane**: three agent harnesses are normalized under the same runtime protocol, so you don't have to write three separate integrations for three tools.
+- **Agent API**: from a trusted backend, start / follow / continue / stop / archive / delete an agent's work — the agent's work becomes something you can orchestrate.
+- **Isolated AI-agent sandboxes**: stream back responses and tool activity, handle permission requests, cancel work, and inspect diagnostics inside an isolated execution environment — making "handing an agent to your users" safe and controllable.
+- **Durable work**: threads, runs, events, and managed files persist across multiple executions. This is its most essential idea: an agent isn't a one-shot call, but an execution line that can resume from where it stopped.
+- **Observability**: run status, replayable activity, diagnostics, usage estimates — operational visibility, not compliance auditing.
+
+The surrounding ecosystem already has its skeleton in place: `mosoo-agent-driver`, `mosoo-connector`, and an interesting `mosoo-skills` package (20 project-aware coding-agent skills, of which 16 are unmodified copies of public upstreams and 4 are maintained by mosoo and deliberately excluded from the sync manifest, so an upstream refresh can't wipe out project-specific guardrails). On the tech-stack side, it runs natively on Cloudflare Workers + D1 + R2, and can be self-hosted in your own account.
+
+### Risk warning (an honest note from the editors)
+
+Readers should be aware: **mosoo is currently in Alpha.** The official README states clearly that the hosted runtime and Agent API have been released and are covered by repo tests, but "production reliability and external adoption have not yet been validated," and the public API and product behavior may still change. It's therefore a good fit for developers willing to be early adopters and prototype agent productization; if you're planning to stake your production core path on it, be sure to evaluate the risks and isolate it properly first.
+
+### Editor's take
+
+mosoo's significance lies in turning "running coding agents" from a loose DIY assembly job into a deployable, observable, orchestrable piece of infrastructure. While the whole industry is debating "how to turn agents into products," the Dify team has drawn on its accumulated experience with LLM application platforms to offer a Cloudflare-native reference answer — isolated sandboxes, durable sessions, a unified API, resumable execution. For teams extending Codex / the Claude Agent SDK / OpenCode into their own products, it deserves a serious spot on the evaluation shortlist.
+
+## Summary: this issue at a glance
+
+| Project | What it gives the agent | Core philosophy | License/status | Who it's for |
+| --- | --- | --- | --- | --- |
+| **yuiju** | A 「heart」 that knows how to live — life trajectory, memory, plans | The world precedes the conversation; the LLM decides, the system keeps the ledger | Open source, early and growing | AI-companionship fans, product people and developers researching virtual life |
+| **lathe** | A pair of 「hands」 that can do real work — safely callable CLI contracts | The spec is the truth, the catalog is the contract | MIT, relatively mature | Teams with existing APIs to connect to agents, CLI and agent-tooling enthusiasts |
+| **mosoo** | A scalable 「body」 — sandboxes, API, durable execution | The agent goes from a call to a persistent execution line | Apache 2.0, Alpha | Developers turning coding agents into products |
+
+## Closing thoughts
+
+For this first issue, we put three seemingly unrelated stars on the same page to say one thing: **the next form of AI is probably not a smarter chat box, but an "entity" that can run, can work, and can live.** yuiju gave it a life, lathe gave it hands, mosoo gave it a body — they represent the three layers of experience, interface, and infrastructure, and the real product of the future will probably need all three at once.
+
+If you happen to be working on something similar, or have a deeper understanding of one of these projects, you're welcome to leave a comment and talk with us. Next issue, we'll dig into the theme of "agent memory" and unearth more open-source projects that deserve to be seen.
+
+**Quick-start and experience links**
+
+- yuiju: repo `github.com/yixiaojiu/yuiju`｜try it online `yuiju-web.yixiaojiu.top`｜author's blog `note.yixiaojiu.top/blog/yuiju`
+- lathe: repo `github.com/lathe-cli/lathe` (initiated by samzong)
+- mosoo: repo `github.com/langgenius/mosoo`｜cloud experience `cloud.mosoo.ai`｜official site `mosoo.ai`
+
+**Authors and teams**
+
+| Project | Author / team | GitHub |
+| --- | --- | --- |
+| yuiju | yixiaojiu (Yixiaojiu) | `github.com/yixiaojiu` |
+| lathe | samzong | `github.com/samzong` |
+| mosoo | LangGenius (the team behind Dify) | `github.com/langgenius` |

--- a/content/collections/agents-heart-hands-body/meta.json
+++ b/content/collections/agents-heart-hands-body/meta.json
@@ -1,0 +1,54 @@
+{
+  "type": "projects",
+  "title": {
+    "zh": "编辑推荐 · 第一期：当 AI 开始「生活」——三个开源项目，三种 Agent 的形态",
+    "en": "Editor's Picks Vol. 1: When AI Starts to \"Live\" — Three Open-Source Projects, Three Forms of the Agent"
+  },
+  "intro": {
+    "zh": "编辑推荐栏目第一期。我们挑选了三个风格迥异、却深层互文的开源项目：yuiju 让 AI 角色在自己的世界里吃饭、上学、写日记，拥有独立于用户的生活（Agent 的「心」）；lathe 把存量 API 一键变成 Agent 能安全调用的 CLI 契约与 Skill（Agent 的「手」）；mosoo 在 Cloudflare 原生沙箱里规模化运行 Codex、Claude Agent SDK、OpenCode（Agent 的「身体」）。",
+    "en": "The first issue of our Editor's Picks column. Three very different yet deeply connected open-source projects: yuiju gives an AI character a life of her own — meals, school, diaries — independent of the user (the agent's \"heart\"); lathe turns existing APIs into CLI contracts and Skills that agents can safely call (the agent's \"hands\"); mosoo runs Codex, Claude Agent SDK, and OpenCode at scale in Cloudflare-native sandboxes (the agent's \"body\")."
+  },
+  "publishedAt": "2026-08-07",
+  "tags": ["ai-agent", "editor-picks", "open-source"],
+  "items": [
+    {
+      "kind": "repo",
+      "id": "yixiaojiu/yuiju",
+      "blurb": {
+        "zh": "LLM 驱动的角色自主生活模拟：世界引擎按 tick 推进，不依赖用户消息；LLM 只做原子 Action 的决策，状态变化由系统记账。不做 AI 智能助手，做有自己生活的「人」——这是 Agent 的「心」。",
+        "en": "An LLM-driven autonomous life simulation: the world engine advances on ticks, independent of user messages; the LLM only picks among atomic Actions while the system records state. Not an AI assistant — a \"person\" with her own life. This is the agent's \"heart\"."
+      },
+      "stats": {
+        "stars": 43,
+        "language": "TypeScript",
+        "description": "Build AI companions that have their own lives"
+      }
+    },
+    {
+      "kind": "repo",
+      "id": "lathe-cli/lathe",
+      "blurb": {
+        "zh": "把 Swagger/OpenAPI/protobuf/GraphQL 一键生成单二进制、Agent 友好的 Cobra CLI：结构化命令目录、auth 预检、--dry-run、机器可读输出，外加一份生成的 Skill 操作手册。Spec 即真相，Catalog 即契约——这是 Agent 的「手」。",
+        "en": "Generates single-binary, agent-friendly Cobra CLIs from Swagger/OpenAPI/protobuf/GraphQL: structured command catalogs, auth preflight, --dry-run, machine-readable output, plus a generated Skill guide. Spec as truth, catalog as contract — these are the agent's \"hands\"."
+      },
+      "stats": {
+        "stars": 39,
+        "language": "Go",
+        "description": "Agentic-friendly CLI generator for APIs"
+      }
+    },
+    {
+      "kind": "repo",
+      "id": "langgenius/mosoo",
+      "blurb": {
+        "zh": "Dify 团队出品的 Cloudflare 原生 coding agent 运行时：统一运行时协议、Agent API、隔离沙箱、可断点续跑的持久执行线。把 Codex / Claude Agent SDK / OpenCode 产品化所需的基础设施——这是 Agent 的「身体」。（Alpha 阶段，生产使用需评估风险）",
+        "en": "A Cloudflare-native coding-agent runtime from the Dify team: unified runtime protocol, Agent API, isolated sandboxes, and durable runs you can resume. The infrastructure for productizing Codex / Claude Agent SDK / OpenCode — the agent's \"body\". (Alpha — assess risks before production use.)"
+      },
+      "stats": {
+        "stars": 114,
+        "language": "TypeScript",
+        "description": "Open-source, Cloudflare-native agent runtime for Codex, Claude Agent SDK, and OpenCode"
+      }
+    }
+  ]
+}

--- a/content/collections/agents-heart-hands-body/zh.md
+++ b/content/collections/agents-heart-hands-body/zh.md
@@ -1,0 +1,147 @@
+> 这是本站「编辑推荐」栏目的第一期。我们不打算做一份流水账式的清单，而是想认真聊聊一个问题：当 AI 不再只是一个会对话的对话框，它还可以是什么？这一期，我们挑选了三个风格迥异、却又在深层互文的开源项目——一个让 AI 拥有「生活」，一个让 AI 拥有「手」，一个让 AI 拥有可规模化的「身体」。
+
+## 卷首语：为什么是这三个
+
+2026 年，Agent（智能体）这个词已经从热词变成了工程现实。但大多数人谈论 Agent 时，讨论的仍是“它能不能更好地回答我”。这一期我们想换个角度：**Agent 不该只是被唤起的工具，而应是能持续存在、持续运作、甚至持续生活的实体。**
+
+顺着这个想法，我们选了三颗星，恰好构成 Agent 从里到外的三层图谱：
+
+- **yuiju**（yixiaojiu/yuiju）——让 AI 角色在自己的世界里吃饭、上学、散步、记录日记，拥有独立于用户之外的生活。这是 Agent 的「心」。
+- **lathe**（samzong 发起，现维护于 lathe-cli 组织）——把存量 API 一键变成 Agent 能安全调用的 CLI 契约与 Skill，让 Agent 拥有可以操作真实系统的「手」。
+- **mosoo**（langgenius/mosoo）——在 Cloudflare 原生的隔离沙箱里规模化运行 Codex、Claude Agent SDK、OpenCode 等编程 Agent。这是 Agent 的「身体」。
+
+一颗会生活的心、一双能干活的手、一个能跑起来的身体——它们各自回答了“AI 的下一形态”的一个根本问题。以下是我们的深度分析。
+
+## 一、yuiju：不做 AI 智能助手，做有自己生活的「人」
+
+![yuiju 角色「悠酱」头像](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-avatar.webp "图：yuiju 项目角色「悠酱」的头像，来自仓库 packages/source/picture/")
+
+### 一句话推荐语（作者语）
+
+在展开之前，先引用项目作者本人为 yuiju 写的一段推荐语，我们认为它精准概括了这个项目的灵魂：
+
+> yuiju 是一个以虚拟世界模拟角色生活为核心的 AI 陪伴项目。它通过构建可持续运行的虚拟世界，让角色拥有自己的生活轨迹、社交关系与成长经历，而非仅仅围绕用户展开对话。项目借鉴游戏设计思维，将 AI 陪伴从“聊天工具”升级为“可长期体验的世界”，让用户在陪伴中体验探索、养成、互动与共同成长的乐趣。
+
+### 它到底在做什么
+
+主流的 AI 陪伴产品，本质是“以用户为中心的人设引擎”：角色随叫随到，回复由一段固定人设文本即时生成。yuiju 把这个逻辑整个倒了过来——**世界先于对话存在**。
+
+这是一个 LLM 驱动的“角色自主生活模拟”项目，融合了 AI 聊天与“AI 小镇”的思路。角色在一个持续推进的虚拟世界中感知时间、天气、地点与自身状态，自主决策、执行行为，留下可追溯的生活轨迹、记忆、日记和计划。用户可以通过 QQ、飞书等消息入口与角色交流，但聊天只是用户观察和介入角色生活的窗口；角色的回复、近况与主动分享，都来自她在世界中**真实发生过**的经历，而不是临时现编的一段文本。项目 philosophy 写得很直白：不做 AI 智能助手，做有自己生活的“人”。
+
+### 深度解析：它凭什么“活”起来
+
+读过它的技术文档后，我们认为 yuiju 最值得称道的不是“角色会主动说话”这个表象，而是背后一套相当克制的工程哲学：
+
+**第一，世界引擎是“按 tick 推进”的，而不是“按对话触发”的。** 核心模块 `@yuiju/world` 同时维护两条持续运行的流程：世界状态推进（时间、天气、场景开放状态、资源数量，像游戏引擎一样按固定间隔运转）和角色行为推进（读取角色状态、世界状态与历史经历，计算当前可执行行为）。**这条流程不依赖用户消息**——即使没人跟角色说话，世界依然在运转，她依然在生活。这是“可持续运行的世界”这句话落到工程上的关键。
+
+**第二，LLM 只负责“决策”，不负责“改状态”。** 这是整套系统最聪明的一处取舍。“生活”太连续了，不能直接丢给大模型自由发挥。yuiju 把复杂行为拆成一个个原子化的 Action，LLM 只在通过前置条件的候选 Action 里做选择，返回一份结构化决策结果（选哪个、为什么）；真正的状态变化由 Action 的执行逻辑完成，并沉淀为行为记录，供后续记忆、日记和消息回复使用。换句话说，模型是“人生道路上的选择者”，而系统是“记录生活的事实簿”——这既避免了角色行为失控，也让一切经历变得可追溯、可回放。
+
+**第三，记忆不是堆聊天记录，而是有层次的。** 消息上下文不会无限拼接：系统同时维护最近原始消息、滚动摘要和自然对话窗口，对话窗口在合适边界沉淀为 Memory Episode 并更新人物记忆。角色因此能“记得今天”，而不是每次都从头自我介绍。作者在博客里也坦诚，记忆模块仍以 JSON 存储、由 LLM 自更新，偶尔会出错——这种诚实，恰恰是开源项目最动人的地方。
+
+**第四，游戏设计思维的全面渗透。** 动态天气系统让日常不只是固定脚本；角色可以拥有长期与短期计划，不只是被动回应用户的当下输入；当生活里发生值得说的事，她会在合适的时机主动分享，而不是永远等你开口。作者本人把项目介绍为“有状态、有行动、有记忆、有生活节奏的 AI 角色系统”——这是对“虚拟生命”最凝练的定义。
+
+![yuiju 系统架构图](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-architecture.png "图：yuiju 系统架构——@yuiju/world 世界引擎同时推进世界状态与角色行为，LLM 只做 Action 决策")
+
+### 编辑点评
+
+yuiju 回答了一个许多 AI 陪伴项目回避的问题：**一个 AI 能不能在没有你的时候，也拥有自己的生活？** 它把陪伴从“你召唤我”升级为“我们各自生活，偶尔相遇”，让情感连接建立在真实的共同经历之上，而非即时生成的甜蜜话术。虽然项目仍处于早期，记忆模块等环节也在持续打磨，但它提供的方向——用游戏引擎式的确定性框架，去约束和承载 LLM 的自由度——对整个 AI 角色领域都极具参考价值。喜欢《动物森友会》、喜欢养成与陪伴感的读者，值得立刻去它的 Web 页面体验一次（`yuiju-web.yixiaojiu.top`）。最后放一张悠酱的表情包，感受一下她的“小脾气”：
+
+![悠酱表情包 hmph](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-hmph.png "悠酱表情包：hmph")
+
+## 二、lathe：让 API 一键长出 Agent 的「手」
+
+![lathe logo](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-logo.png "图：lathe 项目 logo，来自仓库 docs/images/")
+
+### 它是什么
+
+lathe 是一个面向 Agent 的 API 转 CLI 生成器：从 Swagger 2.0、OpenAPI 3、带 `google.api.http` 注解的 protobuf，乃至 GraphQL schema，生成**单二进制、生产级**的 Cobra CLI，并附带结构化命令目录与一份生成的 Skill 指南。项目由 samzong 发起，现维护于 lathe-cli 组织下，MIT 协议，是一个还很年轻、但迭代极快的项目。
+
+作者的初衷很朴素，也很动人——“把旧世界存量的系统直接接入 Agent”。大多数团队不是没有 API，而是有一堆历史 API，却苦于无法安全、可靠地让 AI 去操作它们。
+
+### 核心哲学：Spec 即真相，Catalog 即契约
+
+lathe 的全部设计浓缩为两句话：
+
+1. **API 规范是唯一事实来源。** 你声明 pin 住的上游 spec（按 tag 固定、解析到 commit SHA，拒绝浮动分支），声明 CLI 身份（`cli.yaml`）与模块来源（`specs/sources.yaml`），必要时加 overlay 打磨帮助文本；当 API 变化时，重新生成即可。告别了“手写 CLI、然后花一辈子防止它 drift（漂移）”的宿命。
+2. **生成的 CLI 不只是一层外壳，而是一套 Agent 可机器化消费的契约。** 这才是 lathe 与普通 API 封装工具的本质区别。
+
+### 深度解析：为「Agent 不靠猜」设计的整套协议
+
+读过它的 README，你会发现 lathe 把“Agent 如何安全地使用一个 CLI”这件事拆解得异常细致：
+
+- **发现**：`search "<intent>" --json` 按自然语言意图找候选命令；`commands --json` 输出完整命令目录；`commands show <path>` 查看某条命令的 flags、body、鉴权、HTTP 方法与输出提示——所有信息都是结构化 JSON。
+- **预检**：`auth status --hostname <host>` 在调受保护命令前确认凭据；`--dry-run` 打印将发送的请求（含脱敏的 headers 与 body）而不真正发送，让 Agent 在执行前能核对一切。
+- **执行**：`--file` / `--set` / `--set-str` 构造请求体，`-o table|json|yaml|raw` 提供机器可读输出，枚举校验、分页、流式一应俱全。
+- **生成的 Skill**：codegen 默认写出 `skills/<cli-name>/` 目录，相当于一份“该 CLI 的 Agent 操作手册”（如何发现命令、检查目录、预检鉴权、构造 body、选择输出格式），还能打包进二进制（`<cli> skill install`）。运行时目录仍是真相，Skill 是教会 Agent 怎么用的入门指南。
+
+此外还有三处工程细节值得一提：所有生成模块共享**同一套运行时**（鉴权、请求构造、输出、分页、流式、错误处理行为一致）；**overlay 层**允许在不改上游 spec、不改生成的 Go 代码的前提下，隐藏/忽略命令、修正参数、添加快捷命令；两阶段流水线（`specsync` 拉取并固定 spec → `codegen` 归一化为统一 IR 再渲染）保证了可复现性。
+
+![lathe 架构图](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-architecture.png "图：lathe 生成流程——spec 固定同步 → codegen 归一化渲染 → 生成 CLI 与配套 Skill")
+
+### 为什么是现在：CLI 正在成为 Agent 的事实接口
+
+lathe 站上了一个很有意思的行业浪头。Vercel CEO 曾直言“CLIs are the de-facto MCPs for agents”（CLI 就是 Agent 事实上的工具协议），Perplexity CTO 与 Y Combinator 掌舵人 Garry Tan 也在同期公开支持 CLI 路线，中文社区甚至一度喊出“MCP 已死”。与此同时，飞书这样的厂商同时维护着 CLI 与 MCP Server 两个开源项目。在这个“Agent 接口之争”的关口，lathe 的选择很聪明：**它不争论 CLI 还是 MCP 谁赢，而是把“从 API 生成 agent 友好 CLI”本身做成了一条自动化流水线，并且连配套 Skill 都一并生成。**
+
+### 编辑点评
+
+lathe 适合两类人：一类是手里攒着大量 Swagger/OpenAPI/proto/GraphQL、想把存量系统接入 Agent 的团队——它是目前把“旧世界接入新世界”成本压到最低的工具之一；另一类是喜欢“一个二进制，人类能用、Agent 能安全检查”这种工程美学的开发者。它把“Agent 不该靠猜”从一句口号变成了可执行的六步循环（搜索 → 查看 → 预检鉴权 → dry-run → 执行 → 结构化输出），这是它最扎实的贡献。
+
+## 三、mosoo：给 coding agent 一个能规模化运行的「家」
+
+![mosoo banner](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/mosoo-banner.png "图：mosoo 官方 banner（2400×1260），来自仓库 docs/assets/")
+
+### 它是什么
+
+mosoo 是一个开源的、Cloudflare 原生的 **coding agent 运行时**：把 OpenAI Codex、Claude Agent SDK 和 OpenCode 等编程 Agent，跑在 API endpoint 后面、彼此隔离的 AI Agent 沙箱里，并提供可检查、可回放、可续跑的执行记录。它出自 **LangGenius——也就是开源 LLM 应用平台 Dify 背后的团队**，这从一开始就注定了它的工程取向：不是给个人玩家的小玩具，而是面向“要把 Agent 集成进自己产品”的开发者的基础设施。Apache 2.0 协议。
+
+### 它解决的是哪一层痛苦
+
+如果你要在自己的产品里用 coding agent，通常会撞上同一个坑：你需要自己维护 agent 运行时、沙箱服务、会话存储、文件管道、Agent API——每接入一种 agent harness（Codex、Claude、OpenCode……），这套东西就要重来一遍。mosoo 的定位，就是把这一整块收拢成一个**控制平面**：你的应用归属你，它拥有产品行为与最终用户体验；mosoo 只负责 Agent 的执行与生命周期。它把自己定位得很克制——“App 部署是另一个 Alpha 面，不是核心产品契约”。
+
+### 深度解析：Agent 从「一次调用」变成「一条持续存在的执行线」
+
+mosoo 的五个核心能力，完整对应了“把 agent 产品化”所需的每一环：
+
+- **统一的运行时与控制平面**：三种 agent harness 被归一化到同一个运行时协议下，你不需要为每种工具写三套集成。
+- **Agent API**：从一个可信后端 start / follow / continue / stop / archive / delete Agent 的工作——Agent 的工作是你可以编排的。
+- **隔离的 AI Agent 沙箱**：流式返回响应与工具活动、处理权限请求、取消工作、在隔离执行环境中查看诊断信息——让“把 agent 放给用户”这件事变得安全可控。
+- **持久化工作（Durable Work）**：Threads、Runs、事件与托管文件跨多次执行保留。这是它最本质的理念：Agent 不是一次性的调用，而是一条可以断点续跑的执行线。
+- **可观测性**：Run 状态、可回放的活动、诊断、用量估算——运营可见性，而非合规审计。
+
+配套生态也已经搭起骨架：`mosoo-agent-driver`、`mosoo-connector`，以及一份有意思的 `mosoo-skills`（20 个项目感知的 coding-agent skills，其中 16 个是未修改的公共上游副本，4 个由 mosoo 维护，且刻意排除在同步清单外，防止上游刷新抹掉项目特定的护栏）。技术栈上，它原生跑在 Cloudflare Workers + D1 + R2 之上，可以自托管到自己的账号里。
+
+### 风险提示（编辑的诚实提醒）
+
+必须提醒读者：**mosoo 目前处于 Alpha 阶段。** 官方 README 明确写道，托管运行时与 Agent API 已发布并有仓库测试覆盖，但“生产可靠性与外部采纳尚未被验证”，公开 API 与产品行为仍可能变化。因此它适合愿意吃螃蟹、在探索 agent 产品化原型的开发者；如果是要直接押在生产核心链路上，请务必先评估风险、做好隔离。
+
+### 编辑点评
+
+mosoo 的意义在于把“运行 coding agent”这件事从散装的 DIY 拼装，变成了一块可部署、可观察、可编排的基础设施。当整个行业都在讨论“Agent 该怎么做成产品”时，Dify 团队用自己在 LLM 应用平台上的积累，给出了一个 Cloudflare 原生的参考答案——隔离沙箱、持久会话、统一 API、按需续跑。对于正在把 Codex / Claude Agent SDK / OpenCode 扩展成自己产品的团队，它值得放进对比清单里认真评估。
+
+## 总结：一张表看懂这一期
+
+| 项目 | 让 Agent 拥有 | 核心哲学 | 协议/状态 | 适合谁 |
+| --- | --- | --- | --- | --- |
+| **yuiju** | 一颗会生活的「心」——生活轨迹、记忆、计划 | 世界先于对话；LLM 决策、系统记账 | 开源，早期成长中 | AI 陪伴玩家、研究虚拟生命的产品人与开发者 |
+| **lathe** | 一双能干活的「手」——可被安全调用的 CLI 契约 | Spec 即真相，Catalog 即契约 | MIT，较成熟 | 有存量 API 想接入 Agent 的团队、CLI 与 Agent 工具爱好者 |
+| **mosoo** | 一个能规模化运行的「身体」——沙箱、API、持久执行 | Agent 从调用变成一条持续的执行线 | Apache 2.0，Alpha | 把 coding agent 做成产品的开发者 |
+
+## 写在最后
+
+第一期，我们把三颗看似无关的星放在同一页，其实想说一件事：**AI 的下一个形态，大概不是一个更聪明的对话框，而是一个能跑、能干、能生活的「实体」。** yuiju 给了它生活，lathe 给了它双手，mosoo 给了它身体——它们分别代表了体验、接口与基础设施三个层次，而真正的未来产品，大概要同时拥有这三样。
+
+如果你恰好也在做类似的事，或者对其中某个项目有更深的理解，欢迎留言与我们交流。下一期，我们会围绕“Agent 的记忆”这一主题，深挖更多值得被看见的开源项目。
+
+**快速上手与体验入口**
+
+- yuiju：仓库 `github.com/yixiaojiu/yuiju`｜在线体验 `yuiju-web.yixiaojiu.top`｜作者博客 `note.yixiaojiu.top/blog/yuiju`
+- lathe：仓库 `github.com/lathe-cli/lathe`（由 samzong 发起）
+- mosoo：仓库 `github.com/langgenius/mosoo`｜云端体验 `cloud.mosoo.ai`｜官网 `mosoo.ai`
+
+**作者与团队**
+
+| 项目 | 作者 / 团队 | GitHub |
+| --- | --- | --- |
+| yuiju | yixiaojiu（翊小久） | `github.com/yixiaojiu` |
+| lathe | samzong | `github.com/samzong` |
+| mosoo | LangGenius（Dify 团队） | `github.com/langgenius` |


### PR DESCRIPTION
## 内容
新增 `/collections/agents-heart-hands-body`(zh/en 双语):
- yuiju(Agent 的「心」)/ lathe(「手」)/ mosoo(「身体」)三个项目深度推荐
- meta.json 挂 3 个 repo 卡片,数据取 GitHub API 当前值

## 图片
9 张图托管到 Cloudflare R2(`ghfind-assets` bucket),不再依赖第三方 CDN。

## 对原稿的事实修正
- lathe「1500+ 星」系误记(实际 39 star),已改正
- 作者表去掉内联头像(Figure 组件渲染会破表格版式)

## 验证
- collections 测试 7/7 通过
- pnpm typecheck 通过