### PR TITLE
fix(deps): approve esbuild build script (unblock CF auto-deploy)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true
-  esbuild: set this to true or false
+  esbuild: true
   sharp: true
   unrs-resolver: true
   workerd: true


### PR DESCRIPTION
pnpm-workspace.yaml 里 `allowBuilds.esbuild` 是 pnpm approve-builds 提示留下的占位符 `set this to true or false`，pnpm 视为未批准。CI 环境下（`CI=true`）pnpm 对 ignored builds 直接报错 `ERR_PNPM_IGNORED_BUILDS`，导致 deploy-cf-production 在 install 步挂掉（见 run 33315922585）。

改为 `true` 即可；esbuild 的 postinstall 只是校验二进制，平台二进制由 @esbuild/* 包提供，无安全风险。