### PR TITLE
chore(collections): 图片 URL 切换到 assets.usedify.app

### DIFF
--- a/content/collections/agents-heart-hands-body/en.md
+++ b/content/collections/agents-heart-hands-body/en.md
@@ -14,7 +14,7 @@ A heart that knows how to live, a pair of hands that can do real work, a body th
 
 ## 1. yuiju: not an AI assistant, but a "person" with a life of her own
 
-![Avatar of Yuu-chan, the yuiju character](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-avatar.webp "Figure: avatar of Yuu-chan, the yuiju project character, from the repo's packages/source/picture/ directory")
+![Avatar of Yuu-chan, the yuiju character](https://assets.usedify.app/collections/agents-heart-hands-body/yuiju-avatar.webp "Figure: avatar of Yuu-chan, the yuiju project character, from the repo's packages/source/picture/ directory")
 
 ### A one-line recommendation (from the author)
 
@@ -40,17 +40,17 @@ After reading through its technical documentation, we believe the most commendab
 
 **Fourth, game-design thinking permeates everything.** A dynamic weather system keeps daily life from being a fixed script; the character can hold long-term and short-term plans rather than passively responding to whatever the user just typed; and when something worth telling happens in her life, she shares it at the right moment instead of forever waiting for you to speak first. The author himself describes the project as "an AI character system with state, actions, memory, and a rhythm of life" — the most concise definition of "virtual life" we've seen.
 
-![yuiju system architecture](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-architecture.png "Figure: yuiju system architecture — the @yuiju/world engine advances world state and character behavior in parallel, while the LLM only makes Action decisions")
+![yuiju system architecture](https://assets.usedify.app/collections/agents-heart-hands-body/yuiju-architecture.png "Figure: yuiju system architecture — the @yuiju/world engine advances world state and character behavior in parallel, while the LLM only makes Action decisions")
 
 ### Editor's take
 
 yuiju answers a question many AI companion projects dodge: **can an AI have a life of its own when you're not around?** It upgrades companionship from "you summon me" to "we each live our own lives and meet occasionally," grounding the emotional connection in genuinely shared experience rather than sweet talk generated on the fly. The project is still early, and pieces like the memory module are still being polished, but the direction it offers — using a game-engine-style deterministic framework to constrain and carry the LLM's freedom — is enormously valuable reference material for the entire AI-character field. If you love Animal Crossing, or love the feeling of nurturing and companionship, it's worth heading straight to its web page and experiencing it once (`yuiju-web.yixiaojiu.top`). To close, here's a Yuu-chan sticker, so you can get a feel for her little temper:
 
-![Yuu-chan sticker: hmph](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-hmph.png "Yuu-chan sticker: hmph")
+![Yuu-chan sticker: hmph](https://assets.usedify.app/collections/agents-heart-hands-body/yuiju-hmph.png "Yuu-chan sticker: hmph")
 
 ## 2. lathe: growing an agent's 「hands」 from your APIs in one shot
 
-![lathe logo](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-logo.png "Figure: the lathe project logo, from the repo's docs/images/ directory")
+![lathe logo](https://assets.usedify.app/collections/agents-heart-hands-body/lathe-logo.png "Figure: the lathe project logo, from the repo's docs/images/ directory")
 
 ### What it is
 
@@ -76,7 +76,7 @@ Read its README and you'll find that lathe has decomposed "how an agent safely u
 
 Three engineering details are also worth mentioning: all generated modules share **the same runtime** (auth, request construction, output, pagination, streaming, and error handling behave consistently); the **overlay layer** lets you hide/ignore commands, fix parameters, and add shortcut commands without touching the upstream spec or the generated Go code; and the two-stage pipeline (`specsync` fetches and pins the spec → `codegen` normalizes it into a unified IR and renders) guarantees reproducibility.
 
-![lathe architecture diagram](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-architecture.png "Figure: the lathe generation flow — spec pinned and synced → codegen normalizes and renders → CLI plus companion Skill generated")
+![lathe architecture diagram](https://assets.usedify.app/collections/agents-heart-hands-body/lathe-architecture.png "Figure: the lathe generation flow — spec pinned and synced → codegen normalizes and renders → CLI plus companion Skill generated")
 
 ### Why now: the CLI is becoming the de facto interface for agents
 
@@ -88,7 +88,7 @@ lathe suits two kinds of people. The first is teams sitting on a pile of Swagger
 
 ## 3. mosoo: giving coding agents a scalable 「body」 to run in
 
-![mosoo banner](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/mosoo-banner.png "Figure: the official mosoo banner (2400×1260), from the repo's docs/assets/ directory")
+![mosoo banner](https://assets.usedify.app/collections/agents-heart-hands-body/mosoo-banner.png "Figure: the official mosoo banner (2400×1260), from the repo's docs/assets/ directory")
 
 ### What it is
 

--- a/content/collections/agents-heart-hands-body/zh.md
+++ b/content/collections/agents-heart-hands-body/zh.md
@@ -14,7 +14,7 @@
 
 ## 一、yuiju：不做 AI 智能助手，做有自己生活的「人」
 
-![yuiju 角色「悠酱」头像](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-avatar.webp "图：yuiju 项目角色「悠酱」的头像，来自仓库 packages/source/picture/")
+![yuiju 角色「悠酱」头像](https://assets.usedify.app/collections/agents-heart-hands-body/yuiju-avatar.webp "图：yuiju 项目角色「悠酱」的头像，来自仓库 packages/source/picture/")
 
 ### 一句话推荐语（作者语）
 
@@ -40,17 +40,17 @@
 
 **第四，游戏设计思维的全面渗透。** 动态天气系统让日常不只是固定脚本；角色可以拥有长期与短期计划，不只是被动回应用户的当下输入；当生活里发生值得说的事，她会在合适的时机主动分享，而不是永远等你开口。作者本人把项目介绍为“有状态、有行动、有记忆、有生活节奏的 AI 角色系统”——这是对“虚拟生命”最凝练的定义。
 
-![yuiju 系统架构图](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-architecture.png "图：yuiju 系统架构——@yuiju/world 世界引擎同时推进世界状态与角色行为，LLM 只做 Action 决策")
+![yuiju 系统架构图](https://assets.usedify.app/collections/agents-heart-hands-body/yuiju-architecture.png "图：yuiju 系统架构——@yuiju/world 世界引擎同时推进世界状态与角色行为，LLM 只做 Action 决策")
 
 ### 编辑点评
 
 yuiju 回答了一个许多 AI 陪伴项目回避的问题：**一个 AI 能不能在没有你的时候，也拥有自己的生活？** 它把陪伴从“你召唤我”升级为“我们各自生活，偶尔相遇”，让情感连接建立在真实的共同经历之上，而非即时生成的甜蜜话术。虽然项目仍处于早期，记忆模块等环节也在持续打磨，但它提供的方向——用游戏引擎式的确定性框架，去约束和承载 LLM 的自由度——对整个 AI 角色领域都极具参考价值。喜欢《动物森友会》、喜欢养成与陪伴感的读者，值得立刻去它的 Web 页面体验一次（`yuiju-web.yixiaojiu.top`）。最后放一张悠酱的表情包，感受一下她的“小脾气”：
 
-![悠酱表情包 hmph](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/yuiju-hmph.png "悠酱表情包：hmph")
+![悠酱表情包 hmph](https://assets.usedify.app/collections/agents-heart-hands-body/yuiju-hmph.png "悠酱表情包：hmph")
 
 ## 二、lathe：让 API 一键长出 Agent 的「手」
 
-![lathe logo](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-logo.png "图：lathe 项目 logo，来自仓库 docs/images/")
+![lathe logo](https://assets.usedify.app/collections/agents-heart-hands-body/lathe-logo.png "图：lathe 项目 logo，来自仓库 docs/images/")
 
 ### 它是什么
 
@@ -76,7 +76,7 @@ lathe 的全部设计浓缩为两句话：
 
 此外还有三处工程细节值得一提：所有生成模块共享**同一套运行时**（鉴权、请求构造、输出、分页、流式、错误处理行为一致）；**overlay 层**允许在不改上游 spec、不改生成的 Go 代码的前提下，隐藏/忽略命令、修正参数、添加快捷命令；两阶段流水线（`specsync` 拉取并固定 spec → `codegen` 归一化为统一 IR 再渲染）保证了可复现性。
 
-![lathe 架构图](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/lathe-architecture.png "图：lathe 生成流程——spec 固定同步 → codegen 归一化渲染 → 生成 CLI 与配套 Skill")
+![lathe 架构图](https://assets.usedify.app/collections/agents-heart-hands-body/lathe-architecture.png "图：lathe 生成流程——spec 固定同步 → codegen 归一化渲染 → 生成 CLI 与配套 Skill")
 
 ### 为什么是现在：CLI 正在成为 Agent 的事实接口
 
@@ -88,7 +88,7 @@ lathe 适合两类人：一类是手里攒着大量 Swagger/OpenAPI/proto/GraphQ
 
 ## 三、mosoo：给 coding agent 一个能规模化运行的「家」
 
-![mosoo banner](https://pub-f0560cb5ffde4095b7345da9c0f73c28.r2.dev/collections/agents-heart-hands-body/mosoo-banner.png "图：mosoo 官方 banner（2400×1260），来自仓库 docs/assets/")
+![mosoo banner](https://assets.usedify.app/collections/agents-heart-hands-body/mosoo-banner.png "图：mosoo 官方 banner（2400×1260），来自仓库 docs/assets/")
 
 ### 它是什么
 


### PR DESCRIPTION
R2 bucket `ghfind-assets` 绑定自定义域名 `assets.usedify.app`(usedify.app zone 在同一 CF 账号),替换编辑推荐第一期 zh/en 正文里的 12 处 r2.dev 前缀。9 张图已逐一 curl 确认 200。