### PR TITLE
fix: profile snapshot data not updating after rescan

### DIFF
--- a/internal/backend/http.go
+++ b/internal/backend/http.go
@@ -753,6 +753,7 @@ func (s *APIServer) scan(w http.ResponseWriter, request *http.Request) {
 		TurnstileToken unknownString `json:"turnstileToken"`
 		Campaign       unknownString `json:"campaign"`
 	}
+	force := request.URL.Query().Get("force") == "1"
 	decoder := json.NewDecoder(io.LimitReader(request.Body, 16<<10))
 	if err := decoder.Decode(&input); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_body"}, nil)
@@ -811,7 +812,7 @@ func (s *APIServer) scan(w http.ResponseWriter, request *http.Request) {
 		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate_limited"}, headers)
 		return
 	}
-	if s.scanCache != nil {
+	if !force && s.scanCache != nil {
 		// Cache availability is deliberately not an admission dependency. This
 		// mirrors the existing best-effort cache read: a Redis miss/outage falls
 		// through to the durable worker rather than making a valid scan fail.

--- a/src/components/RescanButton.tsx
+++ b/src/components/RescanButton.tsx
@@ -58,7 +58,7 @@ export function RescanButton({
     }
     setStatus("scanning");
     try {
-      const scanRes = await fetch("/api/scan", {
+      const scanRes = await fetch("/api/scan?force=1", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, turnstileToken: token }),


### PR DESCRIPTION
## Summary

Fixes issue where profile snapshot data (bio, company, top repositories, impact repositories, organizations, signature work) does not update after rescan.

## Root Cause

The /api/scan endpoint caches results for 24 hours in Redis. When users click 'Rescan', the frontend calls POST /api/scan then POST /api/roast with refresh: true. The refresh parameter bypasses roast cache but not scan cache. Result: score and roast appear updated, but profile snapshot data remains stale.

## Changes

1. src/components/RescanButton.tsx: Add ?force=1 to /api/scan request
2. internal/backend/http.go: Check force query param and skip cache lookup when present

## Testing

- Rescan a profile via profile page -> bio/company/repos now reflect latest GitHub state
- Homepage scan with existing cached profile -> click rescan -> fresh data collected
- Normal scan (no force param) -> cache still used for performance

Fixes #217