### PR TITLE
fix(feed): govern legacy assessment product tags

### DIFF
--- a/docs/operations/project-feed-backend-runbook.md
+++ b/docs/operations/project-feed-backend-runbook.md
@@ -22,6 +22,10 @@ Current production algorithm: `cloudflare-tag-quality-v1`.
 - Canonical tags are eligible for recall. Assessment tags with a free-form
   namespace/slug are stored as evidence-backed proposals and have zero recall
   effect until an administrator creates or maps a canonical tag.
+- Legacy v1/v2 assessments have evidence-backed product tags but no namespace.
+  They enter the review-only `use_case` intake bucket; this is not an automatic
+  semantic classification and does not grant recall. An administrator can map
+  an accepted proposal to a canonical tag in any governed namespace.
 - The baseline ranks tag affinity, saved-tag similarity, product score,
   confidence, freshness, and long-tail exposure; MMR limits repetitive tags.
   There is no online embedding, LLM ranking, Gorse, or hidden model fallback.

--- a/src/lib/__tests__/feed.test.ts
+++ b/src/lib/__tests__/feed.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { ProjectAnalysisArtifact } from "../project-analysis-contract";
+import {
+  PREVIOUS_PROJECT_ANALYSIS_SCHEMA_VERSION,
+  type ProjectAnalysisArtifact,
+} from "../project-analysis-contract";
 import { validProjectAnalysis } from "./project-analysis-contract.test";
 
 let feed: typeof import("../feed");
@@ -57,6 +60,33 @@ afterAll(() => {
 });
 
 describe("Cloudflare Feed baseline", () => {
+  it("queues legacy v2 product tags for review without granting them recall", async () => {
+    const source = assessment(6);
+    const legacy = {
+      ...source,
+      schema_version: PREVIOUS_PROJECT_ANALYSIS_SCHEMA_VERSION,
+      project: {
+        ...source.project,
+        product_tags: [{
+          slug: "legacy-v2-only",
+          labels: { zh: "旧版专属特征", en: "Legacy v2-only feature" },
+          evidence_ids: ["readme-contract"],
+        }],
+      },
+    } as ProjectAnalysisArtifact;
+
+    await feed.syncFeedProjectProjection(legacy);
+
+    const pending = await feed.listPendingFeedTagProposals(20);
+    expect(pending).toContainEqual(expect.objectContaining({
+      id: "owner/tool-6:feed-analysis-6:use_case:legacy-v2-only",
+      namespace: "use_case",
+      slug: "legacy-v2-only",
+    }));
+    const tags = await feed.listFeedTags();
+    expect(tags.tags.some((tag) => tag.id === "use_case:legacy-v2-only")).toBe(false);
+  });
+
   it("keeps unreviewed assessment tags out of recall until a governed review accepts them", async () => {
     const first = assessment(1);
     await feed.syncFeedProjectProjection(first);

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -376,8 +376,14 @@ export async function syncFeedProjectProjection(
   );
 
   for (const candidate of analysis.project.product_tags) {
-    if (!("namespace" in candidate) || !isNamespace(candidate.namespace)) continue;
-    const tagId = await canonicalTagId(db, candidate.namespace, candidate.slug);
+    // v1/v2 assessments carry evidence-backed product characteristics but no
+    // governed namespace. Put those into a review-only intake bucket instead
+    // of silently discarding them or granting them use_case recall. An admin
+    // can still map a legacy proposal to a canonical tag in any namespace.
+    const namespace = "namespace" in candidate && isNamespace(candidate.namespace)
+      ? candidate.namespace
+      : "use_case";
+    const tagId = await canonicalTagId(db, namespace, candidate.slug);
     if (tagId) {
       await db.execute({
         sql: `INSERT INTO feed_project_tags
@@ -390,7 +396,7 @@ export async function syncFeedProjectProjection(
       });
       continue;
     }
-    const proposalId = `${repoKey}:${analysisId}:${candidate.namespace}:${candidate.slug}`;
+    const proposalId = `${repoKey}:${analysisId}:${namespace}:${candidate.slug}`;
     await db.execute({
       sql: `INSERT INTO feed_tag_proposals
             (id, repo_key, analysis_id, namespace, slug, label_zh, label_en, evidence_json, status, created_at, updated_at)
@@ -398,7 +404,7 @@ export async function syncFeedProjectProjection(
             ON CONFLICT(repo_key, analysis_id, namespace, slug) DO UPDATE SET
               label_zh = excluded.label_zh, label_en = excluded.label_en, evidence_json = excluded.evidence_json,
               updated_at = excluded.updated_at`,
-      args: [proposalId, repoKey, analysisId, candidate.namespace, candidate.slug, candidate.labels.zh, candidate.labels.en, JSON.stringify(candidate.evidence_ids), now, now],
+      args: [proposalId, repoKey, analysisId, namespace, candidate.slug, candidate.labels.zh, candidate.labels.en, JSON.stringify(candidate.evidence_ids), now, now],
     });
   }
 }


### PR DESCRIPTION
## Problem

All 261 production assessments are v2 artifacts with 3–5 evidence-backed product tags but no governed namespace. The Feed projector silently skipped them, leaving the review queue empty and reducing personalization to artifact/lifecycle only.

## Change

- Route namespace-less v1/v2 tags to the review-only `use_case` intake bucket.
- They remain unavailable for recall until an administrator explicitly creates or maps a canonical tag; a map may target any governed namespace.
- Preserve v3 explicit namespace behavior.
- Add a regression test and document the lifecycle.

## Validation

- `pnpm vitest run src/lib/__tests__/feed.test.ts` (14 tests)
- `pnpm typecheck`
- `pnpm lint`

After CI and the automatic main deployment, the bounded reconciliation workflow will run once with `bootstrap_credential=false` to repair the existing catalog.