### PR TITLE
fix: validate CF target account instead of token author

### DIFF
--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -108,14 +108,16 @@ jobs:
             echo "Cloudflare returned an invalid rollback version id" >&2
             exit 1
           fi
-          previous_author="$(jq -er '.author_email' < "$status_file")"
-          test "$previous_author" = "beiming1201@gmail.com"
+          # The API credential may be a delegated user token. The deployment
+          # target is enforced by the pinned account ID above; the author is
+          # audit metadata and must not be used as an account-ownership gate.
+          previous_author="$(jq -r '.author_email // "unknown"' < "$status_file")"
           echo "previous_version=$previous_version" >> "$GITHUB_OUTPUT"
           {
             echo "### Cloudflare production release"
             echo "- Commit: `$RELEASE_SHA`"
             echo "- Account: `$CLOUDFLARE_ACCOUNT_ID`"
-            echo "- Previous active author: `$previous_author`"
+            echo "- Previous active author (audit metadata only): `$previous_author`"
             echo "- Rollback target: `$previous_version`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -254,10 +254,10 @@ production release gate.
 ## Automated rollback
 
 The production workflow records the active 100% Worker version before each
-serialized release. It also requires that the active deployment was authored by
-the Beiming Cloudflare identity. If build/deploy/active-version/post-deploy
-the build/deployment, active-version check, or post-deploy smoke fails, it
-automatically runs:
+serialized release. The target account is enforced by the pinned Beiming Account
+ID; Cloudflare's `author_email` is retained as audit metadata only because a
+delegated user token may legitimately publish into that account. If
+build/deploy/active-version/post-deploy smoke fails, it automatically runs:
 
 ```bash
 pnpm exec wrangler rollback <CAPTURED_VERSION_ID> --name ghfind --env production --message "rollback: post-deploy verification failed" --yes

--- a/scripts/check-cf-release-workflow.mts
+++ b/scripts/check-cf-release-workflow.mts
@@ -49,4 +49,16 @@ if (/^  push:/m.test(workflow) || /^  workflow_dispatch:/m.test(workflow)) {
   );
 }
 
+if (workflow.includes('test "$previous_author" = "beiming1201@gmail.com"')) {
+  throw new Error(
+    "Do not use Cloudflare author_email as the production account gate; validate the pinned account ID instead.",
+  );
+}
+
+if (!workflow.includes("Previous active author (audit metadata only)")) {
+  throw new Error(
+    "Production release must label Cloudflare author_email as audit metadata only.",
+  );
+}
+
 console.log(`Cloudflare release workflow contract passed (${workflowPath})`);


### PR DESCRIPTION
## Summary\n- keep production account validation pinned to Beiming1201@gmail.com's Cloudflare Account ID\n- stop treating Cloudflare deployment author_email as an account-ownership gate\n- retain author_email as audit-only metadata in the release summary\n- add a CI contract check preventing the old over-strict guard from returning\n\n## Validation\n- pnpm ci:check-cf-release-workflow\n- pnpm typecheck\n- pnpm lint\n\nThis prevents the next upstream/main release from being blocked after a delegated Cloudflare token publishes into the correct Beiming account.