### PR TITLE
fix(backend): keep campaign SSE available when the revision key expired

### DIFF
--- a/internal/backend/campaign_sse.go
+++ b/internal/backend/campaign_sse.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 )
@@ -54,12 +53,16 @@ func (h *campaignSSEHub) subscribe(ctx context.Context, campaign string) (<-chan
 			h.mu.Unlock()
 			return nil, nil, err
 		}
-		if revision == nil {
-			h.mu.Unlock()
-			return nil, nil, fmt.Errorf("campaign revision unavailable")
+		// A missing revision key only means nobody has joined the campaign
+		// recently (the writer INCRs it with a 7-day TTL). Start the stream at
+		// 0 so the endpoint stays available instead of 503ing until the next
+		// join; the poller picks up the first bump from there.
+		initial := int64(0)
+		if revision != nil {
+			initial = *revision
 		}
 		channel = &campaignRevisionChannel{
-			campaign: campaign, revision: *revision, listeners: map[chan int64]struct{}{}, stop: make(chan struct{}),
+			campaign: campaign, revision: initial, listeners: map[chan int64]struct{}{}, stop: make(chan struct{}),
 		}
 		h.channels[campaign] = channel
 		go h.poll(channel)

--- a/internal/backend/campaign_sse_test.go
+++ b/internal/backend/campaign_sse_test.go
@@ -66,6 +66,28 @@ func TestCampaignSSEHubSharesRevisionPollingAndCleansUp(t *testing.T) {
 	}
 }
 
+func TestCampaignSSEHubSubscribesWithoutStoredRevision(t *testing.T) {
+	// The revision key expires 7 days after the last campaign join; a missing
+	// key must not 503 the stream — it starts at 0 and picks up the next bump.
+	store := &fakeCampaignRevisionStore{}
+	hub := newCampaignSSEHub(store)
+	hub.pollInterval = 10 * time.Millisecond
+	listener, unsubscribe, err := hub.subscribe(context.Background(), "advx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unsubscribe()
+	store.setRevision(1)
+	select {
+	case revision := <-listener:
+		if revision != 1 {
+			t.Fatalf("revision=%d", revision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("listener did not receive the first bump")
+	}
+}
+
 func TestCampaignSSEHubEnforcesPerCampaignCapacity(t *testing.T) {
 	initial := int64(1)
 	hub := newCampaignSSEHub(&fakeCampaignRevisionStore{revision: &initial})


### PR DESCRIPTION
## 问题

`BumpCampaignLeaderboardRevision` 只在**新成员加入 campaign** 时 INCR `campaign-leaderboard:<id>:revision`（TTL 7 天）。advx campaign 约 7 天没有新成员加入 → key 过期 → `subscribe()` 把 key 缺失当错误 → SSE 端点 503 "Live updates unavailable"。

而部署 smoke 正好检查这个端点，导致 **8/13 起每次 main 部署门控都在 smoke 阶段失败并回滚 Railway**（run 31699155975、31701694023 均因此失败，与 #202 的改动无关）。

## 修复

- `subscribe()`：revision key 缺失时从 0 起播，poller 会正常接住下一次 bump；端点不再 503。
- 新增缺失 key 路径的回归测试。

## 已做的生产侧临时处置

已直接对 Upstash 执行 `INCR campaign-leaderboard:advx:revision` + `EXPIRE 7d`（与 writer 行为一致），生产 SSE 端点已恢复 200（实测返回 `retry: 2000`）。门控即时解封；本 PR 是根治，防止 7 天后复发。

## 验证

- 生产后端直连验证：修复前 503 "Live updates unavailable"，处置后 200 + `retry: 2000`。
- Go 测试由 CI 运行（本地无 Go 工具链）。