### PR TITLE
ci: harden upstream Cloudflare release guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
             pnpm versions:check
           fi
 
+      - name: Verify Cloudflare release workflow contract
+        run: pnpm ci:check-cf-release-workflow
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -1,14 +1,15 @@
 name: Deploy production (Cloudflare)
 
 # Replaces the retired Vercel/Railway gate: ghfind.com is now served by the
-# Next-on-Workers (OpenNext) build. A successful CI run for a `main` commit is
-# the only automatic production trigger; main branch protection is optional.
-# The workflow checks out the exact SHA that CI verified, then runs the build,
-# `wrangler deploy --env
-# production`, R2 incremental-cache population, and a read-only public smoke.
-# Any failure after the rollback anchor is captured restores the previous
-# Worker version. Frontend and backend are one Worker in the current topology,
-# so that single rollback covers both request surfaces.
+# Next-on-Workers (OpenNext) build. This workflow is production-owned by
+# hikariming/ghfind; a copied workflow in a fork must fail its provenance guard.
+# A successful CI run for a `main` commit is the only automatic production
+# trigger; main branch protection is optional. The workflow checks out the exact
+# SHA that CI verified, then runs the build, `wrangler deploy --env production`,
+# R2 incremental-cache population, and a read-only public smoke. Any failure
+# after the rollback anchor is captured restores the previous Worker version.
+# Frontend and backend are one Worker in the current topology, so that single
+# rollback covers both request surfaces.
 #
 # Required GitHub secrets:
 # - CF_API_TOKEN — Cloudflare API token ("Edit Cloudflare Workers" template)
@@ -30,17 +31,46 @@ concurrency:
 jobs:
   deploy:
     name: Build and deploy to Cloudflare Workers (production)
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'hikariming/ghfind' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.repository.full_name == 'hikariming/ghfind' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       CI: "true"
       NEXT_TELEMETRY_DISABLED: "1"
+      EXPECTED_REPOSITORY: hikariming/ghfind
+      EXPECTED_ACCOUNT_ID: 8f19bebe359e4ec1a24c68c5f49c1584
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+      CF_VERSION_TAG: main-${{ github.event.workflow_run.head_sha }}
+      CF_VERSION_MESSAGE: release ${{ github.event.workflow_run.head_sha }} from upstream/main
     steps:
       - name: Check out
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Verify upstream/main provenance
+        env:
+          SOURCE_REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}
+          SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$SOURCE_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$SOURCE_BRANCH" = "main"
+          test "$SOURCE_SHA" = "$RELEASE_SHA"
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          case "$SOURCE_SHA" in
+            [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*) ;;
+            *) echo "workflow_run head_sha is not a commit SHA" >&2; exit 1 ;;
+          esac
+          {
+            echo "### Release provenance"
+            echo "- Repository: \`$SOURCE_REPOSITORY\`"
+            echo "- Branch: \`$SOURCE_BRANCH\`"
+            echo "- Commit: \`$SOURCE_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # No `version:` — pnpm/action-setup reads packageManager from
       # package.json (pnpm@11.24.0); pinning a second version here breaks the
@@ -62,23 +92,30 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
-          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          status_file="$RUNNER_TEMP/cf-production-before.json"
+          pnpm exec wrangler deployments status \
+            --name ghfind \
+            --env production \
+            --json > "$status_file"
           previous_version="$(
-            pnpm exec wrangler deployments status \
-              --name ghfind \
-              --env production \
-              --json \
+            cat "$status_file" \
               | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("production is not a single 100% deployment") end'
           )"
