### PR TITLE
ci: gate Cloudflare production releases and rollback failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,19 +69,26 @@ UPSTASH_REDIS_REST_TOKEN=
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
-# ── Leaderboard + percentile (optional) ───────────────────────────────────
-# Turso / libSQL. Stores account scores plus project analysis jobs, assessments,
-# treasure history and boards. Project-analysis writes fail loudly when absent.
-#   Cloud:  turso db create github-roast && turso db tokens create github-roast
+# ── Local database fallback ────────────────────────────────────────────────
+# Production uses the Cloudflare D1 binding GHFIND_D1 from wrangler.jsonc.
+# TURSO_* is retained for local development and compatibility with maintenance
+# scripts; do not use it as a replacement for the production D1 binding.
 #   Local:  TURSO_DATABASE_URL=file:./local.db   (no auth token needed)
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
 
-# ── Go API + worker (server-side; follow each variable's placement note) ─────
-# The Go API and Go worker reuse the Turso/Upstash resources above without any
-# migration. RabbitMQ is the durable task broker for work that must outlive an
-# HTTP request. The Go worker also receives GITHUB_TOKEN; the Go API and Vercel
-# must not. Use `amqps://` with a managed broker in production.
+# ── Cloudflare Worker runtime ──────────────────────────────────────────────
+# The frontend and backend execute in the same OpenNext Worker. Production
+# secrets are set with `wrangler secret put --env production`; do not commit
+# secret values or put them in NEXT_PUBLIC_* variables. D1 and R2 are bindings
+# managed in wrangler.jsonc. Upstash remains an external Redis REST service for
+# cache, coalescing, locks, and rate limits.
+# GHFIND_DEPLOY_ENV is supplied by wrangler.jsonc per environment.
+# Optional non-secret kill switch for hiding the GitHub login UI.
+# GHFIND_OAUTH_ENABLED=0
+
+# The following variables are retained only for the historical Go/Railway
+# fixture workflow and are not used by the current Cloudflare Worker:
 RABBITMQ_URL=amqp://guest:guest@localhost:5672/
 # Job state is stored under `ghfind:backend:job-status:v1:*` in the existing
 # Upstash instance and expires after seven days. e.g. 24h, 168h.
@@ -95,29 +102,17 @@ RABBITMQ_URL=amqp://guest:guest@localhost:5672/
 # 5000/h GraphQL), not the broker or the worker; add worker replicas
 # (competing consumers) beyond that.
 # GHFIND_SCAN_WORKER_CONCURRENCY=8
-# Go listener for local compose/VPS. Railway's injected PORT is honored when
-# this is unset.
+# Go listener for the historical local compose/VPS workflow.
 # GHFIND_API_LISTEN_ADDR=:8080
-# Trust Vercel's platform client-IP header for Go-side rate limits. Enable only
-# when direct API ingress is restricted to Vercel/ops traffic; otherwise the Go
-# API falls back to the non-spoofable socket RemoteAddr.
+# Historical Vercel-to-Go forwarding trust flag; do not set for Cloudflare.
 # GHFIND_TRUST_VERCEL_HEADERS=1
-# Worker metrics listener. Expose only to Railway private networking,
-# Prometheus, or an SSH tunnel; browsers and Vercel do not need it.
+# Historical Go worker metrics listener.
 # GHFIND_WORKER_METRICS_LISTEN_ADDR=:9090
 
-# Set only in the Vercel server environment after the Go API is deployed. This
-# preserves https://ghfind.com/api/* through a transparent rewrite. Do not set
-# it to a public browser variable and do not append a path.
+# Retired split-backend variable; the current single Worker has no backend origin.
 # GHFIND_BACKEND_ORIGIN=https://api-staging.example.com
-# Optional non-secret kill switch for hiding GitHub login UI while the Go OAuth
-# endpoint is being repaired. Do not configure OAuth client secrets in Vercel.
-# GHFIND_OAUTH_ENABLED=0
-
-# Required only once POST /api/vs-verdict is migrated. Set the same random
-# value in the Go API and Vercel *server* environment (never NEXT_PUBLIC_*).
-# It authenticates the small BotID verification gateway to the private Go
-# endpoint; do not give it to the worker or a browser.
+# Retired Vercel BotID gateway credential; no longer used by the same-origin
+# Cloudflare route.
 # GHFIND_VERDICT_GATEWAY_SECRET=
 
 # ── Admin endpoints (optional) ────────────────────────────────────────────
@@ -126,28 +121,31 @@ RABBITMQ_URL=amqp://guest:guest@localhost:5672/
 ADMIN_SECRET=
 
 # Public origin (used for metadata, API profile URLs, share links, and provider
-# attribution). Vercel Production requires both values to be identical HTTPS
+# attribution). Cloudflare production requires both values to be identical HTTPS
 # origins; the default production origin is https://ghfind.com.
 NEXT_PUBLIC_SITE_URL=https://ghfind.com
 PUBLIC_SITE_URL=https://ghfind.com
 
-# ── 用户登录 / GitHub OAuth (Go API only; optional) ───────────────────────
+# ── 用户登录 / GitHub OAuth (Worker server-side; optional) ─────────────────
 # Lets visitors "Login with GitHub" (identity only for now). If these are
 # absent, the login entry is hidden and everything else works unchanged.
 # Create a GitHub OAuth App: https://github.com/settings/developers
 #   Homepage URL              = https://ghfind.com
 #   Authorization callback URL = https://ghfind.com/api/auth/callback/github
-#   For local Go API dev, add another or use http://localhost:8080/api/auth/callback/github
-# Store these only in the Go API service. Vercel only needs GHFIND_BACKEND_ORIGIN
-# so /api/auth/* is transparently rewritten to Go.
+#   For local app dev, add another or use http://localhost:3000/api/auth/callback/github
+# Store these as Worker secrets in production; never expose them through
+# NEXT_PUBLIC_* variables.
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
 # Session signing secret. Generate: openssl rand -base64 33   (or: npx auth secret)
 AUTH_SECRET=
-# Usually auto-trusted on Vercel; set to true only if login callbacks misbehave.
+# Set to true only if login callbacks require explicit host trust.
 # AUTH_TRUST_HOST=true
 
-# ── Railway staging 一键部署（scripts/deploy-staging.sh）──────────────────
+# ── Historical split-backend staging (scripts/deploy-staging.sh) ────────────
+# This block is retained only for the old Go/Railway fixture workflow. It is not
+# the current production deployment path; use docs/operations/cloudflare-
+# deployment-runbook.md for the Cloudflare Worker.
 # 以下变量只经环境变量传给脚本，绝不写入文件/仓库。填好后：
 #   set -a && source .env.staging && set +a && ./scripts/deploy-staging.sh
 #

--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -1,19 +1,23 @@
 name: Deploy production (Cloudflare)
 
 # Replaces the retired Vercel/Railway gate: ghfind.com is now served by the
-# Next-on-Workers (OpenNext) build. A push to main runs the exact same command
-# as a manual release — build, `wrangler deploy --env production`, and R2
-# incremental-cache population — against the merged commit.
+# Next-on-Workers (OpenNext) build. A successful CI run on the merged `main`
+# commit is the only automatic production trigger. The workflow checks out the
+# exact SHA that CI verified, then runs the build, `wrangler deploy --env
+# production`, R2 incremental-cache population, and a read-only public smoke.
+# Any failure after the rollback anchor is captured restores the previous
+# Worker version. Frontend and backend are one Worker in the current topology,
+# so that single rollback covers both request surfaces.
 #
 # Required GitHub secrets:
 # - CF_API_TOKEN — Cloudflare API token ("Edit Cloudflare Workers" template)
 # The account ID is intentionally pinned below to Beiming1201@gmail.com's Account.
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
-  # Manual escape hatch when a push trigger is lost.
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,6 +29,7 @@ concurrency:
 jobs:
   deploy:
     name: Build and deploy to Cloudflare Workers (production)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -33,6 +38,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       # No `version:` — pnpm/action-setup reads packageManager from
       # package.json (pnpm@11.24.0); pinning a second version here breaks the
@@ -49,10 +56,86 @@ jobs:
       - name: Install locked dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Capture rollback target
+        id: release
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
+          previous_version="$(
+            pnpm exec wrangler deployments status \
+              --name ghfind \
+              --env production \
+              --json \
+              | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("production is not a single 100% deployment") end'
+          )"
+          test -n "$previous_version"
+          echo "previous_version=$previous_version" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Cloudflare production release"
+            echo "- Commit: `$RELEASE_SHA`"
+            echo "- Account: `$CLOUDFLARE_ACCOUNT_ID`"
+            echo "- Rollback target: `$previous_version`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Deploy (build + wrangler deploy --env production + populateCache)
+        id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
         run: |
           test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
           pnpm cf:deploy:prod
