### PR TITLE
fix(roast): 修正年度贡献数的错误归因

### DIFF
--- a/internal/backend/roast_prompt.go
+++ b/internal/backend/roast_prompt.go
@@ -120,6 +120,7 @@ func roastContextNotes(scan ScanResult, language roastLanguage) map[string]any {
 		notes = map[string]any{
 			"recent_prs_scope":                  "recent_prs contains only the most recent merged PR sample; it is not the all-time PR distribution.",
 			"account_time_scope":                "contribution_years_active is the count of calendar years with contributions after account creation, not continuous elapsed active time. Do not compare it directly against account_age_years as a time-travel/future anomaly.",
+			"last_year_contributions_scope":     "last_year_contributions is the aggregate count from GitHub's trailing-year contribution calendar and may include commits, PRs, issues, reviews, and other counted activity. It is not a PR count and does not provide repository-ownership distribution. Never attribute the entire value to PRs, commits, external repositories, or the user's own repositories; use only explicit breakdown fields in the payload.",
 			"recent_prs_sample_size":            m.RecentMergedPRSample,
 			"total_merged_pr_count":             m.MergedPRCount,
 			"workflow_landed_pr_count":          valueOrZero(m.WorkflowLandedPRCount),
@@ -151,6 +152,7 @@ func roastContextNotes(scan ScanResult, language roastLanguage) map[string]any {
 	notes = map[string]any{
 		"recent_prs_scope":                  "recent_prs 只包含最近 merged PR 样本，不代表全量 PR 分布。",
 		"account_time_scope":                "contribution_years_active 是账号创建后出现过贡献的自然年份数量，不是连续活跃时长；不要把它直接和 account_age_years 比较并写成穿越/来自未来。",
+		"last_year_contributions_scope":     "last_year_contributions 是 GitHub 过去一年贡献日历的聚合计数，可能包含 commit、PR、Issue、Review 等多种计入活动；它不是 PR 数，也不提供仓库归属分布。不得把该数值全部归因于 PR、commit、外部仓库或用户自有仓库；贡献类型和仓库归属只能使用 payload 中对应的明确拆分字段。",
 		"recent_prs_sample_size":            m.RecentMergedPRSample,
 		"total_merged_pr_count":             m.MergedPRCount,
 		"workflow_landed_pr_count":          valueOrZero(m.WorkflowLandedPRCount),

--- a/internal/backend/roast_prompt_test.go
+++ b/internal/backend/roast_prompt_test.go
@@ -371,6 +371,43 @@ func TestRoastPromptMarksRecentPRsAsSample(t *testing.T) {
 	}
 }
 
+func TestRoastPromptScopesLastYearContributionsAsAggregate(t *testing.T) {
+	scan := roastPromptBaseScan()
+	scan.Metrics.LastYearContributions = 694
+	scan.Metrics.TotalPRCount = 8
+	scan.Metrics.MergedPRCount = 5
+
+	tests := []struct {
+		language roastLanguage
+		needles  []string
+	}{
+		{roastLanguageZH, []string{"聚合计数", "不是 PR 数", "不提供仓库归属分布", "不得把该数值全部归因于"}},
+		{roastLanguageEN, []string{"aggregate count", "not a PR count", "does not provide repository-ownership distribution", "Never attribute the entire value"}},
+	}
+
+	for _, test := range tests {
+		messages := buildRoastPrompt(scan, test.language)
+		if !strings.Contains(messages[0].Content, "context_notes.last_year_contributions_scope") {
+			t.Fatalf("system prompt missing last-year contribution scope: %q", messages[0].Content)
+		}
+		payload := roastPromptUserPayload(t, messages)
+		metrics := roastPayloadMap(t, payload, "metrics")
+		if metrics["last_year_contributions"] != float64(694) || metrics["total_pr_count"] != float64(8) || metrics["merged_pr_count"] != float64(5) {
+			t.Fatalf("metrics=%#v", metrics)
+		}
+		context := roastPayloadMap(t, payload, "context_notes")
+		scope, ok := context["last_year_contributions_scope"].(string)
+		if !ok {
+			t.Fatalf("last_year_contributions_scope=%#v", context["last_year_contributions_scope"])
+		}
+		for _, needle := range test.needles {
+			if !strings.Contains(scope, needle) {
+				t.Fatalf("last_year_contributions_scope=%q missing %q", scope, needle)
+			}
+		}
+	}
+}
+
 func TestRoastPromptKeepsOrganizationMaintenanceEvidenceOutsideScoreInputs(t *testing.T) {
 	scan := roastPromptBaseScan()
 	scan.SignatureWork = SignatureWork{

--- a/internal/backend/roast_prompt_text.go
+++ b/internal/backend/roast_prompt_text.go
@@ -23,6 +23,7 @@ const roastSystemTemplateZH = `你是「GitHub 毒舌锐评写手」。分数、
 
 ## 写作护栏
 - 分数来自评分引擎，不是你的判断。可以解释为什么这个分数显得合理，但不能改分、不能暗示模型另有裁决。
+- ~last_year_contributions~ 必须按 context_notes.last_year_contributions_scope 解释：它是贡献日历聚合数，不得把它写成 PR 数，也不得据此推断贡献类型或仓库归属。
 - 学校、公司、雇主、组织 membership 只是背景，不是分数背书；即使这些信息写在 profile、bio、company 或 README 里，除非数据里有真实项目/PR/commit/维护证据，否则不要写成“因此更强/更可信/值得加分”。
 - AI 使用只是现代开发背景，不是扣分依据；即使 README 自述使用 ChatGPT，也只能在原创项目质量弱、代码/可用性证据也弱时写成原创性 caveat，不能写成作弊、丢人、懒、代笔定论。
 - recent_prs 只是最近 merged PR 样本，不要从 recent_prs 推断全量分布。
@@ -123,6 +124,7 @@ The Markdown report after the three control lines must be written in **English o
 
 ## Writing guardrails
 - The score comes from the scoring engine, not from your judgment. You may explain why the score fits the facts, but you must not modify it or imply a separate model ruling.
+- ~last_year_contributions~ must follow context_notes.last_year_contributions_scope: it is a contribution-calendar aggregate, must not be written as a PR count, and cannot establish contribution types or repository ownership.
 - School, company, employer, or organization membership is background context, not score evidence, even when it appears in the profile, bio, company field, or README text. Do not write it as "therefore stronger / more trustworthy / deserving a bump" unless the data ties it to real repo quality, PR/commit work, or maintainer evidence.
 - AI tool use is normal modern development context, not score evidence. Even if a README self-describes ChatGPT usage, mention it only as an originality caveat when repo quality/code/usability evidence is also weak; do not frame AI use as cheating, shameful, laziness, or ghostwriting by default.
 - recent_prs is only the most recent merged PR sample; do not extrapolate all-time behavior from recent_prs.

--- a/src/lib/__tests__/prompt.test.ts
+++ b/src/lib/__tests__/prompt.test.ts
@@ -337,6 +337,50 @@ describe("buildRoastMessages", () => {
     expect(enPayload.context_notes.no_sample_extrapolation).toContain("Do not infer");
   });
 
+  it("keeps last-year contribution totals separate from PR and repository attribution", () => {
+    const aggregateScan = {
+      ...scan,
+      metrics: {
+        ...scan.metrics,
+        last_year_contributions: 694,
+        total_pr_count: 8,
+        merged_pr_count: 5,
+      },
+    } as ScanResult;
+
+    const [zhSystem, zhUser] = buildRoastMessages(aggregateScan, "zh");
+    const zhPayload = JSON.parse(zhUser.content.match(/```json\n([\s\S]*)\n```/)![1]);
+    expect(zhSystem.content).toContain("context_notes.last_year_contributions_scope");
+    expect(zhSystem.content).toContain("不得把它写成 PR 数");
+    expect(zhPayload.metrics).toMatchObject({
+      last_year_contributions: 694,
+      total_pr_count: 8,
+      merged_pr_count: 5,
+    });
+    expect(zhPayload.context_notes.last_year_contributions_scope).toContain("聚合计数");
+    expect(zhPayload.context_notes.last_year_contributions_scope).toContain("不是 PR 数");
+    expect(zhPayload.context_notes.last_year_contributions_scope).toContain("不提供仓库归属分布");
+    expect(zhPayload.context_notes.last_year_contributions_scope).toContain("不得把该数值全部归因于");
+
+    const [enSystem, enUser] = buildRoastMessages(aggregateScan, "en");
+    const enPayload = JSON.parse(enUser.content.match(/```json\n([\s\S]*)\n```/)![1]);
+    expect(enSystem.content).toContain("context_notes.last_year_contributions_scope");
+    expect(enSystem.content).toContain("must not be written as a PR count");
+    expect(enPayload.metrics).toMatchObject({
+      last_year_contributions: 694,
+      total_pr_count: 8,
+      merged_pr_count: 5,
+    });
+    expect(enPayload.context_notes.last_year_contributions_scope).toContain("aggregate count");
+    expect(enPayload.context_notes.last_year_contributions_scope).toContain("not a PR count");
+    expect(enPayload.context_notes.last_year_contributions_scope).toContain(
+      "does not provide repository-ownership distribution",
+    );
+    expect(enPayload.context_notes.last_year_contributions_scope).toContain(
+      "Never attribute the entire value",
+    );
+  });
+
   it("keeps impact coverage neutral and includes verified high-star PR samples", () => {
     const [zhSys, zhUser] = buildRoastMessages(scan, "zh");
     expect(zhSys.content).toContain("不能把样本数写成");

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -335,6 +335,7 @@ const SYSTEM_PROMPT_ZH = `你是「GitHub 毒舌锐评写手」。分数、档�
 ## 写作护栏
 - 分数来自评分引擎，不是你的判断。可以解释为什么这个分数显得合理，但不能改分、不能暗示模型另有裁决。
 - 任何“大于/小于/更多/更少/比例”结论都必须由 payload 的精确数字推出。粉丝与关注的关系必须遵循 context_notes.follower_following_fact；数值接近时优先直接写两个数字，不要臆造高低关系。
+- \`last_year_contributions\` 必须按 context_notes.last_year_contributions_scope 解释：它是贡献日历聚合数，不得把它写成 PR 数，也不得据此推断贡献类型或仓库归属。
 - 学校、公司、雇主、组织 membership 只是背景，不是分数背书；即使这些信息写在 profile、bio、company 或 README 里，除非数据里有真实项目/PR/commit/维护证据，否则不要写成“因此更强/更可信/值得加分”。
 - AI 使用只是现代开发背景，不是扣分依据；即使 README 自述使用 ChatGPT，也只能在原创项目质量弱、代码/可用性证据也弱时写成原创性 caveat，不能写成作弊、丢人、懒、代笔定论。
 - recent_prs 只是最近 merged PR 样本，不要从 recent_prs 推断全量分布。
@@ -436,6 +437,7 @@ The Markdown report after the three control lines must be written in **English o
 ## Writing guardrails
 - The score comes from the scoring engine, not from your judgment. You may explain why the score fits the facts, but you must not modify it or imply a separate model ruling.
 - Every more/fewer, larger/smaller, or ratio claim must follow the exact payload numbers. For followers versus following, obey context_notes.follower_following_fact; when values are close, state the two counts rather than inventing a relationship.
+- \`last_year_contributions\` must follow context_notes.last_year_contributions_scope: it is a contribution-calendar aggregate, must not be written as a PR count, and cannot establish contribution types or repository ownership.
 - School, company, employer, or organization membership is background context, not score evidence, even when it appears in the profile, bio, company field, or README text. Do not write it as "therefore stronger / more trustworthy / deserving a bump" unless the data ties it to real repo quality, PR/commit work, or maintainer evidence.
 - AI tool use is normal modern development context, not score evidence. Even if a README self-describes ChatGPT usage, mention it only as an originality caveat when repo quality/code/usability evidence is also weak; do not frame AI use as cheating, shameful, laziness, or ghostwriting by default.
 - recent_prs is only the most recent merged PR sample; do not extrapolate all-time behavior from recent_prs.
@@ -594,6 +596,8 @@ function buildPayload(scan: ScanResult, lang: Lang) {
             "recent_prs contains only the most recent merged PR sample; it is not the all-time PR distribution.",
           account_time_scope:
             "contribution_years_active is the count of calendar years with contributions after account creation, not continuous elapsed active time. Do not compare it directly against account_age_years as a time-travel/future anomaly.",
+          last_year_contributions_scope:
+            "last_year_contributions is the aggregate count from GitHub's trailing-year contribution calendar and may include commits, PRs, issues, reviews, and other counted activity. It is not a PR count and does not provide repository-ownership distribution. Never attribute the entire value to PRs, commits, external repositories, or the user's own repositories; use only explicit breakdown fields in the payload.",
           recent_prs_sample_size: scan.metrics.recent_merged_pr_sample,
           total_merged_pr_count: scan.metrics.merged_pr_count,
           follower_following_fact: followerFollowingFact,
@@ -648,6 +652,8 @@ function buildPayload(scan: ScanResult, lang: Lang) {
             "recent_prs 只包含最近 merged PR 样本，不代表全量 PR 分布。",
           account_time_scope:
             "contribution_years_active 是账号创建后出现过贡献的自然年份数量，不是连续活跃时长；不要把它直接和 account_age_years 比较并写成穿越/来自未来。",
+          last_year_contributions_scope:
+            "last_year_contributions 是 GitHub 过去一年贡献日历的聚合计数，可能包含 commit、PR、Issue、Review 等多种计入活动；它不是 PR 数，也不提供仓库归属分布。不得把该数值全部归因于 PR、commit、外部仓库或用户自有仓库；贡献类型和仓库归属只能使用 payload 中对应的明确拆分字段。",
           recent_prs_sample_size: scan.metrics.recent_merged_pr_sample,
           total_merged_pr_count: scan.metrics.merged_pr_count,
           follower_following_fact: followerFollowingFact,


### PR DESCRIPTION
## 关联 Issue

关联 #209（不自动关闭）。

## 问题

`last_year_contributions` 来自 GitHub 过去一年贡献日历的聚合计数，但锐评模型可能把它误写成 PR 数，并进一步据此推断贡献类型或仓库归属。

例如 Issue #209 中的 payload 同时包含：

- `last_year_contributions = 694`
- `total_pr_count = 8`
- `merged_pr_count = 5`

原始 PR 统计是独立且正确的，错误发生在锐评生成阶段对字段语义的解释。

## 修复

- 在中英文 system prompt 中明确要求按 `context_notes.last_year_contributions_scope` 解释年度贡献总数；
- 在 TypeScript 和 Go 两条 roast prompt 路径中补充相同的字段语义；
- 明确禁止把该聚合值写成 PR 数，或用它推断贡献类型、外部仓库/自有仓库分布；
- 保留原始指标和评分逻辑，不修改 GitHub 数据采集；
- 增加中英文回归测试，覆盖 694 次年度贡献、8 个 PR、5 个 merged PR 的组合。

## 验证

- `pnpm test -- src/lib/__tests__/prompt.test.ts`：28/28 通过
- Go 定向 roast prompt 回归：通过
- `pnpm typecheck`：通过
- `pnpm lint`：通过（仅有未修改文件中的既有 warning）
- `pnpm test`：612/612 通过
- `go test ./...`：通过
- `pnpm smoke:deployment:selftest`：通过
- `pnpm smoke:backend:async:selftest`：通过
- `pnpm smoke:backend:resilience:selftest`：通过
- `pnpm build`：通过

## 影响范围

该修改只约束新生成锐评对字段的解释，不改变贡献数、PR 数或评分结果。已经生成并缓存的旧锐评可能需要重新生成或等待缓存失效。