### PR TITLE
feat(robots): add bingbot Crawl-delay 10

### DIFF
--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -77,6 +77,20 @@ export function GET() {
     lines.push(`User-agent: ${bot}`, "Disallow: /", "");
   }
 
+  // Bingbot gets its own group because a UA that matches a specific group stops
+  // reading `*` entirely — so the /api/ policy must be repeated here. Crawl-delay
+  // is honored by Bing (Google ignores it): bingbot crawls ~19k facet pages/day
+  // at 99% ISR MISS, i.e. a fresh SSR render per hit. 10s ≈ 8.6k req/day cap.
+  lines.push(
+    "User-agent: bingbot",
+    "Allow: /",
+    "Allow: /api/og/",
+    "Allow: /api/card/",
+    "Disallow: /api/",
+    "Crawl-delay: 10",
+    "",
+  );
+
   // Everyone else: open, but keep the budget-burning API private (images allowed).
   lines.push(
     "User-agent: *",


### PR DESCRIPTION
bingbot crawls ~19.4k facet pages/day at 99% ISR MISS (fresh SSR render per hit). Adds a dedicated bingbot group with Crawl-delay: 10 (~8.6k req/day cap), replicating the `*` group's /api/ policy since a UA that matches a specific group stops reading `*`. Google ignores Crawl-delay and is unaffected (googlebot: ~109 req/day).

Part of the bot-cost reduction along with the Bot Protection managed ruleset rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)