### PR TITLE
feat(ui): restyle sponsor strip, label StepFun as model sponsor

### DIFF
--- a/src/components/Roaster.tsx
+++ b/src/components/Roaster.tsx
@@ -389,6 +389,7 @@ export function Roaster({
       <div className="mt-3 flex flex-col items-center gap-3">
         {!campaign ? (
           <div className="flex items-center gap-1.5 text-xs">
+            <span className="text-zinc-600">模型赞助商</span>
             <a
               href="https://www.stepfun.com/"
               target="_blank"

--- a/src/components/Sponsor.tsx
+++ b/src/components/Sponsor.tsx
@@ -45,13 +45,14 @@ export function SponsorStrip() {
         href={SPONSOR.url}
         target="_blank"
         rel="noopener noreferrer sponsored"
-        className="inline-flex items-center gap-1.5 text-xs text-zinc-400 transition-colors hover:text-zinc-200"
+        className="inline-flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-xs text-zinc-400 transition-colors hover:text-zinc-200"
       >
+        <span className="text-zinc-500">赞助商</span>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={SPONSOR.logo} alt={SPONSOR.name} className="h-4 w-4 rounded" />
-        <span>
-          Powered by <span className="font-semibold">{SPONSOR.name}</span>
-        </span>
+        <span className="font-semibold text-zinc-200">{SPONSOR.name}</span>
+        <span className="text-zinc-500">{SPONSOR.tagline}</span>
+        <span className="text-blue-500">了解更多 →</span>
       </a>
     </div>
   );

--- a/src/lib/__tests__/oauth-session.test.ts
+++ b/src/lib/__tests__/oauth-session.test.ts
@@ -1,3 +1,5 @@
+import { createHmac } from "node:crypto";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   decodeSignedPayload,
@@ -31,7 +33,6 @@ describe("oauth session signing (Go wire-format compatibility)", () => {
     // (Go-issued ghfind_session cookies must stay valid).
     const payload = { github_id: 1, login: "a", expires_at: 2 };
     const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
-    const { createHmac } = require("node:crypto") as typeof import("node:crypto");
     const sig = createHmac("sha256", "test-secret")
       .update(`ghfind:oauth:session:${encodedPayload}`)
       .digest("base64url");

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -9,6 +9,7 @@
 export const SPONSOR = {
   name: process.env.SPONSOR_NAME || "LobeHub",
   url: process.env.SPONSOR_URL || "https://lobehub.com",
+  tagline: "Your Chief Agent Operator · 你的首席 Agent 操作官",
   logo: "/lobehub.png",
   /**
    * 32px re-encode of the same mark. The SVG cards inline the logo as base64


### PR DESCRIPTION
顶栏赞助商条改为：赞助商 → logo → 名字 → tagline → 「了解更多 →」；Roaster 区 StepFun 前加「模型赞助商」字样。