-          test -n "$previous_version"
+          if [[ ! "$previous_version" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+            echo "Cloudflare returned an invalid rollback version id" >&2
+            exit 1
+          fi
+          previous_author="$(jq -er '.author_email' < "$status_file")"
+          test "$previous_author" = "beiming1201@gmail.com"
           echo "previous_version=$previous_version" >> "$GITHUB_OUTPUT"
           {
             echo "### Cloudflare production release"
             echo "- Commit: `$RELEASE_SHA`"
             echo "- Account: `$CLOUDFLARE_ACCOUNT_ID`"
+            echo "- Previous active author: `$previous_author`"
             echo "- Rollback target: `$previous_version`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -88,8 +125,26 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
         run: |
-          test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
           pnpm cf:deploy:prod
+
+      - name: Confirm a single 100% version is active
+        id: active
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          active_version="$(
+            pnpm exec wrangler deployments status \
+              --name ghfind \
+              --env production \
+              --json \
+              | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("production is not a single 100% deployment") end'
+          )"
+          echo "active_version=$active_version" >> "$GITHUB_OUTPUT"
+          echo "- New active Worker version: `$active_version`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post-deploy read-only smoke
         id: smoke
@@ -117,15 +172,22 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
           PREVIOUS_VERSION: ${{ steps.release.outputs.previous_version }}
-          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          test "$CLOUDFLARE_ACCOUNT_ID" = "8f19bebe359e4ec1a24c68c5f49c1584"
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
           pnpm exec wrangler rollback "$PREVIOUS_VERSION" \
             --name ghfind \
             --env production \
             --message "rollback: post-deploy verification failed for $RELEASE_SHA" \
             --yes
+          active_version="$(
+            pnpm exec wrangler deployments status \
+              --name ghfind \
+              --env production \
+              --json \
+              | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("production is not a single 100% deployment") end'
+          )"
+          test "$active_version" = "$PREVIOUS_VERSION"
           {
             echo "### Automatic rollback"
             echo "- Restored Worker version: `$PREVIOUS_VERSION`"
@@ -133,6 +195,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify rollback
+        id: rollback_smoke
         if: ${{ always() && steps.rollback.outcome == 'success' }}
         env:
           SMOKE_BASE_URL: https://ghfind.com
@@ -140,3 +203,11 @@ jobs:
           SMOKE_FACET_TYPE: language
           SMOKE_FACET_VALUE: TypeScript
         run: pnpm smoke:deployment
+
+      - name: Report unrecoverable release state
+        if: ${{ always() && failure() && (steps.release.outcome != 'success' || steps.rollback.outcome != 'success' || steps.rollback_smoke.outcome == 'failure') }}
+        run: |
+          {
+            echo "### Manual intervention required"
+            echo "Automatic rollback did not complete successfully. Inspect the Cloudflare deployment status and restore the last known-good Worker version before retrying."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -214,8 +214,12 @@ pnpm cf:deploy:prod      # ghfind.com
 
 Production deploys also run from
 [`.github/workflows/deploy-cf-production.yml`](./.github/workflows/deploy-cf-production.yml)
-on `main`. Configure secrets with `wrangler secret put --env <env>`; do not commit
-secret values. Cloudflare D1/R2 bindings are defined in [`wrangler.jsonc`](./wrangler.jsonc).
+in the canonical `hikariming/ghfind` repository: a successful upstream `main`
+CI run checks out that exact SHA, deploys to Beiming's Cloudflare account, and
+automatically rolls back the single frontend/backend Worker if deployment or
+post-deploy smoke fails. Configure secrets with `wrangler secret put --env
+<env>`; do not commit secret values. Cloudflare D1/R2 bindings are defined in
+[`wrangler.jsonc`](./wrangler.jsonc).
 
 ## Bring your own model / API key
 

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -30,6 +30,31 @@ repository config and production workflow pin this account. The
 `AsperforMias` account is not a production target and must not be used for
 production Workers, D1, R2, or Secrets.
 
+## Canonical GitHub source and CI ownership
+
+`hikariming/ghfind` is the only canonical production repository. Production is
+not connected to a personal fork or to a Cloudflare dashboard Git integration;
+the binding is enforced by the upstream workflow itself:
+
+```text
+upstream/main commit
+  -> CI push run succeeds
+  -> Deploy production (Cloudflare) workflow_run on that exact SHA
+  -> provenance guard confirms hikariming/ghfind + main
+  -> deploy ghfind in Beiming's account
+```
+
+The fork has no production deployment workflow. The only GitHub Actions secret
+needed by the production workflow is the upstream repository secret
+`CF_API_TOKEN`. `CF_ACCOUNT_ID` is deliberately not read by the workflow; the
+Beiming account ID is pinned in both the workflow and `wrangler.jsonc`. Worker
+runtime secrets such as Upstash Redis and the LLM credentials stay in the
+Cloudflare Worker environment and must not be copied into GitHub Actions.
+
+Every automated Worker version is tagged with the exact `main-<commit-sha>` and
+given a release message containing the same SHA. This makes the Cloudflare
+version history traceable back to upstream `main` without exposing credentials.
+
 ## Hard stop: preflight the target account and resources
 
 Run these checks from the repository root before a remote deployment:
@@ -151,11 +176,14 @@ to deploy Workers and access the configured D1/R2 resources.
 
 The automatic production workflow is triggered by a successful `CI` workflow
 completion on `main`, not by a raw push. It checks out the exact commit SHA that
-CI verified, captures the active 100% Worker version, deploys, and runs the
-read-only production smoke three times at most. A build, deployment, or smoke
-failure invokes `wrangler rollback` to restore the captured version, then runs
-the smoke again against the restored origin. Because the current frontend and
-backend are one Worker, this is a single atomic application rollback for both.
+CI verified and rejects any event whose repository, branch, or checked-out SHA
+does not match upstream `main`. It captures the active 100% Worker version,
+deploys, confirms that production still has one 100% version, and runs the
+read-only production smoke three times at most. A build, deployment, active
+version, or smoke failure invokes `wrangler rollback` to restore the captured
+version, verifies that the old version is active, then runs the smoke again
+against the restored origin. Because the current frontend and backend are one
+Worker, this is a single atomic application rollback for both.
 
 Main branch protection is optional for this release design. The deployment
 workflow is the release gate: it reacts only to a successful `CI` completion on
@@ -222,8 +250,9 @@ production release gate.
 ## Automated rollback
 
 The production workflow records the active 100% Worker version before each
-serialized release. If build/deploy/post-deploy smoke fails, it automatically
-runs:
+serialized release. It also requires that the active deployment was authored by
+the Beiming Cloudflare identity. If build/deploy/active-version/post-deploy
+smoke fails, it automatically runs:
 
 ```bash
 pnpm exec wrangler rollback <CAPTURED_VERSION_ID> --name ghfind --env production --message "rollback: post-deploy verification failed" --yes
@@ -237,7 +266,9 @@ release started. With `cancel-in-progress: false`, queued releases are handled
 one at a time: if commit1 is the last smoke-qualified release and commits2
 through5 fail, each failed release returns to commit1. If an intermediate
 release passes its post-deploy smoke, that release becomes the new rollback
-anchor for the releases that follow.
+anchor for the releases that follow. An out-of-band deployment or a split
+traffic state is not accepted as a rollback anchor; the release stops and needs
+operator review.
 ## Manual rollback
 
 Cloudflare rollback is a Worker-version rollback; DNS does not need to be changed

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "smoke:backend:resilience:selftest": "tsx scripts/smoke-backend-resilience-selftest.mts",
     "smoke:deployment": "tsx scripts/smoke-deployment.mts",
     "smoke:deployment:selftest": "tsx scripts/smoke-deployment-selftest.mts",
+    "ci:check-cf-release-workflow": "tsx scripts/check-cf-release-workflow.mts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.release.json",
     "versions:check": "tsx scripts/check-release-versions.mts",
     "gen:assets": "tsx scripts/gen-embedded-assets.mts",
     "cf:build": "NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build",
-    "cf:deploy:dev": "CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://dev.ghfind.com opennextjs-cloudflare build && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 wrangler deploy --env dev --keep-vars && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 opennextjs-cloudflare populateCache remote -- --env dev",
-    "cf:deploy:prod": "CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 wrangler deploy --env production --keep-vars && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 opennextjs-cloudflare populateCache remote -- --env production"
+    "cf:deploy:dev": "CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://dev.ghfind.com opennextjs-cloudflare build && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 wrangler deploy --env dev --keep-vars --tag \"${CF_VERSION_TAG:-dev-manual}\" --message \"${CF_VERSION_MESSAGE:-manual dev deployment}\" && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 opennextjs-cloudflare populateCache remote -- --env dev",
+    "cf:deploy:prod": "CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 NEXT_PUBLIC_GHFIND_DEPLOY_PLATFORM=cloudflare NEXT_PUBLIC_SITE_URL=https://ghfind.com opennextjs-cloudflare build && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 wrangler deploy --env production --keep-vars --tag \"${CF_VERSION_TAG:-production-manual}\" --message \"${CF_VERSION_MESSAGE:-manual production deployment}\" && CLOUDFLARE_ACCOUNT_ID=8f19bebe359e4ec1a24c68c5f49c1584 opennextjs-cloudflare populateCache remote -- --env production"
   },
   "dependencies": {
     "@libsql/client": "^0.17.4",

--- a/scripts/check-cf-release-workflow.mts
+++ b/scripts/check-cf-release-workflow.mts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const workflowPath = resolve(
+  process.cwd(),
+  ".github/workflows/deploy-cf-production.yml",
+);
+const workflow = readFileSync(workflowPath, "utf8");
+
+const requiredFragments = [
+  'workflow_run:',
+  'workflows: ["CI"]',
+  "types: [completed]",
+  "branches: [main]",
+  "github.repository == 'hikariming/ghfind'",
+  "github.event.workflow_run.conclusion == 'success'",
+  "github.event.workflow_run.event == 'push'",
+  "github.event.workflow_run.head_branch == 'main'",
+  "github.event.workflow_run.repository.full_name == 'hikariming/ghfind'",
+  "ref: ${{ github.event.workflow_run.head_sha }}",
+  "persist-credentials: false",
+  "cancel-in-progress: false",
+  "EXPECTED_ACCOUNT_ID: 8f19bebe359e4ec1a24c68c5f49c1584",
+  "CF_VERSION_TAG: main-${{ github.event.workflow_run.head_sha }}",
+  "CF_VERSION_MESSAGE: release ${{ github.event.workflow_run.head_sha }} from upstream/main",
+  "secrets.CF_API_TOKEN",
+  "wrangler deployments status",
+  "wrangler rollback",
+  "steps.release.outputs.previous_version",
+  "id: rollback_smoke",
+];
+
+for (const fragment of requiredFragments) {
+  if (!workflow.includes(fragment)) {
+    throw new Error(`Cloudflare release workflow is missing: ${fragment}`);
+  }
+}
+
+if (/^  push:/m.test(workflow) || /^  workflow_dispatch:/m.test(workflow)) {
+  throw new Error(
+    "Production deploy must remain workflow_run-only; do not add a direct trigger.",
+  );
+}
+
+console.log(`Cloudflare release workflow contract passed (${workflowPath})`);


### PR DESCRIPTION
## What changed

- enforce that production deploys can only run in `hikariming/ghfind` from a successful push CI run on `main`
- verify the workflow checks out the exact CI-verified SHA before using the Cloudflare secret
- tag and message Worker versions with the upstream `main` commit SHA
- verify the production deployment remains a single 100% version before smoke
- verify the captured rollback version is active before rollback smoke
- report manual intervention when the rollback anchor or rollback verification fails
- add a CI contract test for these release invariants
- document the canonical repository, secret ownership, and rollback behavior

## Validation

- `pnpm ci:check-cf-release-workflow`
- `pnpm typecheck`
- `pnpm lint` (existing warning only in `src/components/LiveRoast.tsx`)
- `pnpm smoke:deployment:selftest`
