### PR TITLE
feat: move LobeHub sponsor credit to a navbar top strip

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { MobileMenu } from "./MobileMenu";
 import { BrandMark } from "./BrandMark";
 import { GlobalSearch } from "./GlobalSearch";
 import { LanguageSwitcher } from "./LanguageSwitcher";
+import { SponsorStrip } from "./Sponsor";
 
 /**
  * Site-wide top bar. Keep the public-site feel: plain brand on the left, normal
@@ -21,6 +22,7 @@ export async function Navbar() {
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-white/10 bg-white/[0.03] backdrop-blur-xl">
+      <SponsorStrip />
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-6 px-5 sm:px-6">
         <Link
           href="/"

--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -20,7 +20,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { CopyBadge } from "./CopyBadge";
 import { ShareMenu } from "./ShareMenu";
-import { SponsorPill } from "./Sponsor";
 import { ShareCard } from "./ShareCard";
 import { ShareCardExportHost } from "./ShareCardExportHost";
 import { createShareCardBlob } from "./shareCardExport";
@@ -388,7 +387,6 @@ export function Roaster({
       </div>
 
       <div className="mt-3 flex flex-col items-center gap-3">
-        <SponsorPill large />
         {!campaign ? (
           <Button
             type="button"

--- a/src/components/Sponsor.tsx
+++ b/src/components/Sponsor.tsx
@@ -33,6 +33,30 @@ export function SponsorPill({ large = false }: { large?: boolean }) {
   );
 }
 
+/**
+ * Thin full-width strip rendered at the very top of the navbar. Replaces the
+ * homepage-only sponsor pill so the credit is visible on every page without
+ * eating hero real estate.
+ */
+export function SponsorStrip() {
+  return (
+    <div className="flex w-full items-center justify-center border-b border-white/10 bg-white/[0.03] px-4 py-1.5">
+      <a
+        href={SPONSOR.url}
+        target="_blank"
+        rel="noopener noreferrer sponsored"
+        className="inline-flex items-center gap-1.5 text-xs text-zinc-400 transition-colors hover:text-zinc-200"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={SPONSOR.logo} alt={SPONSOR.name} className="h-4 w-4 rounded" />
+        <span>
+          Powered by <span className="font-semibold">{SPONSOR.name}</span>
+        </span>
+      </a>
+    </div>
+  );
+}
+
 /** Tiny one-line credit for the global footer (every page). */
 export function PoweredByLobeHub() {
   return (


### PR DESCRIPTION
## 改动

- 首页 hero 里的 `SponsorPill large` 移除（带 "Bring your own key" 链接的按钮保留）
- 新增 `SponsorStrip`：导航栏最顶部的一条全宽细条（logo + Powered by LobeHub 链接）
- 复用现有语义化样式（`border-white/10`、`bg-white/[0.03]`），明暗主题都兼容

## 验证

- `pnpm typecheck` ✅
- `pnpm lint` ✅（0 errors，LiveRoast.tsx 的 1 个 warning 为既有问题）