+
+      - name: Post-deploy read-only smoke
+        id: smoke
+        env:
+          SMOKE_BASE_URL: https://ghfind.com
+          SMOKE_CANARY_HANDLE: octocat
+          SMOKE_FACET_TYPE: language
+          SMOKE_FACET_VALUE: TypeScript
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if pnpm smoke:deployment; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep 5
+            fi
+          done
+          exit 1
+
+      - name: Roll back frontend and backend Worker
+        id: rollback
+        if: ${{ failure() && steps.release.outputs.previous_version != '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+          PREVIOUS_VERSION: ${{ steps.release.outputs.previous_version }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
+          pnpm exec wrangler rollback "$PREVIOUS_VERSION" \
+            --name ghfind \
+            --env production \
+            --message "rollback: post-deploy verification failed for $RELEASE_SHA" \
+            --yes
+          {
+            echo "### Automatic rollback"
+            echo "- Restored Worker version: `$PREVIOUS_VERSION`"
+            echo "- Failed release commit: `$RELEASE_SHA`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify rollback
+        if: ${{ always() && steps.rollback.outcome == 'success' }}
+        env:
+          SMOKE_BASE_URL: https://ghfind.com
+          SMOKE_CANARY_HANDLE: octocat
+          SMOKE_FACET_TYPE: language
+          SMOKE_FACET_VALUE: TypeScript
+        run: pnpm smoke:deployment

--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -7,7 +7,7 @@ name: Deploy production (Cloudflare)
 #
 # Required GitHub secrets:
 # - CF_API_TOKEN — Cloudflare API token ("Edit Cloudflare Workers" template)
-# - CF_ACCOUNT_ID — Cloudflare account ID
+# The account ID is intentionally pinned below to Beiming1201@gmail.com's Account.
 
 on:
   push:
@@ -52,5 +52,7 @@ jobs:
       - name: Deploy (build + wrangler deploy --env production + populateCache)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        run: pnpm cf:deploy:prod
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+        run: |
+          test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
+          pnpm cf:deploy:prod

--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -1,9 +1,10 @@
 name: Deploy production (Cloudflare)
 
 # Replaces the retired Vercel/Railway gate: ghfind.com is now served by the
-# Next-on-Workers (OpenNext) build. A successful CI run on the merged `main`
-# commit is the only automatic production trigger. The workflow checks out the
-# exact SHA that CI verified, then runs the build, `wrangler deploy --env
+# Next-on-Workers (OpenNext) build. A successful CI run for a `main` commit is
+# the only automatic production trigger; main branch protection is optional.
+# The workflow checks out the exact SHA that CI verified, then runs the build,
+# `wrangler deploy --env
 # production`, R2 incremental-cache population, and a read-only public smoke.
 # Any failure after the rollback anchor is captured restores the previous
 # Worker version. Frontend and backend are one Worker in the current topology,

--- a/README.md
+++ b/README.md
@@ -185,29 +185,37 @@ facts.
 
 See [`.env.example`](./.env.example). The minimum to run the GitHub roast flow is `GITHUB_TOKEN` + `LLM_API_KEY` (defaults to StepFun, OpenAI-compatible; swap in any OpenAI-compatible service). Cache, rate limiting, human verification, GitHub login, profile comments/reactions, and the leaderboard **degrade silently** when unconfigured in local development. Production requires `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`: when the limiter is unavailable, only protected uncached cost-bearing routes return `503` with `Retry-After`; edge-cached responses and ordinary browsing continue. `RATE_LIMIT_FAIL_OPEN=1` is an emergency operator override and should not be set during normal operation.
 
-## Leaderboard + percentile (Turso, optional)
+## Leaderboard + percentile (Cloudflare D1)
 
-Configure `TURSO_*` to unlock the "Hall of Fame" leaderboard (`/leaderboard`) and the result page's "🏆 You beat X% of developers".
+Production stores scores in the Cloudflare D1 `GHFIND_D1` binding configured in
+`wrangler.jsonc`. Follow the [Cloudflare deployment runbook](./docs/operations/cloudflare-deployment-runbook.md)
+to verify the target account and database before deploying. `TURSO_*` remains a
+local/maintenance fallback and is not the production database.
 Each scan upserts the account's latest score into the DB (one row per account); percentile = the share of stored scores strictly below yours.
 **The public board only lists accounts scoring ≥60**; lower scores still count toward the percentile but are not publicly named (anti-harassment). The whole feature degrades silently when unconfigured.
 
 ```bash
-# cloud
-turso db create github-roast
-turso db tokens create github-roast   # gives TURSO_DATABASE_URL(libsql://...) + TURSO_AUTH_TOKEN
-# local dev, no cloud
+# local development only
 TURSO_DATABASE_URL=file:./local.db
 ```
 
-## Deploy to Vercel
+## Deploy to Cloudflare Workers
 
-1. Push to GitHub, import in Vercel.
-2. Configure environment variables (as above). `UPSTASH_*` can be provisioned in one click via Vercel's Upstash integration.
-3. Grab a Cloudflare Turnstile site/secret key pair; set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`.
-4. (Optional) Turso: `TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` to enable the leaderboard, archived reports, profile comments/reactions, and persisted quick-scan profiles.
-5. (Optional) GitHub OAuth: `AUTH_GITHUB_ID` + `AUTH_GITHUB_SECRET` + `AUTH_SECRET` to enable signed-in comments/reactions.
-6. Set both `NEXT_PUBLIC_SITE_URL` and `PUBLIC_SITE_URL` to the same HTTPS origin. Vercel Production rejects a missing, local, HTTP, malformed, or mismatched value during the build so metadata, sitemap, API profile URLs, cards, and LLM attribution cannot drift.
-7. Deploy the web application.
+The frontend and backend run together in one OpenNext Cloudflare Worker. See the
+[Cloudflare deployment runbook](./docs/operations/cloudflare-deployment-runbook.md)
+for account/resource preflight, secrets, smoke checks, and rollback.
+
+```bash
+pnpm exec wrangler whoami
+pnpm cf:build
+pnpm cf:deploy:dev       # dev.ghfind.com
+pnpm cf:deploy:prod      # ghfind.com
+```
+
+Production deploys also run from
+[`.github/workflows/deploy-cf-production.yml`](./.github/workflows/deploy-cf-production.yml)
+on `main`. Configure secrets with `wrangler secret put --env <env>`; do not commit
+secret values. Cloudflare D1/R2 bindings are defined in [`wrangler.jsonc`](./wrangler.jsonc).
 
 ## Bring your own model / API key
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -182,29 +182,36 @@ agent 要判断单个账号时应使用 `scan` 或 `score`;排行榜和开发者
 
 见 [`.env.example`](./.env.example)。GitHub 评分流程最小可跑只需 `GITHUB_TOKEN` + `LLM_API_KEY`(默认 StepFun 阶跃,OpenAI 兼容;可换任意 OpenAI 兼容服务);缓存、限流、人机校验、GitHub 登录、个人页评论/反应、排行榜在未配置时会**静默降级**(适合本地)。生产强烈建议全配齐。
 
-## 排行榜 + 百分位(Turso,可选)
+## 排行榜 + 百分位(Cloudflare D1)
 
-配置 `TURSO_*` 后解锁「名人堂排行榜」(`/leaderboard`) 和结果页的「🏆 你超越了 X% 的开发者」。
+生产环境使用 `wrangler.jsonc` 中的 Cloudflare D1 绑定 `GHFIND_D1`。部署前请按
+[Cloudflare 部署手册](./docs/operations/cloudflare-deployment-runbook.md)核对目标账号和数据库；`TURSO_*`
+只保留给本地开发/维护脚本，不是生产数据库。
 每次扫描把账号的最新分数 upsert 进库(一账号一行);百分位 = 库里分数严格低于你的占比。
 **公开榜只收录 ≥60 分的账号**,低分号仍参与百分位统计但不被公开点名(防骚扰)。未配置时整套功能静默降级。
 
 ```bash
-# 云端
-turso db create github-roast
-turso db tokens create github-roast   # 得到 TURSO_DATABASE_URL(libsql://...) + TURSO_AUTH_TOKEN
-# 本地开发免云
+# 仅本地开发
 TURSO_DATABASE_URL=file:./local.db
 ```
 
-## 部署到 Vercel
+## 部署到 Cloudflare Workers
 
-1. Push 到 GitHub,在 Vercel 导入。
-2. 配置环境变量(同上)。`UPSTASH_*` 用 Vercel 的 Upstash 集成一键开通。
-3. Cloudflare Turnstile 拿一对 site/secret key,配 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`。
-4. (可选)Turso:`TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` 开排行榜、归档报告、个人页评论/反应。
-5. (可选)GitHub OAuth:`AUTH_GITHUB_ID` + `AUTH_GITHUB_SECRET` + `AUTH_SECRET` 开启登录评论/反应。
-6. (可选)自定义域名部署时设置 `PUBLIC_SITE_URL`,保证 metadata、sitemap、卡片和 LLM attribution 使用正确域名。
-7. Deploy。
+当前前端和后端由同一个 OpenNext Cloudflare Worker 承载。账号/资源预检、
+Secrets、冒烟验证和回滚请看
+[Cloudflare 部署手册](./docs/operations/cloudflare-deployment-runbook.md)。
+
+```bash
+pnpm exec wrangler whoami
+pnpm cf:build
+pnpm cf:deploy:dev       # dev.ghfind.com
+pnpm cf:deploy:prod      # ghfind.com
+```
+
+生产部署也会由 `main` 分支触发
+[Cloudflare GitHub Actions](./.github/workflows/deploy-cf-production.yml)。
+Secrets 用 `wrangler secret put --env <env>` 配置，不要提交密钥值；Cloudflare
+D1/R2 绑定统一维护在 [`wrangler.jsonc`](./wrangler.jsonc)。
 
 ## 自带模型 / API Key
 

--- a/docs/operations/backend-route-ownership.md
+++ b/docs/operations/backend-route-ownership.md
@@ -1,4 +1,9 @@
-# Backend route ownership matrix
+# Historical backend route ownership matrix
+
+> **Historical reference.** This matrix records the pre-migration Go extraction
+> boundary and is retained for contract/history review. The current app is a
+> single Cloudflare Worker with same-origin page and API routes. For current
+> deployment and rollback, use the [Cloudflare deployment runbook](./cloudflare-deployment-runbook.md).
 
 This matrix is the cutover checklist for issue #170. A route is only marked
 **Go-owned** after its Next handler contains no direct data/business dependency,

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -24,6 +24,12 @@ The authoritative deployment files are:
 - [`.github/workflows/deploy-cf-production.yml`](../../.github/workflows/deploy-cf-production.yml) — production push/manual release.
 - [`scripts/smoke-deployment.mts`](../../scripts/smoke-deployment.mts) — read-only public smoke checks.
 
+Production ownership is fixed: `ghfind` must be deployed to
+`Beiming1201@gmail.com's Account` (`8f19bebe359e4ec1a24c68c5f49c1584`). The
+repository config and production workflow pin this account. The
+`AsperforMias` account is not a production target and must not be used for
+production Workers, D1, R2, or Secrets.
+
 ## Hard stop: preflight the target account and resources
 
 Run these checks from the repository root before a remote deployment:
@@ -35,6 +41,12 @@ pnpm exec wrangler d1 info ghfind
 pnpm exec wrangler r2 bucket list
 pnpm exec wrangler secret list --env dev
 pnpm exec wrangler secret list --env production
+```
+
+For production, the account check is mandatory:
+
+```bash
+test "${CLOUDFLARE_ACCOUNT_ID:-8f19bebe359e4ec1a24c68c5f49c1584}" = "8f19bebe359e4ec1a24c68c5f49c1584"
 ```
 
 Confirm all of the following before continuing:
@@ -49,14 +61,16 @@ Confirm all of the following before continuing:
 4. The production values of `PUBLIC_SITE_URL` and `NEXT_PUBLIC_SITE_URL` are both
    `https://ghfind.com`. The dev values are both `https://dev.ghfind.com`.
 
-If the OAuth session can access multiple Cloudflare accounts, set the account
-explicitly for the command or CI job with `CLOUDFLARE_ACCOUNT_ID`. Do not deploy
-until the D1 and R2 inventory is visible in that account.
+If the OAuth session can access multiple Cloudflare accounts, the production
+commands in this repository force `CLOUDFLARE_ACCOUNT_ID` to the Beiming account.
+Do not replace it with an `AsperforMias` account ID and do not deploy until the
+D1 and R2 inventory is visible in Beiming.
 
 For a local release, the explicit form is:
 
 ```bash
 export CLOUDFLARE_ACCOUNT_ID=<target-account-id>
+export CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584
 pnpm exec wrangler d1 list
 pnpm exec wrangler r2 bucket list
 ```
@@ -131,9 +145,11 @@ pnpm cf:deploy:prod
 ```
 
 The same command runs from `.github/workflows/deploy-cf-production.yml` on pushes
-to `main` and through `workflow_dispatch`. The CI job supplies
-`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`; the token must have permission
-to deploy Workers and access the configured D1/R2 resources.
+to `main` and through `workflow_dispatch`. The repository script pins the
+Beiming account and deploys with `--keep-vars`, preserving dashboard variables;
+Worker Secrets are not removed by a code deployment. CI supplies
+`CLOUDFLARE_API_TOKEN`; the token must have permission to deploy Workers and
+access the configured D1/R2 resources.
 
 Before a production release, record the current active deployment and run the
 local checks required by CI:

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -157,10 +157,11 @@ failure invokes `wrangler rollback` to restore the captured version, then runs
 the smoke again against the restored origin. Because the current frontend and
 backend are one Worker, this is a single atomic application rollback for both.
 
-Protect `main` in GitHub and require the `CI / Verify release` check before
-merging. The workflow-level gate prevents a failed CI run from deploying even
-if an administrator bypasses branch protection; branch protection is still
-needed to enforce merge-only changes.
+Main branch protection is optional for this release design. The deployment
+workflow is the release gate: it reacts only to a successful `CI` completion on
+`main`, so a commit whose CI fails is never deployed. If branch protection is
+enabled separately, the relevant check name is `Verify release`; it is not
+required for the rollback behavior below.
 
 Before a production release, record the current active deployment and run the
 local checks required by CI:
@@ -220,8 +221,9 @@ production release gate.
 
 ## Automated rollback
 
-The production workflow records the active Worker version before publishing.
-If build/deploy/post-deploy smoke fails, it automatically runs:
+The production workflow records the active 100% Worker version before each
+serialized release. If build/deploy/post-deploy smoke fails, it automatically
+runs:
 
 ```bash
 pnpm exec wrangler rollback <CAPTURED_VERSION_ID> --name ghfind --env production --message "rollback: post-deploy verification failed" --yes
@@ -230,6 +232,12 @@ pnpm exec wrangler rollback <CAPTURED_VERSION_ID> --name ghfind --env production
 It then repeats the read-only smoke. A failed rollback verification keeps the
 GitHub Actions run failed and requires operator intervention.
 
+The captured version is the last release that was active before the current
+release started. With `cancel-in-progress: false`, queued releases are handled
+one at a time: if commit1 is the last smoke-qualified release and commits2
+through5 fail, each failed release returns to commit1. If an intermediate
+release passes its post-deploy smoke, that release becomes the new rollback
+anchor for the releases that follow.
 ## Manual rollback
 
 Cloudflare rollback is a Worker-version rollback; DNS does not need to be changed

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -21,7 +21,7 @@ The authoritative deployment files are:
 
 - [`wrangler.jsonc`](../../wrangler.jsonc) — Worker environments and D1/R2 bindings.
 - [`package.json`](../../package.json) — build and deploy scripts.
-- [`.github/workflows/deploy-cf-production.yml`](../../.github/workflows/deploy-cf-production.yml) — production push/manual release.
+- [`.github/workflows/deploy-cf-production.yml`](../../.github/workflows/deploy-cf-production.yml) — CI-gated production release and automatic Worker rollback.
 - [`scripts/smoke-deployment.mts`](../../scripts/smoke-deployment.mts) — read-only public smoke checks.
 
 Production ownership is fixed: `ghfind` must be deployed to
@@ -144,12 +144,23 @@ The normal local/manual release command is:
 pnpm cf:deploy:prod
 ```
 
-The same command runs from `.github/workflows/deploy-cf-production.yml` on pushes
-to `main` and through `workflow_dispatch`. The repository script pins the
-Beiming account and deploys with `--keep-vars`, preserving dashboard variables;
-Worker Secrets are not removed by a code deployment. CI supplies
-`CLOUDFLARE_API_TOKEN`; the token must have permission to deploy Workers and
-access the configured D1/R2 resources.
+The repository script pins the Beiming account and deploys with `--keep-vars`,
+preserving dashboard variables; Worker Secrets are not removed by a code
+deployment. CI supplies `CLOUDFLARE_API_TOKEN`; the token must have permission
+to deploy Workers and access the configured D1/R2 resources.
+
+The automatic production workflow is triggered by a successful `CI` workflow
+completion on `main`, not by a raw push. It checks out the exact commit SHA that
+CI verified, captures the active 100% Worker version, deploys, and runs the
+read-only production smoke three times at most. A build, deployment, or smoke
+failure invokes `wrangler rollback` to restore the captured version, then runs
+the smoke again against the restored origin. Because the current frontend and
+backend are one Worker, this is a single atomic application rollback for both.
+
+Protect `main` in GitHub and require the `CI / Verify release` check before
+merging. The workflow-level gate prevents a failed CI run from deploying even
+if an administrator bypasses branch protection; branch protection is still
+needed to enforce merge-only changes.
 
 Before a production release, record the current active deployment and run the
 local checks required by CI:
@@ -207,7 +218,19 @@ The `smoke:backend:*` scripts and the old Railway/Vercel resilience evidence are
 historical tests for the retired split backend topology. They are not the current
 production release gate.
 
-## Rollback
+## Automated rollback
+
+The production workflow records the active Worker version before publishing.
+If build/deploy/post-deploy smoke fails, it automatically runs:
+
+```bash
+pnpm exec wrangler rollback <CAPTURED_VERSION_ID> --name ghfind --env production --message "rollback: post-deploy verification failed" --yes
+```
+
+It then repeats the read-only smoke. A failed rollback verification keeps the
+GitHub Actions run failed and requires operator intervention.
+
+## Manual rollback
 
 Cloudflare rollback is a Worker-version rollback; DNS does not need to be changed
 back to Vercel:

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -1,0 +1,221 @@
+# Cloudflare deployment runbook
+
+This is the current release and rollback guide for GitHub Roast.
+
+## Current topology
+
+The frontend and backend are deployed together as one Next-on-Workers application
+through `@opennextjs/cloudflare`:
+
+| Environment | Worker | Public origin | Cloudflare resources |
+| --- | --- | --- | --- |
+| dev | `ghfind-dev` | `https://dev.ghfind.com` | D1 binding `GHFIND_D1`, R2 `ghfind-next-cache-dev` |
+| production | `ghfind` | `https://ghfind.com` | D1 binding `GHFIND_D1`, R2 `ghfind-next-cache` |
+
+There is no Vercel frontend, Railway API, `GHFIND_BACKEND_ORIGIN`, or same-origin
+backend rewrite in the current production path. Browser and machine clients call
+the same Worker origin. Upstash Redis, GitHub, LLM providers, and Mosoo remain
+external services reached by the Worker through server-side secrets.
+
+The authoritative deployment files are:
+
+- [`wrangler.jsonc`](../../wrangler.jsonc) — Worker environments and D1/R2 bindings.
+- [`package.json`](../../package.json) — build and deploy scripts.
+- [`.github/workflows/deploy-cf-production.yml`](../../.github/workflows/deploy-cf-production.yml) — production push/manual release.
+- [`scripts/smoke-deployment.mts`](../../scripts/smoke-deployment.mts) — read-only public smoke checks.
+
+## Hard stop: preflight the target account and resources
+
+Run these checks from the repository root before a remote deployment:
+
+```bash
+pnpm exec wrangler whoami
+pnpm exec wrangler d1 list
+pnpm exec wrangler d1 info ghfind
+pnpm exec wrangler r2 bucket list
+pnpm exec wrangler secret list --env dev
+pnpm exec wrangler secret list --env production
+```
+
+Confirm all of the following before continuing:
+
+1. The account that owns the configured D1 database is the account Wrangler will
+   deploy to. Compare the `database_id` in `wrangler.jsonc` with `wrangler d1
+   list`/`wrangler d1 info ghfind`; do not create an empty replacement database
+   merely to make deployment pass.
+2. `ghfind-next-cache-dev` and `ghfind-next-cache` exist in the same account.
+3. Required secrets exist in the target environment. `secret list` exposes names,
+   not values; never paste secret values into a command, log, issue, or screenshot.
+4. The production values of `PUBLIC_SITE_URL` and `NEXT_PUBLIC_SITE_URL` are both
+   `https://ghfind.com`. The dev values are both `https://dev.ghfind.com`.
+
+If the OAuth session can access multiple Cloudflare accounts, set the account
+explicitly for the command or CI job with `CLOUDFLARE_ACCOUNT_ID`. Do not deploy
+until the D1 and R2 inventory is visible in that account.
+
+For a local release, the explicit form is:
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=<target-account-id>
+pnpm exec wrangler d1 list
+pnpm exec wrangler r2 bucket list
+```
+
+### Important dev-data warning
+
+At the time of writing, `wrangler.jsonc` gives both `dev` and `production` the same
+`GHFIND_D1` database ID. The R2 cache buckets are separate, but the D1 data is not.
+Until a separate staging D1 is deliberately created and configured, treat dev as
+a production-data environment: do not run write-path scan/roast or destructive
+SQL smoke tests against `dev.ghfind.com`.
+
+## Secrets
+
+Set secrets interactively for each Worker environment. Never commit a secret file:
+
+```bash
+pnpm exec wrangler secret put GITHUB_TOKEN --env production
+pnpm exec wrangler secret put LLM_API_KEY --env production
+pnpm exec wrangler secret put UPSTASH_REDIS_REST_URL --env production
+pnpm exec wrangler secret put UPSTASH_REDIS_REST_TOKEN --env production
+pnpm exec wrangler secret put TURNSTILE_SECRET_KEY --env production
+pnpm exec wrangler secret put AUTH_GITHUB_ID --env production
+pnpm exec wrangler secret put AUTH_GITHUB_SECRET --env production
+pnpm exec wrangler secret put AUTH_SECRET --env production
+pnpm exec wrangler secret put ADMIN_SECRET --env production
+```
+
+Add the optional fallback LLM, Mosoo, CLI, Resend, and project-analysis secrets
+when those features are enabled. Repeat the required set for `--env dev` only if
+the dev Worker is intended to be used; do not copy production OAuth or write-path
+credentials into dev without an explicit data-safety decision.
+
+`NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `PUBLIC_SITE_URL`, and
+`NEXT_PUBLIC_SITE_URL` are non-secret build/runtime variables. The first is set in
+the deployment environment; the latter two are already defined per environment in
+`wrangler.jsonc` and must remain equal to the public origin.
+
+## Validate without changing Cloudflare
+
+Build and validate the Worker bundle before publishing it:
+
+```bash
+pnpm cf:build
+pnpm exec wrangler deploy --env dev --dry-run
+pnpm exec wrangler deploy --env production --dry-run
+```
+
+`--dry-run` is a validation step only. It must not be treated as proof that the
+remote account has the configured D1/R2 resources; the preflight above is still
+required.
+
+## Deploy dev
+
+Only deploy dev after the resource preflight and the D1 data-safety warning have
+been acknowledged:
+
+```bash
+pnpm cf:deploy:dev
+```
+
+The script builds OpenNext, deploys `ghfind-dev`, and populates the remote R2
+incremental cache. Use this repository script as the release command so the
+cache-population step is explicit and remains coupled to the Worker deployment.
+
+## Deploy production
+
+The normal local/manual release command is:
+
+```bash
+pnpm cf:deploy:prod
+```
+
+The same command runs from `.github/workflows/deploy-cf-production.yml` on pushes
+to `main` and through `workflow_dispatch`. The CI job supplies
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`; the token must have permission
+to deploy Workers and access the configured D1/R2 resources.
+
+Before a production release, record the current active deployment and run the
+local checks required by CI:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm cf:build
+```
+
+If `migrations/` changed, review and apply the migration to the intended remote
+D1 before publishing the Worker:
+
+```bash
+pnpm exec wrangler d1 migrations list ghfind --remote --env production
+pnpm exec wrangler d1 migrations apply ghfind --remote --env production
+```
+
+Run this only after the account/database preflight. A Worker-version rollback does
+not undo an applied D1 migration; schema changes need a separately reviewed
+forward-fix or data recovery plan.
+
+## Post-deploy smoke
+
+The smoke is read-only and exercises the public Worker origin. It does not start a
+scan or roast. Configure the values privately in the shell or deployment runner:
+
+```bash
+export SMOKE_BASE_URL=https://dev.ghfind.com
+export SMOKE_CANARY_HANDLE=octocat
+export SMOKE_FACET_TYPE=language
+export SMOKE_FACET_VALUE=JavaScript
+pnpm smoke:deployment
+```
+
+For production, change only `SMOKE_BASE_URL` to `https://ghfind.com` and use a
+known indexed canary/facet value. The smoke covers profile, score, profile data,
+badge, autocomplete, leaderboard, developer facets, projects, sitemap inventory,
+MCP `tools/list`, and campaign SSE. If a previously admitted scan job is available,
+set `SMOKE_SCAN_JOB_ID`, `SMOKE_SCAN_JOB_USERNAME`, and
+`SMOKE_SCAN_JOB_EXPECT_RESULT=1` to verify its public result path.
+
+For the rate-limit incident, add a manual browser check after the read-only smoke:
+
+1. Open the public site in a normal browser and submit one roast.
+2. Confirm the browser `/api/roast` request is not rejected by the machine-only
+   authentication path or a global edge rule.
+3. Confirm repeated requests use the expected cached/reuse path and that a true
+   machine request still receives the intended authentication/rate-limit response.
+4. If behavior is unclear, inspect the Worker with `pnpm exec wrangler tail ghfind`
+   or the Workers Logs dashboard; never log request bodies, API keys, or cookies.
+
+The `smoke:backend:*` scripts and the old Railway/Vercel resilience evidence are
+historical tests for the retired split backend topology. They are not the current
+production release gate.
+
+## Rollback
+
+Cloudflare rollback is a Worker-version rollback; DNS does not need to be changed
+back to Vercel:
+
+```bash
+pnpm exec wrangler deployments list --name ghfind
+pnpm exec wrangler rollback <VERSION_ID> --name ghfind --message "rollback: <reason>"
+```
+
+`wrangler rollback` immediately makes the selected version active across the
+Worker's routes and domains. Verify the public origin with the same smoke command
+after rollback. A code rollback does not undo D1 schema/data changes, R2 objects,
+Redis keys, or external-provider side effects; those require a separate, reviewed
+recovery operation.
+
+For dev, use the same commands with `--name ghfind-dev`. Do not delete the Worker,
+custom domain, D1 database, or R2 bucket as an incident response shortcut.
+
+## Release evidence
+
+Record the following for every production release or rollback:
+
+- git commit and Cloudflare Worker deployment/version ID;
+- target account ID and confirmation that D1/R2 preflight passed;
+- smoke command, origin, timestamp, and result;
+- any changed D1 migration, secret name, WAF rule, or cache action;
+- rollback target and the post-rollback smoke result, if rollback occurred.

--- a/docs/operations/go-backend-runbook.md
+++ b/docs/operations/go-backend-runbook.md
@@ -1,4 +1,10 @@
-# Go backend extraction runbook
+# Historical Go backend extraction runbook
+
+> **Archived architecture.** This document describes the retired Vercel frontend
+> plus Railway/Go backend split. The current frontend and backend run together in
+> the Cloudflare Worker. Do not use the deployment, secret placement, staging, or
+> rollback instructions below for production. Use the [current Cloudflare
+> deployment runbook](./cloudflare-deployment-runbook.md) instead.
 
 ## Ownership and topology
 

--- a/docs/plans/2026-08-28-cloudflare-migration-analysis.md
+++ b/docs/plans/2026-08-28-cloudflare-migration-analysis.md
@@ -1,6 +1,7 @@
-# 全面迁移 Cloudflare 分析：Railway + Turso + Vercel 下线
+# 历史归档：Cloudflare 迁移分析
 
 > 2026-08-28。基于对当前 main 分支的全量代码摸底（前端 Vercel 面 / Railway Go 后端 / Turso 数据层三路并行审计）。
+> **状态：历史分析。** 迁移已完成，当前前端页面和 `/api/*` 后端由同一个 OpenNext Cloudflare Worker 承载。现行部署、冒烟、账号/资源预检和回滚请看 [`../operations/cloudflare-deployment-runbook.md`](../operations/cloudflare-deployment-runbook.md)。本文保留迁移前基线、目标映射和风险记录，不是当前生产拓扑说明。
 > 前提约束：**项目分析继续用 Mosoo**（try.mosoo.ai 外部 API，不迁移）；LLM 供应商（StepFun/DeepSeek）不变；`ghfind` CLI 不变（只走 HTTP）。
 
 ---

--- a/docs/plans/2026-08-28-cloudflare-migration-execution.md
+++ b/docs/plans/2026-08-28-cloudflare-migration-execution.md
@@ -2,13 +2,15 @@
 
 > 2026-08-28。分析背景与成本测算见 [2026-08-28-cloudflare-migration-analysis.md](./2026-08-28-cloudflare-migration-analysis.md)，本文件是可执行的作战清单，按阶段推进、逐项勾销。
 > 原则：**每一步生产零感知；切正式 = 改一条 DNS 记录；任何时刻可秒级回滚。**
+>
+> **当前状态（2026-09-02）：迁移已完成。** 前端页面和 `/api/*` 后端现由同一个 OpenNext Cloudflare Worker 承载；当前发布、冒烟和版本回滚请以 [`cloudflare-deployment-runbook.md`](../operations/cloudflare-deployment-runbook.md) 为准。本文的阶段清单和后续进度条目保留作迁移历史，不再表示当前线上拓扑。
 
 ## 环境与命名
 
 | 环境 | 前端 | 后端 API | 数据面 |
 |---|---|---|---|
-| dev（新建，常驻，未来即 staging） | `dev.ghfind.com` → Workers (env: dev) | `api-dev.ghfind.com` → Workers (env: dev)；阶段 1 期间暂指 Railway/staging mocks | `GHFIND_STAGING_*` 那套（staging Turso/Upstash/Mosoo） |
-| production | `ghfind.com` / `www`（切换前 = Vercel 灰云记录；切换后 = Workers env: production） | 阶段 2 起 `api.ghfind.com`（或纯 Service Binding 不出网） | 生产 Turso/Upstash → 阶段 3 迁 D1/KV/DO |
+| dev | `dev.ghfind.com` → `ghfind-dev` Worker (env: dev) | 页面和 `/api/*` 同源，由同一个 Worker 处理 | D1 `GHFIND_D1` + R2 `ghfind-next-cache-dev`；当前与 production 共用 D1 ID，未完全隔离 |
+| production | `ghfind.com` → `ghfind` Worker (env: production) | 页面和 `/api/*` 同源，由同一个 Worker 处理 | D1 `GHFIND_D1` + R2 `ghfind-next-cache`；Upstash/GitHub/LLM/Mosoo 通过 Worker Secrets 访问 |
 
 命名规则：**只用一级子域**（`api-dev.ghfind.com`，不用 `dev.api.ghfind.com`）——免费版 Universal SSL 只覆盖 `*.ghfind.com` 一层。
 

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -36,7 +36,7 @@ split-backend checks and should be removed from the Cloudflare release job.
 Use `SMOKE_ALLOW_HTTP=1` only for local smoke runs. Remote origins must be HTTPS.
 
 Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
-API, profile presentation, badge embed data, autocomplete, score leaderboard,
+API, badge embed data, autocomplete, score leaderboard,
 facet bucket, project list, sitemap inventory, MCP tools/list transport, campaign
 SSE reconnect frame, optional public scan status/result, and canonical origin.
 Missing required values, `localhost` canonical output on a remote smoke,

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -36,7 +36,7 @@ split-backend checks and should be removed from the Cloudflare release job.
 Use `SMOKE_ALLOW_HTTP=1` only for local smoke runs. Remote origins must be HTTPS.
 
 Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
-API, badge embed data, autocomplete, score leaderboard,
+API, badge SVG, autocomplete, score leaderboard,
 facet bucket, project list, sitemap inventory, MCP tools/list transport, campaign
 SSE reconnect frame, optional public scan status/result, and canonical origin.
 Missing required values, `localhost` canonical output on a remote smoke,

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -1,9 +1,15 @@
-# Deployment smoke
+# Cloudflare deployment smoke
+
+The current production topology is one OpenNext Cloudflare Worker: the same
+origin serves the UI and all `/api/*` routes. This document describes the
+read-only release smoke for `ghfind-dev` and `ghfind`; it no longer assumes a
+Vercel frontend, Railway API, or a separate metrics origin.
 
 `scripts/smoke-deployment.mts` is read-only. It never starts a scan or roast and
 does not print canary handles, run IDs, response bodies, or credentials.
 
-Configure these values privately in the deployment system:
+Configure these values privately in the deployment system. Use
+`https://dev.ghfind.com` for dev or `https://ghfind.com` for production:
 
 ```text
 SMOKE_BASE_URL
@@ -12,9 +18,8 @@ SMOKE_FACET_TYPE
 SMOKE_FACET_VALUE
 ```
 
-For the Go backend cutover, also configure a previously admitted public scan job
-so the smoke can prove the `202 -> Location -> result` path without starting new
-GitHub work:
+To optionally verify a previously admitted public scan job without starting new
+GitHub work, configure:
 
 ```text
 SMOKE_SCAN_JOB_ID
@@ -23,29 +28,32 @@ SMOKE_SCAN_JOB_EXPECT_RESULT=1
 SMOKE_REQUIRE_SCAN_JOB=1
 ```
 
-To prove process-level Railway health and metrics, configure private origins
-reachable only from the deployment runner, Railway private networking, or an SSH
-tunnel:
+The current single-Worker smoke does not require separate backend or worker
+metrics origins. `SMOKE_BACKEND_BASE_URL` and
+`SMOKE_WORKER_METRICS_BASE_URL`, if present in an old runner, are legacy
+split-backend checks and should be removed from the Cloudflare release job.
 
-```text
-SMOKE_BACKEND_BASE_URL
-SMOKE_WORKER_METRICS_BASE_URL
-```
-
-Use `SMOKE_ALLOW_HTTP=1` only for local or tunneled localhost smoke runs. Remote
-origins must be HTTPS.
+Use `SMOKE_ALLOW_HTTP=1` only for local smoke runs. Remote origins must be HTTPS.
 
 Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
-API, Go-owned profile presentation, badge embed data, autocomplete, score
-leaderboard, facet bucket, project list, sitemap inventory, MCP tools/list
-transport, campaign SSE reconnect frame, optional public scan status/result,
-optional Go API `/healthz` `/readyz` `/metrics`, optional worker `/metrics`,
-and canonical origin. Missing required values, `localhost` canonical output on
-a remote smoke, unexpected status, or malformed JSON fails the run.
+API, profile presentation, badge embed data, autocomplete, score leaderboard,
+facet bucket, project list, sitemap inventory, MCP tools/list transport, campaign
+SSE reconnect frame, optional public scan status/result, and canonical origin.
+Missing required values, `localhost` canonical output on a remote smoke,
+unexpected status, or malformed JSON fails the run.
 
 Run `pnpm smoke:deployment:selftest` to exercise every smoke branch against a
-local fixture server. CI runs this self-test without production secrets; staging
-must still run the real smoke against the deployed Vercel/Railway origins.
+local fixture server. CI runs this self-test without production secrets; a
+release must still run the real smoke against the deployed Cloudflare Worker
+origin.
+
+## Historical split-backend smoke
+
+The following `smoke:backend:*` sections and resilience evidence were written for
+the retired Go API/worker plus Railway topology. They remain useful for fixture
+regression until the old scripts are removed, but they are not Cloudflare
+production release gates and must not be used to infer that a separate backend is
+still deployed.
 
 ## Backend async smoke
 
@@ -77,21 +85,20 @@ Run `pnpm smoke:backend:async`. The script does not print the handle, API key,
 job payload or response bodies. Run `pnpm smoke:backend:async:selftest` to
 exercise the control flow locally without secrets.
 
-## Rollback verification
+## Historical rollback verification
 
-Use the same smoke commands after a rollback, but record which rollback mode was
-used:
+The old Railway/Vercel rollback modes below are retained only as historical
+evidence format. For the current release path, use the
+[Cloudflare deployment runbook](../operations/cloudflare-deployment-runbook.md):
+list Worker deployments, roll back the `ghfind` version, then run the smoke
+against `https://ghfind.com`. Do not remove `GHFIND_BACKEND_ORIGIN`; it is not part
+of the current production topology.
 
-- Railway API/worker rollback: run `pnpm smoke:deployment` and, if the worker
-  changed, `pnpm smoke:backend:async` against a cold canary.
-- Vercel deployment rollback: move the production alias back to the saved
-  previous healthy Vercel deployment, then run `pnpm smoke:deployment`.
-- Emergency `GHFIND_BACKEND_ORIGIN` removal: this is fail-closed containment,
-  not a functional rollback. Go-owned routes return `503 backend_not_configured`
-  by design and this state must not be used as issue-completion evidence.
-
-Attach the smoke command, timestamp, deployment IDs, and queue/DLQ depth snapshot
-to the staging evidence bundle. Install or adapt
+For the historical split-backend evidence only, attach the smoke command,
+timestamp, deployment IDs, and queue/DLQ depth snapshot to the staging evidence
+bundle. The current Cloudflare release evidence is defined in the
+[Cloudflare deployment runbook](../operations/cloudflare-deployment-runbook.md).
+Install or adapt
 `docs/operations/backend-alerts.prometheus.yml` before promotion so publish
 failures, worker failures, dead-lettering, latency growth, scan backlog and DLQ
 depth have explicit alerts.
@@ -148,8 +155,8 @@ fixtures without secrets. A passing self-test is not staging proof; the real
 run must attach the generated evidence JSON plus the read-only deployment smoke
 and write-path async smoke output.
 
-Before promoting a Vercel deployment, set both `NEXT_PUBLIC_SITE_URL` and
-`PUBLIC_SITE_URL` to the same HTTPS origin in the Production environment. The
-build rejects missing, local, HTTP, malformed, or mismatched production values.
+Before promoting a Cloudflare production deployment, set both
+`NEXT_PUBLIC_SITE_URL` and `PUBLIC_SITE_URL` to the same HTTPS origin. The build
+rejects missing, local, HTTP, malformed, or mismatched production values.
 Use an explicit local origin only in local development or Preview; never copy
 the value or unrelated environment settings into logs, issues, or screenshots.

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -37,10 +37,10 @@ Use `SMOKE_ALLOW_HTTP=1` only for local smoke runs. Remote origins must be HTTPS
 
 Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
 API, badge SVG, autocomplete, score leaderboard,
-facet bucket, project list, sitemap inventory, MCP tools/list transport, campaign
+facet bucket, projects page, sitemap XML, MCP tools/list transport, campaign
 SSE reconnect frame, optional public scan status/result, and canonical origin.
 Missing required values, `localhost` canonical output on a remote smoke,
-unexpected status, or malformed JSON fails the run.
+unexpected status, or malformed response content fails the run.
 
 Run `pnpm smoke:deployment:selftest` to exercise every smoke branch against a
 local fixture server. CI runs this self-test without production secrets; a

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.release.json",
     "versions:check": "tsx scripts/check-release-versions.mts",
     "gen:assets": "tsx scripts/gen-embedded-assets.mts",
-    "cf:build": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare opennextjs-cloudflare build",
-    "cf:deploy:dev": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare opennextjs-cloudflare build && wrangler deploy --env dev && opennextjs-cloudflare populateCache remote -- --env dev",
-    "cf:deploy:prod": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare opennextjs-cloudflare build && wrangler deploy --env production && opennextjs-cloudflare populateCache remote -- --env production"
+    "cf:build": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build",
+    "cf:deploy:dev": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://dev.ghfind.com opennextjs-cloudflare build && wrangler deploy --env dev && opennextjs-cloudflare populateCache remote -- --env dev",
+    "cf:deploy:prod": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build && wrangler deploy --env production && opennextjs-cloudflare populateCache remote -- --env production"
   },
   "dependencies": {
     "@libsql/client": "^0.17.4",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "versions:check": "tsx scripts/check-release-versions.mts",
     "gen:assets": "tsx scripts/gen-embedded-assets.mts",
     "cf:build": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build",
-    "cf:deploy:dev": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://dev.ghfind.com opennextjs-cloudflare build && wrangler deploy --env dev && opennextjs-cloudflare populateCache remote -- --env dev",
-    "cf:deploy:prod": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build && wrangler deploy --env production && opennextjs-cloudflare populateCache remote -- --env production"
+    "cf:deploy:dev": "CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://dev.ghfind.com opennextjs-cloudflare build && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 wrangler deploy --env dev --keep-vars && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 opennextjs-cloudflare populateCache remote -- --env dev",
+    "cf:deploy:prod": "CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 wrangler deploy --env production --keep-vars && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 opennextjs-cloudflare populateCache remote -- --env production"
   },
   "dependencies": {
     "@libsql/client": "^0.17.4",

--- a/scripts/smoke-deployment-selftest.mts
+++ b/scripts/smoke-deployment-selftest.mts
@@ -45,12 +45,16 @@ function startFixtureServer(): Promise<{ origin: string; close: () => Promise<vo
       writeJSON(response, 200, { entries: [{ username: "octocat" }] });
       return;
     }
-    if (request.method === "GET" && url.pathname === "/api/projects") {
-      writeJSON(response, 200, { projects: [] });
+    if (request.method === "GET" && url.pathname === "/projects") {
+      writeText(response, 200, "<html><main>projects</main></html>", {
+        "content-type": "text/html; charset=utf-8",
+      });
       return;
     }
-    if (request.method === "GET" && url.pathname === "/api/sitemap") {
-      writeJSON(response, 200, { profiles: [], matchups: [] });
+    if (request.method === "GET" && url.pathname === "/sitemap.xml") {
+      writeText(response, 200, "<?xml version=\"1.0\"?><urlset></urlset>", {
+        "content-type": "application/xml; charset=utf-8",
+      });
       return;
     }
     if (request.method === "POST" && url.pathname === "/mcp") {

--- a/scripts/smoke-deployment-selftest.mts
+++ b/scripts/smoke-deployment-selftest.mts
@@ -22,10 +22,6 @@ function startFixtureServer(): Promise<{ origin: string; close: () => Promise<vo
       writeJSON(response, 200, { username: "octocat", profile: `${origin}/u/octocat`, final_score: 42 });
       return;
     }
-    if (request.method === "GET" && url.pathname === "/api/profile/octocat") {
-      writeJSON(response, 200, { detail: { username: "octocat", final_score: 42 } });
-      return;
-    }
     if (request.method === "GET" && url.pathname === "/api/embed/badge/octocat") {
       writeJSON(response, 200, { final_score: 42, tier: "夯", delta: null });
       return;

--- a/scripts/smoke-deployment-selftest.mts
+++ b/scripts/smoke-deployment-selftest.mts
@@ -7,6 +7,11 @@ function writeJSON(response: http.ServerResponse, status: number, body: unknown,
   response.end(JSON.stringify(body));
 }
 
+function writeText(response: http.ServerResponse, status: number, body: string, headers: Record<string, string> = {}) {
+  response.writeHead(status, headers);
+  response.end(body);
+}
+
 function startFixtureServer(): Promise<{ origin: string; close: () => Promise<void> }> {
   const server = http.createServer((request, response) => {
     const host = request.headers.host ?? "127.0.0.1";
@@ -22,8 +27,10 @@ function startFixtureServer(): Promise<{ origin: string; close: () => Promise<vo
       writeJSON(response, 200, { username: "octocat", profile: `${origin}/u/octocat`, final_score: 42 });
       return;
     }
-    if (request.method === "GET" && url.pathname === "/api/embed/badge/octocat") {
-      writeJSON(response, 200, { final_score: 42, tier: "夯", delta: null });
+    if (request.method === "GET" && url.pathname === "/api/badge/octocat") {
+      writeText(response, 200, "<svg xmlns=\"http://www.w3.org/2000/svg\"><text>42</text></svg>", {
+        "content-type": "image/svg+xml; charset=utf-8",
+      });
       return;
     }
     if (request.method === "GET" && url.pathname === "/api/search-users") {

--- a/scripts/smoke-deployment.mts
+++ b/scripts/smoke-deployment.mts
@@ -6,6 +6,7 @@ type Check = {
   path: string;
   status: number;
   validate?: (body: unknown, response: Response) => void;
+  validateText?: (body: string, response: Response) => void;
 };
 
 function usage(): void {
@@ -59,7 +60,7 @@ async function runCheck(base: URL, check: Check): Promise<void> {
   const response = await fetch(new URL(check.path, base), {
     redirect: "follow",
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    headers: { Accept: "application/json, text/html;q=0.9" },
+    headers: { Accept: "application/json, image/svg+xml, text/html;q=0.9" },
   });
   if (response.status !== check.status) {
     throw new Error(`${check.label} returned ${response.status}; expected ${check.status}`);
@@ -74,6 +75,10 @@ async function runCheck(base: URL, check: Check): Promise<void> {
   if (check.validate) {
     const body = await response.json();
     check.validate(body, response);
+  }
+  if (check.validateText) {
+    const body = await response.text();
+    check.validateText(body, response);
   }
   console.log(`PASS ${check.label}`);
 }
@@ -246,13 +251,15 @@ async function main(): Promise<void> {
       },
     },
     {
-      label: "badge embed API",
-      path: `/api/embed/badge/${encodeURIComponent(canary)}`,
+      label: "badge SVG",
+      path: `/api/badge/${encodeURIComponent(canary)}`,
       status: 200,
-      validate(body) {
-        const payload = record(body);
-        if (!("final_score" in payload) || !("tier" in payload) || !("delta" in payload)) {
-          throw new Error("badge embed API is missing expected keys");
+      validateText(body, response) {
+        if (!(response.headers.get("content-type") ?? "").includes("image/svg+xml")) {
+          throw new Error("badge response is not SVG");
+        }
+        if (!body.includes("<svg")) {
+          throw new Error("badge response is missing SVG markup");
         }
       },
     },

--- a/scripts/smoke-deployment.mts
+++ b/scripts/smoke-deployment.mts
@@ -288,21 +288,26 @@ async function main(): Promise<void> {
       },
     },
     {
-      label: "projects API",
-      path: "/api/projects?limit=1",
+      label: "projects page",
+      path: "/projects",
       status: 200,
-      validate(body) {
-        if (!Array.isArray(record(body).projects)) throw new Error("projects are missing");
+      validateText(body, response) {
+        if (!(response.headers.get("content-type") ?? "").includes("text/html")) {
+          throw new Error("projects page is not HTML");
+        }
+        if (!body.includes("<main")) throw new Error("projects page is missing main content");
       },
     },
     {
-      label: "sitemap inventory API",
-      path: "/api/sitemap",
+      label: "sitemap XML",
+      path: "/sitemap.xml",
       status: 200,
-      validate(body) {
-        const payload = record(body);
-        if (!Array.isArray(payload.profiles) || !Array.isArray(payload.matchups)) {
-          throw new Error("sitemap inventory arrays are missing");
+      validateText(body, response) {
+        if (!(response.headers.get("content-type") ?? "").includes("xml")) {
+          throw new Error("sitemap is not XML");
+        }
+        if (!body.includes("<urlset")) {
+          throw new Error("sitemap is missing urlset");
         }
       },
     },

--- a/scripts/smoke-deployment.mts
+++ b/scripts/smoke-deployment.mts
@@ -246,20 +246,6 @@ async function main(): Promise<void> {
       },
     },
     {
-      label: "profile presentation API",
-      path: `/api/profile/${encodeURIComponent(canary)}`,
-      status: 200,
-      validate(body) {
-        const detail = record(record(body).detail);
-        if (String(detail.username).toLowerCase() !== canary.toLowerCase()) {
-          throw new Error("profile presentation returned the wrong canary");
-        }
-        if (typeof detail.final_score !== "number") {
-          throw new Error("profile presentation is missing final_score");
-        }
-      },
-    },
-    {
       label: "badge embed API",
       path: `/api/embed/badge/${encodeURIComponent(canary)}`,
       status: 200,

--- a/src/app/api/roast/route.test.ts
+++ b/src/app/api/roast/route.test.ts
@@ -19,7 +19,6 @@ const mocks = vi.hoisted(() => ({
   getCurrentCanonicalQuickScan: vi.fn(),
   getLegacyReadFallbackRoast: vi.fn(),
   getRankCached: vi.fn(),
-  getScoreScannedAt: vi.fn(),
   rateLimitHeaders: vi.fn(),
   releaseRoastLock: vi.fn(),
   setCachedRoast: vi.fn(),
@@ -33,7 +32,6 @@ vi.mock("@/lib/db", () => ({
   getCanonicalScoreWriteIdentity: mocks.getCanonicalScoreWriteIdentity,
   getCurrentCanonicalQuickScan: mocks.getCurrentCanonicalQuickScan,
   getLegacyReadFallbackRoast: mocks.getLegacyReadFallbackRoast,
-  getScoreScannedAt: mocks.getScoreScannedAt,
   updateRoast: mocks.updateRoast,
 }));
 vi.mock("@/lib/rank", () => ({ getRankCached: mocks.getRankCached }));
@@ -74,12 +72,14 @@ const scan = {
 
 describe("POST /api/roast quick score contract", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.GITHUB_ROAST_CLI_API_KEY;
     mocks.checkRoastRequestRateLimit.mockResolvedValue({ success: true });
     mocks.checkRoastRateLimit.mockResolvedValue({ success: true });
     mocks.checkRoastRequestNetworkRateLimit.mockResolvedValue({ success: true });
     mocks.checkRoastNetworkRateLimit.mockResolvedValue({ success: true });
     mocks.rateLimitHeaders.mockReturnValue({});
-    mocks.anonymousSessionPrincipal.mockReturnValue(null);
+    mocks.anonymousSessionPrincipal.mockReturnValue("anon:session-fixture");
     mocks.defaultLlmConfig.mockReturnValue({ baseURL: "https://llm.example.test", apiKey: "key", model: "model" });
     mocks.fallbackLlmConfig.mockReturnValue(null);
     mocks.getCachedScan.mockResolvedValue(null);
@@ -88,7 +88,6 @@ describe("POST /api/roast quick score contract", () => {
     mocks.getCanonicalScoreWriteIdentity.mockResolvedValue({ scannedAt: 1, token: "token" });
     mocks.getCachedRoast.mockResolvedValue(null);
     mocks.getArchivedRoast.mockResolvedValue(null);
-    mocks.getScoreScannedAt.mockResolvedValue(1);
     mocks.acquireRoastLock.mockResolvedValue(true);
     mocks.updateRoast.mockResolvedValue(true);
     mocks.getRankCached.mockResolvedValue(null);
@@ -110,7 +109,8 @@ describe("POST /api/roast quick score contract", () => {
     expect(mocks.updateRoast).toHaveBeenCalled();
   });
 
-  it("accepts an interactive roast without a BotID availability gate", async () => {
+  it("accepts an interactive roast without the machine API quota", async () => {
+    mocks.anonymousSessionPrincipal.mockReturnValue("anon:session-fixture");
     const response = await POST(new NextRequest("https://example.test/api/roast", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -119,11 +119,30 @@ describe("POST /api/roast quick score contract", () => {
 
     expect(response.status).toBe(200);
     await new Response(response.body).text();
-    expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalled();
-    expect(mocks.checkRoastRateLimit).toHaveBeenCalled();
+    expect(mocks.checkRoastRequestRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRoastRequestNetworkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRoastRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRoastNetworkRateLimit).not.toHaveBeenCalled();
   });
 
-  it("uses the signed browser session while retaining the shared network budgets", async () => {
+  it("does not let an unverified browser spend platform model credit", async () => {
+    mocks.anonymousSessionPrincipal.mockReturnValue(null);
+    const response = await POST(new NextRequest("https://example.test/api/roast", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scan, lang: "zh" }),
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "turnstile_failed",
+      useByoKey: true,
+    });
+    expect(mocks.chat).not.toHaveBeenCalled();
+    expect(mocks.acquireRoastLock).not.toHaveBeenCalled();
+  });
+
+  it("uses the signed browser session without shared NAT budgets", async () => {
     mocks.anonymousSessionPrincipal.mockReturnValue("anon:session-fixture");
     const response = await POST(new NextRequest("https://example.test/api/roast", {
       method: "POST",
@@ -133,10 +152,36 @@ describe("POST /api/roast quick score contract", () => {
 
     expect(response.status).toBe(200);
     await new Response(response.body).text();
-    expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalledWith("anon:session-fixture");
-    expect(mocks.checkRoastRequestNetworkRateLimit).toHaveBeenCalledWith("198.51.100.10");
-    expect(mocks.checkRoastRateLimit).toHaveBeenCalledWith("anon:session-fixture");
-    expect(mocks.checkRoastNetworkRateLimit).toHaveBeenCalledWith("198.51.100.10");
+    expect(mocks.checkRoastRequestRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRoastRequestNetworkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRoastRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRoastNetworkRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("serves a compatible roast cache even when the browser asks to refresh", async () => {
+    const snapshotHash = "a".repeat(64);
+    mocks.defaultLlmConfig.mockReturnValue(null);
+    mocks.getCurrentCanonicalQuickScan.mockResolvedValue({ scan, snapshotHash });
+    mocks.getCachedRoast.mockResolvedValue({
+      report: "## 锐评\n工作扎实。",
+      snapshot_hash: snapshotHash,
+      delta: 0,
+      tags: { zh: [], en: [] },
+      final_score: 71,
+      tier: "人上人",
+      roast_line: { zh: "工作扎实。", en: "Solid work." },
+    });
+
+    const response = await POST(new NextRequest("https://example.test/api/roast", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scan, refresh: true, lang: "zh" }),
+    }));
+
+    expect(response.status).toBe(200);
+    await new Response(response.body).text();
+    expect(mocks.checkRoastRateLimit).not.toHaveBeenCalled();
+    expect(mocks.acquireRoastLock).not.toHaveBeenCalled();
   });
 
   it("keeps machine-authenticated callers on their IP budget", async () => {
@@ -157,6 +202,24 @@ describe("POST /api/roast quick score contract", () => {
     await new Response(response.body).text();
     expect(mocks.checkRoastRequestRateLimit).toHaveBeenCalledWith("198.51.100.10");
     expect(mocks.checkRoastRateLimit).toHaveBeenCalledWith("198.51.100.10");
+  });
+
+  it("releases the generation lock when a machine caller is over quota", async () => {
+    process.env.GITHUB_ROAST_CLI_API_KEY = "test-key";
+    mocks.checkRoastRateLimit.mockResolvedValue({ success: false, reset: Date.now() + 1000 });
+
+    const response = await POST(new NextRequest("https://example.test/api/roast", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-key",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ scan, lang: "zh" }),
+    }));
+
+    expect(response.status).toBe(429);
+    expect(mocks.releaseRoastLock).toHaveBeenCalledWith("DemoDev", "zh");
+    expect(mocks.chat).not.toHaveBeenCalled();
   });
 
   it("uses the exact server quick snapshot instead of a client handoff", async () => {

--- a/src/app/api/roast/route.ts
+++ b/src/app/api/roast/route.ts
@@ -8,12 +8,10 @@ import {
   getCanonicalScoreWriteIdentity,
   getCurrentCanonicalQuickScan,
   getLegacyReadFallbackRoast,
-  getScoreScannedAt,
   updateRoast,
   type ScoreWriteIdentity,
 } from "@/lib/db";
 import { getRankCached } from "@/lib/rank";
-import { ROAST_FRESH_MS } from "@/lib/freshness";
 import { Lang, normLang } from "@/lib/lang";
 import {
   ChatAttemptEvent,
@@ -80,9 +78,8 @@ interface RoastBody {
   byoKey?: ByoKey;
   /** UI locale → report language. Defaults to zh (see {@link normLang}). */
   lang?: string;
-  /** Ask to regenerate instead of replaying the cache/archive. Honored only when
-   * the server confirms the stored roast is stale (scanned_at older than
-   * ROAST_FRESH_MS) — otherwise ignored, so the flag can't burn LLM credit. */
+  /** Ask for a fresh scan; a compatible cached/archive roast is still replayed
+   * when the score is unchanged, so this flag cannot burn LLM credit needlessly. */
   refresh?: boolean;
 }
 
@@ -108,7 +105,12 @@ function logRoastSummary(fields: Record<string, unknown>): void {
 }
 
 function clientIp(req: NextRequest): string {
-  return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "0.0.0.0";
+  return (
+    req.headers.get("cf-connecting-ip")?.trim() ||
+    req.headers.get("x-vercel-forwarded-for")?.split(",").at(-1)?.trim() ||
+    req.headers.get("x-forwarded-for")?.split(",").at(-1)?.trim() ||
+    "0.0.0.0"
+  );
 }
 
 function resolveConfig(byo?: ByoKey): { config: LlmConfig; isDefault: boolean } | null {
@@ -615,43 +617,51 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "missing_scan" }, { status: 400 });
   }
 
-  // Invalid machine credentials still fail closed. Interactive browser roasts
-  // are protected by the request and generation rate limits below; a heuristic
-  // bot classifier must not gate this primary user-facing flow.
+  // Invalid machine credentials still fail closed. Bearer callers are the
+  // machine/API surface; interactive browsers have already passed Turnstile on
+  // the scan path and must not spend the machine roast quota.
   const auth = machineAuth(req);
   if (auth === "invalid") {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
+  const isMachineCaller = auth === "valid";
   const ip = clientIp(req);
-  // CLI/MCP callers retain their IP budget. Only an interactive browser that
-  // completed Turnstile can exchange its shared-NAT IP key for a signed session.
-  const principal = auth === "absent" ? anonymousSessionPrincipal(req) ?? ip : ip;
+  const browserPrincipal = auth === "absent" ? anonymousSessionPrincipal(req) : null;
+  const isDefault = !(
+    body.byoKey?.apiKey && body.byoKey?.baseURL && body.byoKey?.model
+  );
+  const path = isDefault ? "default" : "byo";
+  // Browser sessions get a stable principal for auditability. Machine callers
+  // deliberately retain the IP principal for the existing API quota contract.
+  const principal = browserPrincipal ?? ip;
 
-  // This protects every path, including BYO: it runs before the snapshot and
-  // scan-cache reads below, while the later roast limiter remains dedicated
-  // to operator-paid model generation.
-  const requestLimit = await checkRoastRequestRateLimit(principal);
-  if (!requestLimit.success) {
-    return NextResponse.json(
-      { error: requestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
-      {
-        status: requestLimit.unavailable ? 503 : 429,
-        headers: { ...rateLimitHeaders(requestLimit), "Cache-Control": "no-store" },
-      },
-    );
-  }
-  const networkRequestLimit = await checkRoastRequestNetworkRateLimit(ip);
-  if (!networkRequestLimit.success) {
-    return NextResponse.json(
-      {
-        error: networkRequestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
-        useByoKey: true,
-      },
-      {
-        status: networkRequestLimit.unavailable ? 503 : 429,
-        headers: { ...rateLimitHeaders(networkRequestLimit), "Cache-Control": "no-store" },
-      },
-    );
+  // Machine/API requests remain protected. Browser traffic is deliberately
+  // excluded here: its normal path is Turnstile/session + cache/single-flight,
+  // while a cache hit must never be rejected by an API quota.
+  if (isMachineCaller) {
+    const requestLimit = await checkRoastRequestRateLimit(principal);
+    if (!requestLimit.success) {
+      return NextResponse.json(
+        { error: requestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
+        {
+          status: requestLimit.unavailable ? 503 : 429,
+          headers: { ...rateLimitHeaders(requestLimit), "Cache-Control": "no-store" },
+        },
+      );
+    }
+    const networkRequestLimit = await checkRoastRequestNetworkRateLimit(ip);
+    if (!networkRequestLimit.success) {
+      return NextResponse.json(
+        {
+          error: networkRequestLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+          useByoKey: true,
+        },
+        {
+          status: networkRequestLimit.unavailable ? 503 : 429,
+          headers: { ...rateLimitHeaders(networkRequestLimit), "Cache-Control": "no-store" },
+        },
+      );
+    }
   }
 
   const lang = normLang(body.lang);
@@ -659,7 +669,8 @@ export async function POST(req: NextRequest) {
   // A verified v5/v5/v3 artifact is a read-only continuity path when the quick
   // collector is unavailable. It is intentionally checked before resolving an LLM config:
   // replaying already-persisted public text must not depend on model capacity or
-  // spend credit. `refresh` explicitly opts out and continues toward v9 work.
+  // spend credit. `refresh` may cause a new scan upstream, but a compatible roast
+  // remains replayable when the score did not change.
   if (body.refresh !== true && !body.scan) {
     const legacyRoast = await getLegacyReadFallbackRoast(username, lang);
     if (legacyRoast && reportMatchesLang(legacyRoast.report, lang)) {
@@ -682,18 +693,6 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const resolved = resolveConfig(body.byoKey);
-  if (!resolved) {
-    return NextResponse.json({ error: "no_llm_configured", useByoKey: true }, { status: 400 });
-  }
-  const { config, isDefault } = resolved;
-
-  // Default path fails over to the operator's fallback provider (DeepSeek) when
-  // the primary drops/queues the connection before any answer text. BYO keys
-  // never fail over — the user supplied a single key and pays their own way.
-  const fallback = isDefault ? fallbackLlmConfig() : null;
-  const llmConfigs = fallback ? [config, fallback] : [config];
-  const path = isDefault ? "default" : "byo";
   // Single-flight: set once we hold the roast lock, so the stream/error paths
   // know to release it. Only the default model coalesces (BYO keys self-serve).
   let isLeader = false;
@@ -720,7 +719,6 @@ export async function POST(req: NextRequest) {
   // Default-model protections: serve a cached roast for free, else rate-limit the
   // (credit-spending) LLM call. BYO keys skip both — it's the user's own credit.
   if (isDefault) {
-    let refreshHonored = false;
     // Every replay and new report belongs to the deterministic v9 score from
     // this exact quick snapshot. A forged request body cannot produce a report
     // because it has no matching score write identity.
@@ -736,92 +734,64 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // A validated `refresh` skips canonical replay paths only when the
-    // stored report is actually stale.
-    if (body.refresh === true) {
-      const scannedAt = await getScoreScannedAt(username);
-      refreshHonored = scannedAt == null || Date.now() - scannedAt > ROAST_FRESH_MS;
+    const cachedRoast = await getCachedRoast(username, lang);
+    if (
+      cachedRoast?.snapshot_hash === snapshotHash &&
+      reportMatchesLang(cachedRoast.report, lang)
+    ) {
+      const tags = cachedRoast.tags ?? { zh: [], en: [] };
+      const roastLine = cachedRoast.roast_line ?? EMPTY_ROAST_LINE;
+      const meta =
+        cachedRoast.final_score !== undefined && cachedRoast.tier
+          ? await metaForStoredRoast(
+              cachedRoast.final_score,
+              cachedRoast.tier,
+              tags,
+              roastLine,
+              lang,
+            )
+          : await computeMeta(scan, cachedRoast.delta, tags, roastLine, lang);
+      logRoastSummary({
+        requestId, lang, path, ok: true, source: "redis_cache",
+        requestTotalMs: Date.now() - reqT0,
+      });
+      return roastResponse(cachedRoast.report, meta);
     }
+    if (cachedRoast) await clearCachedRoast(username, lang);
 
-    if (!refreshHonored) {
-      const cachedRoast = await getCachedRoast(username, lang);
-      if (
-        cachedRoast?.snapshot_hash === snapshotHash &&
-        reportMatchesLang(cachedRoast.report, lang)
-      ) {
-        const tags = cachedRoast.tags ?? { zh: [], en: [] };
-        const roastLine = cachedRoast.roast_line ?? EMPTY_ROAST_LINE;
-        const meta =
-          cachedRoast.final_score !== undefined && cachedRoast.tier
-            ? await metaForStoredRoast(
-                cachedRoast.final_score,
-                cachedRoast.tier,
-                tags,
-                roastLine,
-                lang,
-              )
-            : await computeMeta(scan, cachedRoast.delta, tags, roastLine, lang);
-        logRoastSummary({
-          requestId, lang, path, ok: true, source: "redis_cache",
-          requestTotalMs: Date.now() - reqT0,
-        });
-        return roastResponse(cachedRoast.report, meta);
-      }
-      if (cachedRoast) await clearCachedRoast(username, lang);
-
-      const archivedRoast = await getArchivedRoast(username, lang);
-      if (archivedRoast && reportMatchesLang(archivedRoast.report, lang)) {
-        const meta = await metaForStoredRoast(
-          archivedRoast.final_score,
-          archivedRoast.tier,
-          archivedRoast.tags,
-          archivedRoast.roast_line,
-          lang,
-        );
-        await cacheRoastReplay(
-          username,
-          lang,
-          snapshotHash,
-          archivedRoast.report,
-          archivedRoast.tags,
-          archivedRoast.roast_line,
-          archivedRoast.final_score,
-          archivedRoast.tier,
-        );
-        logRoastSummary({
-          requestId, lang, path, ok: true, source: "archive",
-          requestTotalMs: Date.now() - reqT0,
-        });
-        return roastResponse(archivedRoast.report, meta);
-      }
-    }
-    const generationLimit = await checkRoastRateLimit(principal);
-    if (!generationLimit.success) {
-      return NextResponse.json(
-        { error: generationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
-        {
-          status: generationLimit.unavailable ? 503 : 429,
-          headers: { ...rateLimitHeaders(generationLimit), "Cache-Control": "no-store" },
-        },
+    const archivedRoast = await getArchivedRoast(username, lang);
+    if (archivedRoast && reportMatchesLang(archivedRoast.report, lang)) {
+      const meta = await metaForStoredRoast(
+        archivedRoast.final_score,
+        archivedRoast.tier,
+        archivedRoast.tags,
+        archivedRoast.roast_line,
+        lang,
       );
+      await cacheRoastReplay(
+        username,
+        lang,
+        snapshotHash,
+        archivedRoast.report,
+        archivedRoast.tags,
+        archivedRoast.roast_line,
+        archivedRoast.final_score,
+        archivedRoast.tier,
+      );
+      logRoastSummary({
+        requestId, lang, path, ok: true, source: "archive",
+        requestTotalMs: Date.now() - reqT0,
+      });
+      return roastResponse(archivedRoast.report, meta);
     }
-    const networkGenerationLimit = await checkRoastNetworkRateLimit(ip);
-    if (!networkGenerationLimit.success) {
+    if (!isMachineCaller && !browserPrincipal) {
       return NextResponse.json(
-        {
-          error: networkGenerationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
-          useByoKey: true,
-        },
-        {
-          status: networkGenerationLimit.unavailable ? 503 : 429,
-          headers: { ...rateLimitHeaders(networkGenerationLimit), "Cache-Control": "no-store" },
-        },
+        { error: "turnstile_failed", useByoKey: true },
+        { status: 403, headers: { "Cache-Control": "no-store" } },
       );
     }
     isLeader = await acquireRoastLock(username, lang);
-    if (isLeader) {
-      if (refreshHonored) await clearCachedRoast(username, lang);
-    } else {
+    if (!isLeader) {
       const lockWaitStartedAt = Date.now();
       const shared = await waitForCachedRoast(username, lang);
       lockWaitMs = Date.now() - lockWaitStartedAt;
@@ -850,6 +820,49 @@ export async function POST(req: NextRequest) {
       generationPath = "follower_fallback";
     }
   }
+
+  // Charge the machine generation budget only after the cache/archive miss and
+  // lock decision. A follower that receives the leader's cached result is free;
+  // a follower that must fall back to its own generation is still protected.
+  if (isMachineCaller && isDefault) {
+    const generationLimit = await checkRoastRateLimit(principal);
+    if (!generationLimit.success) {
+      if (isLeader) await releaseRoastLock(username, lang);
+      return NextResponse.json(
+        { error: generationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", useByoKey: true },
+        {
+          status: generationLimit.unavailable ? 503 : 429,
+          headers: { ...rateLimitHeaders(generationLimit), "Cache-Control": "no-store" },
+        },
+      );
+    }
+    const networkGenerationLimit = await checkRoastNetworkRateLimit(ip);
+    if (!networkGenerationLimit.success) {
+      if (isLeader) await releaseRoastLock(username, lang);
+      return NextResponse.json(
+        {
+          error: networkGenerationLimit.unavailable ? "rate_limit_unavailable" : "rate_limited",
+          useByoKey: true,
+        },
+        {
+          status: networkGenerationLimit.unavailable ? 503 : 429,
+          headers: { ...rateLimitHeaders(networkGenerationLimit), "Cache-Control": "no-store" },
+        },
+      );
+    }
+  }
+
+  const resolved = resolveConfig(body.byoKey);
+  if (!resolved) {
+    return NextResponse.json({ error: "no_llm_configured", useByoKey: true }, { status: 400 });
+  }
+  const { config } = resolved;
+
+  // Default path fails over to the operator's fallback provider (DeepSeek) when
+  // the primary drops/queues the connection before any answer text. BYO keys
+  // never fail over — the user supplied a single key and pays their own way.
+  const fallback = isDefault ? fallbackLlmConfig() : null;
+  const llmConfigs = fallback ? [config, fallback] : [config];
 
   // One model stream writes the report. Progress frames keep the client alive
   // while the model prepares its controls.

--- a/src/app/api/scan/route.test.ts
+++ b/src/app/api/scan/route.test.ts
@@ -128,7 +128,7 @@ describe("POST /api/scan immediate quick contract", () => {
     });
   });
 
-  it("uses a Turnstile-issued browser session before the shared network budget", async () => {
+  it("keeps a Turnstile-issued browser outside the machine rate limit", async () => {
     delete process.env.GITHUB_ROAST_CLI_API_KEY;
     mocks.establishAnonymousSession.mockReturnValue({ id: "session-fixture", issued: true });
 
@@ -139,8 +139,8 @@ describe("POST /api/scan immediate quick contract", () => {
     }));
 
     expect(response.status).toBe(200);
-    expect(mocks.checkRateLimit).toHaveBeenCalledWith("anon:session-fixture");
-    expect(mocks.checkScanNetworkRateLimit).toHaveBeenCalledWith("198.51.100.10");
+    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkScanNetworkRateLimit).not.toHaveBeenCalled();
     expect(mocks.attachAnonymousSession).toHaveBeenCalledWith(
       expect.any(Response),
       { id: "session-fixture", issued: true },

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -10,7 +10,6 @@ import {
 } from "@/lib/db";
 import {
   checkRateLimit,
-  checkScanNetworkRateLimit,
   coalesceScan,
   getCachedScan,
   rateLimitHeaders,
@@ -32,8 +31,12 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 function clientIp(req: NextRequest): string {
-  const fwd = req.headers.get("x-forwarded-for");
-  return fwd?.split(",")[0]?.trim() || "0.0.0.0";
+  return (
+    req.headers.get("cf-connecting-ip")?.trim() ||
+    req.headers.get("x-vercel-forwarded-for")?.split(",").at(-1)?.trim() ||
+    req.headers.get("x-forwarded-for")?.split(",").at(-1)?.trim() ||
+    "0.0.0.0"
+  );
 }
 
 function idempotencyHeaders(req: NextRequest): Record<string, string> {
@@ -178,8 +181,18 @@ export async function POST(req: NextRequest) {
     anonymousSession = establishAnonymousSession(req);
   }
 
-  const principal = auth === "absent" && anonymousSession ? `anon:${anonymousSession.id}` : ip;
-  const limit = await checkRateLimit(principal);
+  const isMachineCaller = auth === "valid";
+  const principal = isMachineCaller
+    ? ip
+    : anonymousSession
+      ? `anon:${anonymousSession.id}`
+      : ip;
+  // A verified, signed browser session is the interactive path. If Turnstile
+  // is unavailable/misconfigured and no session can be issued, retain the IP
+  // guard as a fail-safe rather than making the scan route unlimited.
+  const limit = isMachineCaller || !anonymousSession
+    ? await checkRateLimit(principal)
+    : { success: true };
   const rlHeaders = rateLimitHeaders(limit);
   if (!limit.success) {
     return apiError(limit.unavailable ? "rate_limit_unavailable" : "rate_limited", {
@@ -187,14 +200,6 @@ export async function POST(req: NextRequest) {
       headers: { ...idem, ...rlHeaders, "Cache-Control": "no-store" },
     });
   }
-  const networkLimit = await checkScanNetworkRateLimit(ip);
-  if (!networkLimit.success) {
-    return apiError(networkLimit.unavailable ? "rate_limit_unavailable" : "rate_limited", {
-      status: networkLimit.unavailable ? 503 : 429,
-      headers: { ...idem, ...rateLimitHeaders(networkLimit), "Cache-Control": "no-store" },
-    });
-  }
-
   // `?force=1` (RescanButton) bypasses the cache read so a rescan reflects the
   // fresh snapshot immediately; admission/rate limits above still apply.
   const force = req.nextUrl.searchParams.get("force") === "1";

--- a/src/lib/__tests__/anonymous-session.test.ts
+++ b/src/lib/__tests__/anonymous-session.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 describe("anonymous browser session", () => {
-  it("issues a signed HttpOnly session only with a Turnstile server secret", () => {
+  it("issues a signed HttpOnly session with the Turnstile server secret", () => {
     vi.stubEnv("TURNSTILE_SECRET_KEY", "turnstile-test-secret");
     const request = new NextRequest("https://example.test/api/scan");
     const session = establishAnonymousSession(request, 1_700_000_000_000);
@@ -23,6 +23,16 @@ describe("anonymous browser session", () => {
     expect(cookie?.value).toBe(session?.value);
     expect(cookie?.httpOnly).toBe(true);
     expect(cookie?.sameSite).toBe("lax");
+  });
+
+  it("uses AUTH_SECRET when Turnstile is intentionally not configured", () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "");
+    vi.stubEnv("AUTH_SECRET", "auth-test-secret");
+    const request = new NextRequest("https://example.test/api/scan");
+    const session = establishAnonymousSession(request, 1_700_000_000_000);
+
+    expect(session).toMatchObject({ issued: true });
+    expect(session?.value).toBeTruthy();
   });
 
   it("accepts the issued identity and rejects a tampered cookie", () => {
@@ -43,8 +53,9 @@ describe("anonymous browser session", () => {
     expect(anonymousSessionPrincipal(tampered, now + 1)).toBeNull();
   });
 
-  it("does not issue a browser identity when Turnstile is not configured", () => {
+  it("does not issue a browser identity without either signing secret", () => {
     vi.stubEnv("TURNSTILE_SECRET_KEY", "");
+    vi.stubEnv("AUTH_SECRET", "");
     expect(establishAnonymousSession(new NextRequest("https://example.test/api/scan"))).toBeNull();
   });
 });

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -549,6 +549,31 @@ describe("canonical score materialization", () => {
     expect(Number(runs.rows[0]?.count)).toBe(1);
   });
 
+  it("retains a roast when a new snapshot produces the same scoring output", async () => {
+    const username = "quick-roast-reuse-fixture";
+    const firstScan = syntheticScan(username, { bio: "first snapshot" });
+    const first = await db.publishCompleteQuickScan(firstScan, 1_910_000_012_000);
+    if (!first) throw new Error("expected the first canonical score write");
+    await expect(
+      db.updateRoast(username, "## stable report", "zh", first),
+    ).resolves.toBe(true);
+
+    const secondScan = syntheticScan(username, { bio: "second snapshot" });
+    expect(secondScan.scoring).toEqual(firstScan.scoring);
+    const secondSerialized = serializeScan(secondScan);
+    expect(secondSerialized.snapshotHash).not.toBe(serializeScan(firstScan).snapshotHash);
+    await expect(
+      db.publishCompleteQuickScan(secondScan, 1_910_000_013_000),
+    ).resolves.toBeTruthy();
+
+    await expect(readScoreRow(username)).resolves.toMatchObject({
+      final_score: firstScan.scoring.final_score,
+      score_source_snapshot_hash: secondSerialized.snapshotHash,
+      roast: "## stable report",
+      roast_version: ROAST_CACHE_VERSION,
+    });
+  });
+
   it("publishes a repeated snapshot as the latest run after an intervening snapshot", async () => {
     const username = "quick-snapshot-ordering-fixture";
     const firstScan = syntheticScan(username, { followers: 10 });

--- a/src/lib/anonymous-session.ts
+++ b/src/lib/anonymous-session.ts
@@ -21,14 +21,16 @@ function configured(value: string | undefined): string | null {
 }
 
 /**
- * A browser session is issued only after a real Turnstile verification. Reuse
- * AUTH_SECRET when available; otherwise the Turnstile server secret is still a
- * private, high-entropy signing key. No session is issued without Turnstile.
+ * Reuse AUTH_SECRET when available. When Turnstile is configured, the session
+ * is issued only after the caller has passed Turnstile in the scan route. If
+ * Turnstile is intentionally absent, AUTH_SECRET still lets the no-op local or
+ * emergency browser path issue a signed identity instead of passing scan and
+ * then failing roast because no session can be verified.
  */
 function signingSecret(): string | null {
+  const authSecret = configured(process.env.AUTH_SECRET);
   const turnstileSecret = configured(process.env.TURNSTILE_SECRET_KEY);
-  if (!turnstileSecret) return null;
-  return configured(process.env.AUTH_SECRET) ?? turnstileSecret;
+  return authSecret ?? turnstileSecret;
 }
 
 function signature(payload: string, secret: string): string {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1222,6 +1222,22 @@ async function upsertCanonicalScoreGuarded(
     }
   }
 
+  // A collector refresh can produce a new source snapshot without changing the
+  // deterministic score. Keep the generated prose in that case: the roast is
+  // still compatible with the public score and can be replayed without another
+  // platform-model call. A score-version, final-score, tier, or sub-score change
+  // invalidates the prose and clears it below.
+  const sameScoringOutput =
+    row.score_version === provenance.scoreVersion &&
+    Number(row.final_score) === entry.final_score &&
+    String(row.tier ?? "") === String(entry.tier) &&
+    row.sub_scores === subScores;
+  const roastColumns = sameScoringOutput
+    ? `roast = roast, roast_version = roast_version,
+            roast_en = roast_en, roast_en_version = roast_en_version`
+    : `roast = NULL, roast_version = NULL,
+            roast_en = NULL, roast_en_version = NULL`;
+
   const overwritten = await db.execute({
     sql: `UPDATE scores SET
             prev_score = CASE WHEN ? - scanned_at >= ? THEN final_score ELSE prev_score END,
@@ -1230,7 +1246,7 @@ async function upsertCanonicalScoreGuarded(
             tags = ?, roast_line = ?, score_version = ?, score_write_token = ?,
             score_source_collection_version = ?, score_source_snapshot_hash = ?,
             bot_score = ?, sub_scores = ?, scanned_at = ?,
-            roast = NULL, roast_version = NULL, roast_en = NULL, roast_en_version = NULL
+            ${roastColumns}
           WHERE username = ?
             AND (
               score_version IS NOT ?

--- a/src/lib/go-leaderboard.server.ts
+++ b/src/lib/go-leaderboard.server.ts
@@ -1,9 +1,41 @@
 import "server-only";
 
 import { getLeaderboardCached } from "@/lib/leaderboard";
+import { SITE_URL } from "@/lib/site";
 import type { LeaderboardWindow } from "@/lib/leaderboardWindow";
 import type { LeaderboardView } from "@/components/LeaderboardClient";
 import type { PresentationLeaderboardEntry } from "@/lib/profile-presentation";
+
+type PublicLeaderboardResponse = {
+  entries?: PresentationLeaderboardEntry[];
+};
+
+/**
+ * The homepage is force-static, so its build runs before Cloudflare injects
+ * the D1/Redis runtime bindings. Fetch the already-published public board as a
+ * build-time fallback on Cloudflare; local/runtime reads remain the primary
+ * path everywhere else.
+ */
+async function getPublishedLeaderboard(
+  view: LeaderboardView,
+  window: LeaderboardWindow,
+  limit: number,
+  revalidate: number,
+): Promise<PresentationLeaderboardEntry[]> {
+  const query = new URLSearchParams({ view, window, limit: String(limit) });
+  try {
+    const response = await fetch(`${SITE_URL}/api/leaderboard?${query.toString()}`, {
+      next: { revalidate },
+    });
+    if (!response.ok) return [];
+    const data = (await response.json()) as PublicLeaderboardResponse;
+    return Array.isArray(data.entries) ? data.entries : [];
+  } catch {
+    // The fallback is best-effort. A build should still succeed if the public
+    // origin is temporarily unavailable; the next deploy can repopulate it.
+    return [];
+  }
+}
 
 export async function getGoLeaderboard(
   view: LeaderboardView = "trending",
@@ -14,5 +46,11 @@ export async function getGoLeaderboard(
   _revalidate?: number,
 ): Promise<PresentationLeaderboardEntry[]> {
   const { entries } = await getLeaderboardCached(view, window);
-  return entries.slice(0, limit);
+  if (entries.length > 0) return entries.slice(0, limit);
+
+  // `NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM` is set by the Cloudflare build
+  // scripts. Do not make ordinary local builds unexpectedly read production.
+  if (process.env.NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM !== "cloudflare") return [];
+
+  return getPublishedLeaderboard(view, window, limit, _revalidate ?? 3600);
 }

--- a/src/lib/machine-auth.ts
+++ b/src/lib/machine-auth.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from "next/server";
  *  key returns a spec-shaped 401 (with WWW-Authenticate) instead of falling
  *  through to the normal browser path. Shared by the credit-spending endpoints
  *  (/api/scan, /api/roast): agents authenticate here; browser traffic is guarded
- *  by Turnstile on scan and server-side rate limits on roast. */
+ *  by Turnstile on scan and signed browser sessions thereafter. */
 export function machineAuth(req: NextRequest): "valid" | "invalid" | "absent" {
   const value = req.headers.get("authorization") ?? "";
   if (!value) return "absent";

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -568,7 +568,9 @@ export async function checkRoastNetworkRateLimit(ip: string): Promise<RateLimitR
 }
 
 /** Cached roast: the LLM-written report + deterministic score metadata, keyed
- * by every input contract plus language and username (24h). */
+ * by every input contract plus language and username (48h). A compatible
+ * persisted roast can re-warm this cache after expiry without another LLM call.
+ */
 export interface CachedRoast {
   report: string;
   /** Exact canonical scan identity. Missing on pre-migration cache entries. */
@@ -584,7 +586,7 @@ export interface CachedRoast {
   roast_line?: import("./types").RoastLine;
 }
 
-const ROAST_TTL_SECONDS = 60 * 60 * 24;
+const ROAST_TTL_SECONDS = 60 * 60 * 48;
 export const roastKey = (username: string, lang: Lang) =>
   `roast:${ROAST_CACHE_VERSION}:${SCORE_CACHE_VERSION}:${PUBLIC_SCAN_COLLECTION_VERSION}:${lang}:${username.toLowerCase()}`;
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,8 +1,10 @@
 {
-  // ghfind frontend on Cloudflare Workers via @opennextjs/cloudflare.
+  // ghfind frontend + backend on one Cloudflare Worker via @opennextjs/cloudflare.
   // Top level = local `wrangler dev`. Deployments always use --env:
-  //   wrangler deploy --env dev         → dev.ghfind.com (noindex, staging data)
-  //   wrangler deploy --env production  → ghfind.com (cutover 阶段1.4; no domain bound yet)
+  //   wrangler deploy --env dev         → dev.ghfind.com
+  //   wrangler deploy --env production  → ghfind.com
+  // Preflight the target account and verify the D1/R2 resources before deploying;
+  // dev and production currently share the D1 database ID below.
   // Secrets (TURSO_*, UPSTASH_*, GHFIND_*, TURNSTILE_SECRET_KEY, LLM_*) are set
   // per-env via `wrangler secret put <NAME> --env <env>`, never in this file.
   "name": "ghfind",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,9 +5,12 @@
   //   wrangler deploy --env production  → ghfind.com
   // Preflight the target account and verify the D1/R2 resources before deploying;
   // dev and production currently share the D1 database ID below.
+  // Production of record: Beiming1201@gmail.com's Account. Keep this pinned so
+  // a local OAuth context with multiple accounts cannot publish to the wrong one.
   // Secrets (TURSO_*, UPSTASH_*, GHFIND_*, TURNSTILE_SECRET_KEY, LLM_*) are set
   // per-env via `wrangler secret put <NAME> --env <env>`, never in this file.
   "name": "ghfind",
+  "account_id": "8f19bebe359e4ec1a24c68c5f49c1584",
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-08-06",
   "compatibility_flags": ["nodejs_compat"],


### PR DESCRIPTION
Migrate the Cloudflare release safety work from the fork onto upstream main.

This branch is based on the latest upstream main and preserves its newer commits. It adds:

- Beiming1201 Cloudflare account pinning for production and dev deploy scripts
- browser/session and homepage deployment fixes
- CI-gated production release via successful `workflow_run` for `CI` on `main`, using the exact tested SHA
- serialized release jobs with the active 100% Worker version captured as the rollback anchor
- automatic rollback plus post-rollback smoke when build, deploy, or smoke fails
- smoke checks aligned with the current single-Worker public routes (`/api/badge`, `/projects`, `/sitemap.xml`)

Main branch protection remains optional; the workflow itself blocks failed CI from deploying. Production frontend and backend are one Worker, so code rollback covers both surfaces. D1/R2/Redis data are intentionally not rolled back automatically.