### PR TITLE
ci(deploy): fall back to main deploy hook when Vercel skips a commit author

### DIFF
--- a/.github/scripts/deploy-gate.mjs
+++ b/.github/scripts/deploy-gate.mjs
@@ -204,12 +204,26 @@ async function commandVercelWait() {
   const currentSha = env("GITHUB_SHA");
   const project = env("VERCEL_PROJECT_ID");
   const deadline = Date.now() + 25 * 60 * 1000;
+  // Vercel silently skips deployments whose commit author it can identify as a
+  // Vercel user without contributing access to the team (e.g. a Viewer). When
+  // no deployment for this sha shows up within the grace window, fall back to
+  // the project's deploy hook once — hook-triggered builds carry no commit
+  // author, so the membership check does not apply.
+  const hookUrl = process.env.VERCEL_DEPLOY_HOOK_MAIN;
+  const hookAfter = Date.now() + 3 * 60 * 1000;
+  let hookFired = false;
   try {
     for (;;) {
       const list = await vercelApi(`/v6/deployments?projectId=${project}&limit=20`);
       const deployment = (list.deployments || []).find(
         (candidate) => candidate.meta?.githubCommitSha === currentSha,
       );
+      if (!deployment && !hookFired && hookUrl && Date.now() > hookAfter) {
+        hookFired = true;
+        console.log("no vercel deployment after 3m; triggering the main deploy hook as fallback");
+        const hookResponse = await fetch(hookUrl, { method: "POST" });
+        console.log(`deploy hook responded ${hookResponse.status}`);
+      }
       if (deployment) {
         const status = deployment.readyState || deployment.state;
         if (status === "READY") {

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,6 +18,10 @@ name: Deploy production gate
 # Required GitHub secrets:
 # - VERCEL_TOKEN / VERCEL_ORG_ID / VERCEL_PROJECT_ID — token scoped to the
 #   Vercel team owning the frontend project.
+# - VERCEL_DEPLOY_HOOK_MAIN — deploy hook URL for main. Used as a fallback
+#   when Vercel never starts a deployment for the pushed commit (it silently
+#   skips commits whose author is an identified Vercel user without
+#   contributing access to the team, e.g. a Viewer).
 # - RAILWAY_TOKEN — Railway project token for the backend project+environment.
 
 on:
@@ -53,6 +57,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_DEPLOY_HOOK_MAIN: ${{ secrets.VERCEL_DEPLOY_HOOK_MAIN }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
     steps:
       - name: Check required secrets


### PR DESCRIPTION
## 背景

Vercel 对能识别身份、但在团队中没有贡献权限的提交者（例如团队 Viewer）会**静默跳过部署**。这导致此类提交 merge 进 main 后，`deploy-production.yml` 门控在 `vercel-wait` 阶段等 25 分钟超时，判定失败并回滚 Railway 后端。

## 改动

- `vercel-wait`：3 分钟仍等不到当前 sha 的 Vercel 部署时，自动 POST 一次项目的 main deploy hook（hook 触发的构建不做提交者身份校验），然后继续等待。正常提交不受影响，也不会重复部署。
- `deploy-production.yml`：注入新 secret `VERCEL_DEPLOY_HOOK_MAIN`（已配置），补充头注释。

## 验证

- 已通过 Vercel API 创建 deploy hook 并实测 POST：deployment 正常 BUILDING → READY，生产别名切换正常。
- `node --check .github/scripts/deploy-gate.mjs` 通过。

## 已知残留

被拦截身份的协作者其 **PR 分支预览部署**仍不会被 Vercel 触发（hook 按分支静态绑定，覆盖不了任意 PR 分支）；根治需为其购买 MEMBER 席位。