### PR TITLE
ci: auto-deploy dev branch to dev.ghfind.com

### DIFF
--- a/.github/workflows/deploy-cf-dev.yml
+++ b/.github/workflows/deploy-cf-dev.yml
@@ -1,0 +1,226 @@
+name: Deploy dev (Cloudflare)
+
+# Automatic dev release: a successful CI run for a `dev` commit deploys
+# ghfind-dev (dev.ghfind.com). Mirrors the production gate — the workflow
+# checks out the exact SHA that CI verified, applies pending D1 migrations
+# (dev shares the production database; additive migrations only), runs
+# `wrangler deploy --env dev`, and rolls the Worker back if post-deploy
+# verification fails. The smoke runs against the WAF-free workers.dev
+# entrance because the zone's ASN challenge can block runner egress on the
+# custom domain; SMOKE_EXPECTED_ORIGIN pins the canonical origin.
+#
+# Required GitHub secrets:
+# - CF_API_TOKEN — Cloudflare API token ("Edit Cloudflare Workers" template)
+# The account ID is intentionally pinned below to Beiming1201@gmail.com's Account.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [dev]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-cf-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy to Cloudflare Workers (dev)
+    if: ${{ github.repository == 'hikariming/ghfind' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' && github.event.workflow_run.repository.full_name == 'hikariming/ghfind' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CI: "true"
+      NEXT_TELEMETRY_DISABLED: "1"
+      EXPECTED_REPOSITORY: hikariming/ghfind
+      EXPECTED_ACCOUNT_ID: 8f19bebe359e4ec1a24c68c5f49c1584
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+      CF_VERSION_TAG: dev-${{ github.event.workflow_run.head_sha }}
+      CF_VERSION_MESSAGE: release-${{ github.event.workflow_run.head_sha }}-from-upstream-dev
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Verify upstream/dev provenance
+        env:
+          SOURCE_REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}
+          SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$SOURCE_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$SOURCE_BRANCH" = "dev"
+          test "$SOURCE_SHA" = "$RELEASE_SHA"
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          case "$SOURCE_SHA" in
+            [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*) ;;
+            *) echo "workflow_run head_sha is not a commit SHA" >&2; exit 1 ;;
+          esac
+          {
+            echo "### Dev release provenance"
+            echo "- Repository: \`$SOURCE_REPOSITORY\`"
+            echo "- Branch: \`$SOURCE_BRANCH\`"
+            echo "- Commit: \`$SOURCE_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # No `version:` — pnpm/action-setup reads packageManager from
+      # package.json (pnpm@11.24.0); pinning a second version here breaks the
+      # setup step with ERR_PNPM_BAD_PM_VERSION.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Capture rollback target
+        id: release
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          status_file="$RUNNER_TEMP/cf-dev-before.json"
+          pnpm exec wrangler deployments status \
+            --name ghfind-dev \
+            --env dev \
+            --json > "$status_file"
+          previous_version="$(
+            cat "$status_file" \
+              | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("dev is not a single 100% deployment") end'
+          )"
+          if [[ ! "$previous_version" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+            echo "Cloudflare returned an invalid rollback version id" >&2
+            exit 1
+          fi
+          echo "previous_version=$previous_version" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Cloudflare dev release"
+            echo "- Commit: \`$RELEASE_SHA\`"
+            echo "- Account: \`$CLOUDFLARE_ACCOUNT_ID\`"
+            echo "- Rollback target: \`$previous_version\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply dev D1 migrations
+        id: migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          # dev and production share this database; migrations must stay
+          # additive. A migration failure stops the release before the Worker
+          # can change and does not invoke a redundant rollback.
+          pnpm exec wrangler d1 migrations apply ghfind --remote --env dev
+
+      - name: Deploy (build + wrangler deploy --env dev + populateCache)
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+        run: |
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          pnpm cf:deploy:dev
+
+      - name: Confirm a single 100% version is active
+        id: active
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          active_version="$(
+            pnpm exec wrangler deployments status \
+              --name ghfind-dev \
+              --env dev \
+              --json \
+              | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("dev is not a single 100% deployment") end'
+          )"
+          echo "active_version=$active_version" >> "$GITHUB_OUTPUT"
+          echo "- New active Worker version: \`$active_version\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post-deploy read-only smoke
+        id: smoke
+        env:
+          SMOKE_BASE_URL: https://ghfind-dev.beiming1201.workers.dev
+          SMOKE_EXPECTED_ORIGIN: https://dev.ghfind.com
+          SMOKE_CANARY_HANDLE: octocat
+          SMOKE_FACET_TYPE: language
+          SMOKE_FACET_VALUE: TypeScript
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if pnpm smoke:deployment; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep 5
+            fi
+          done
+          exit 1
+
+      - name: Roll back dev Worker
+        id: rollback
+        # A migration failure happens before the Worker can change and must
+        # not issue a redundant rollback. Only a failure after the deploy step
+        # started is eligible for the single Worker rollback.
+        if: ${{ failure() && steps.release.outputs.previous_version != '' && (steps.deploy.outcome == 'failure' || steps.active.outcome == 'failure' || steps.smoke.outcome == 'failure') }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: "8f19bebe359e4ec1a24c68c5f49c1584"
+          PREVIOUS_VERSION: ${{ steps.release.outputs.previous_version }}
+        run: |
+          set -euo pipefail
+          test "$CLOUDFLARE_ACCOUNT_ID" = "$EXPECTED_ACCOUNT_ID"
+          pnpm exec wrangler rollback "$PREVIOUS_VERSION" \
+            --name ghfind-dev \
+            --env dev \
+            --message "rollback: post-deploy verification failed for $RELEASE_SHA" \
+            --yes
+          active_version="$(
+            pnpm exec wrangler deployments status \
+              --name ghfind-dev \
+              --env dev \
+              --json \
+              | jq -er '.versions | if length == 1 and .[0].percentage == 100 then .[0].version_id else error("dev is not a single 100% deployment") end'
+          )"
+          test "$active_version" = "$PREVIOUS_VERSION"
+          {
+            echo "### Automatic rollback"
+            echo "- Restored Worker version: \`$PREVIOUS_VERSION\`"
+            echo "- Failed release commit: \`$RELEASE_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify rollback
+        id: rollback_smoke
+        if: ${{ always() && steps.rollback.outcome == 'success' }}
+        env:
+          SMOKE_BASE_URL: https://ghfind-dev.beiming1201.workers.dev
+          SMOKE_EXPECTED_ORIGIN: https://dev.ghfind.com
+          SMOKE_CANARY_HANDLE: octocat
+          SMOKE_FACET_TYPE: language
+          SMOKE_FACET_VALUE: TypeScript
+        run: pnpm smoke:deployment
+
+      - name: Report unrecoverable release state
+        if: ${{ always() && failure() && ((steps.release.outcome != 'success') || ((steps.deploy.outcome == 'failure' || steps.active.outcome == 'failure' || steps.smoke.outcome == 'failure') && steps.rollback.outcome != 'success') || steps.rollback_smoke.outcome == 'failure') }}
+        run: |
+          {
+            echo "### Manual intervention required"
+            echo "Automatic rollback did not complete successfully. Inspect the Cloudflare deployment status and restore the last known-good Worker version before retrying."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/operations/cloudflare-deployment-runbook.md
+++ b/docs/operations/cloudflare-deployment-runbook.md
@@ -150,8 +150,16 @@ required.
 
 ## Deploy dev
 
-Only deploy dev after the resource preflight and the D1 data-safety warning have
-been acknowledged:
+Pushes to `dev` deploy automatically: after a successful `CI` run on the branch,
+`.github/workflows/deploy-cf-dev.yml` checks out the verified SHA, applies
+pending D1 migrations, deploys `ghfind-dev`, and rolls the Worker back if the
+post-deploy smoke fails. The smoke runs against the WAF-free workers.dev
+entrance (`SMOKE_BASE_URL=https://ghfind-dev.beiming1201.workers.dev` with
+`SMOKE_EXPECTED_ORIGIN=https://dev.ghfind.com`) because the zone's ASN
+challenge can block runner egress on the custom domain.
+
+For a manual dev release, only deploy after the resource preflight and the D1
+data-safety warning have been acknowledged:
 
 ```bash
 pnpm cf:deploy:dev

--- a/docs/releases/deployment-smoke.md
+++ b/docs/releases/deployment-smoke.md
@@ -35,6 +35,17 @@ split-backend checks and should be removed from the Cloudflare release job.
 
 Use `SMOKE_ALLOW_HTTP=1` only for local smoke runs. Remote origins must be HTTPS.
 
+For dev, the zone's ASN challenge can block runner egress on the custom domain,
+so run against the WAF-free workers.dev entrance and pin the canonical origin
+the score API is expected to report:
+
+```text
+SMOKE_BASE_URL=https://ghfind-dev.beiming1201.workers.dev
+SMOKE_EXPECTED_ORIGIN=https://dev.ghfind.com
+```
+
+`SMOKE_EXPECTED_ORIGIN` defaults to the `SMOKE_BASE_URL` origin when unset.
+
 Run `pnpm smoke:deployment`. The script checks the profile, deterministic score
 API, badge SVG, autocomplete, score leaderboard,
 facet bucket, projects page, sitemap XML, MCP tools/list transport, campaign

--- a/scripts/smoke-deployment.mts
+++ b/scripts/smoke-deployment.mts
@@ -228,7 +228,7 @@ async function main(): Promise<void> {
     throw new Error("SMOKE_FACET_TYPE must be language, org, or repo");
   }
   const facetValue = required("SMOKE_FACET_VALUE");
-  const expectedOrigin = base.origin;
+  const expectedOrigin = originUrl("SMOKE_EXPECTED_ORIGIN", false)?.origin ?? base.origin;
   const checks: Check[] = [
     {
       label: "profile",


### PR DESCRIPTION
Adds `.github/workflows/deploy-cf-dev.yml`: after a successful CI run on `dev`, deploys ghfind-dev (dev.ghfind.com) with the same provenance guard, D1 migration step, and rollback design as the production workflow.

- `workflow_run` triggers only fire from the default branch, so this file must land on main to work; the change is infrastructure-only (no site content changes).
- `scripts/smoke-deployment.mts` gains optional `SMOKE_EXPECTED_ORIGIN` so the dev smoke can run against the WAF-free workers.dev entrance while still pinning the canonical origin to dev.ghfind.com (default behavior unchanged).
- Docs: deployment-smoke.md and the runbook's dev section updated.