### PR TITLE
docs(feed): freeze portable runtime contracts and verified platform audit

### DIFF
--- a/docs/adr/001-portable-feed-runtime.md
+++ b/docs/adr/001-portable-feed-runtime.md
@@ -1,0 +1,103 @@
+# ADR 001: portable Feed runtime and data ownership
+
+Accepted for implementation: 2026-09-08. Baseline: `41ce4cd829f431fa2e20133e0c2509bbe1d5fad3`.
+This is an implementation decision, **not evidence that any deployment gate has passed**.
+
+## Decision
+
+Run an independent Go Feed API and a separate bounded Go task executor. Prefer
+Cloudflare Containers, with Workers providing ingress, D1/R2 capabilities and
+queue delivery. Next retains OAuth, pages and a same-origin gateway. Neither Go
+entry point starts legacy scanning, evaluation or RabbitMQ consumers.
+
+The production storage profile is initially `cf_d1_r2`, using the existing
+dedicated Feed D1. Deliver a second `postgres` profile with pgvector and an S3
+compatible archive. Business code must run from the same Go images in ordinary
+Docker without a Cloudflare or Next runtime. Vector indexes are rebuildable
+derived data; the relational store decides eligibility and deletion state.
+
+| Data / route | Owner | Change boundary |
+| --- | --- | --- |
+| OAuth, public pages, rankings, scans, assessments | Existing application | Preserve behavior and current production facts |
+| Assessment finalization and submission evidence | Core database | Add source outbox in the same transaction; no downstream synchronous dependency |
+| `/api/feed/*` | Next gateway → independent Go API when enabled | Preserve paths, OAuth requirement, error shape and `no-store` |
+| Catalog projection, taxonomy, preferences, events, sessions, tasks | One Feed primary store | D1 initially; PostgreSQL is a separately rehearsed promotion |
+| Archives, snapshots, restore manifests | R2 / S3 archive adapter | Versioned, checksummed, retention and deletion aware |
+| Semantics | Embedding provider + Vectorize / pgvector adapter | Independent switch; off until quality, recovery and cost gates pass |
+
+Production core D1 is the observed assessment source. Historical Turso comparison
+is an unresolved audit item, not authority to overwrite either store. Preserve
+the already-applied résumé-library migration from the dev branch. Historical
+completed evaluations alone do not prove active submission: default to excluding
+such projects from the new Feed until a verifiable receipt is linked. Keep their
+public project pages. Do not approve the existing tag proposal backlog by seed.
+
+## Boundaries
+
+Storage ports represent complete business commands. A preference update includes
+its event/version/outbox; a served page includes its request and all items. No
+arbitrary SQL RPC, runtime DDL, or D1 management REST in the request path. A
+cross-network sequence is never described as a transaction.
+
+`FEED_BACKEND` selects legacy or Go runtime, with legacy as the default.
+`FEED_STORE_PROFILE` selects an adapter at startup. Neither is a database migration
+mechanism. Every write must honor a persistent writer epoch and user deletion
+generation. Promotion uses a versioned control record, snapshot, replay,
+verification and a write fence. Only one store may accept authoritative writes.
+
+The gateway signs a short-lived, request-bound identity using a dedicated secret.
+Go never trusts a bare GitHub ID or a forwarded OAuth cookie. Internal capability,
+gateway and impression/cursor signing secrets have distinct purposes.
+
+New tasks have durable idempotency keys, state, deadlines, leases, finite retries,
+DLQ and replay. Persist effects before acknowledgement. Source outbox success is
+independent of Feed or queue availability. Explicit full repair is limited to four
+pages of at most 100 entries; partial scans cannot prove deletion.
+
+## Deployment and cost gates
+
+Create an isolated staging core D1, Feed D1, R2, queues and credentials. Existing
+dev shares the production core D1 and is not a write-test target. Production
+deployment, migration and rollback run only in GitHub Actions. Deploy immutable
+images before Workers, then verify actual running image and readiness before
+routing traffic; Worker and Container rollout are not atomic.
+
+Measure warm p95 ≤800 ms, cold p95 ≤5 s, projection p95 ≤60 s, availability target
+99.9%, application rollback ≤5 min and restore RPO ≤15 min / RTO ≤60 min. Use
+50,000 projects, 5,000 users and 1,000,000 events in isolation, with bounded
+10 RPS for 10 minutes. Record cold and uncached paths, errors, database work,
+queue lag and cost. These numbers are acceptance targets until measured.
+
+New production plus staging budget: $100/month, forecast at most $80 plus $20
+reserve. Initially cap API at two basic Containers and executor at one; staging
+runs on demand. Include Workers, DO, logging, storage, network and embeddings.
+Budget alerts are not a guaranteed spending cap. Preserve accepted jobs and
+deletion recovery before optional semantic backfills.
+
+Railway is a fallback only after measured CF failure despite reasonable
+optimization, or a documented platform limitation. Missing permissions and first
+deployment failures do not establish infeasibility. A fallback uses new isolated
+resources and the same images; legacy Railway services remain until separately
+authorized disposition.
+
+## Delivery dependencies
+
+Stage 0 freezes facts and contracts. Stages 1 (runtime/platform) and 2 (storage)
+may then proceed in parallel. Stages 3 (API) and 4 (async/recovery) depend on the
+atomic storage contract. Stage 5 waits for all of 1, 3 and 4 before integration,
+migration rehearsal and production rollout. Semantics is stage 6; operational
+handoff and portability proof are stage 7.
+
+Use independent branches/worktrees, at most the primary agent plus three
+subagents. The primary agent serializes shared DTOs, migration numbering, source
+transactions, resource mutations and releases. Each stage has its own PR and
+purposeful commits. Handoff records base/commit SHAs, contract/schema versions,
+tests, resource IDs, rollback point and unmet entry gates; never secret values.
+
+## References
+
+- [Workers and Container connections](https://developers.cloudflare.com/containers/configuration/workers-connections/)
+- [Container architecture](https://developers.cloudflare.com/containers/concepts/architecture/)
+- [Container deployment ordering](https://developers.cloudflare.com/containers/guides/deploy/)
+- [Container pricing](https://developers.cloudflare.com/containers/platform/pricing/)
+- [Queue delivery guarantees](https://developers.cloudflare.com/queues/reference/delivery-guarantees/)

--- a/docs/audits/2026-09-08-feed-platform.md
+++ b/docs/audits/2026-09-08-feed-platform.md
@@ -1,0 +1,182 @@
+# Feed platform audit — 2026-09-08
+
+This is a read-only evidence snapshot for the independent Go Feed work. The
+implementation base and freshly fetched `origin/main` were
+`41ce4cd829f431fa2e20133e0c2509bbe1d5fad3`; `origin/dev` was
+`c2118c73abdc2b501c4552679067bfaa1d8cf8f5`. Inspection took place around
+01:50–02:00 UTC. No remote configuration, data, traffic or deployments changed.
+Database queries returned `rows_written = 0`. GitHub secrets were inspected by
+name only; their values were neither retrieved nor printed.
+
+## Decision and evidence boundaries
+
+Proceed with a standalone Go Feed API/executor, Cloudflare Containers first,
+and a Worker binding adapter. Keep the current Feed D1 as the first production
+fact source. Deliver PostgreSQL as a tested alternative; do not switch runtime
+and database in the same release. This is an implementation decision, **not a
+claim that Containers or the alternative profile have passed production gates**.
+
+The core D1 is the operational assessment source: the active Worker binds it,
+and `src/lib/project-analysis-db.ts` selects `getD1Binding()` before Turso.
+`src/lib/feed.ts` projects assessments from that same core client. Existing
+Turso fallback code does not make Turso the active production source.
+
+Historical migration completeness remains unresolved. The earlier
+[migration execution record](../plans/2026-08-28-cloudflare-migration-execution.md)
+claims an August 29 import and approximately one hour of writes left in the old
+database. That is a historical report, not a current data comparison or renewed
+authorization to discard data. Neither this process nor local `.env.local`
+provided Turso connection settings. No production Turso endpoint was verified,
+and no contents or credentials were obtained from GitHub Secrets. Never resolve
+the difference by picking the newest database or replaying an unverified dump.
+
+## Verified platform snapshot
+
+| Surface | Observation | Evidence / consequence |
+| --- | --- | --- |
+| Repository | `hikariming/ghfind`, default branch `main`, viewer permission `WRITE` | `gh repo view`; no admin permission established. |
+| Production Worker | `ghfind`; active version `2d941c44-b50d-4c3c-95ab-32345858085a`, 100% | Wrangler deployment list and version view; release annotation contains the full base SHA. |
+| Production CI | CI, deploy and bounded catalog reconciliation succeeded for the base SHA | [CI](https://github.com/hikariming/ghfind/actions/runs/34171918209), [deploy](https://github.com/hikariming/ghfind/actions/runs/34172057529), [reconcile](https://github.com/hikariming/ghfind/actions/runs/34172211591). |
+| Core D1 | `ghfind`, `60d45096-bfe7-4de1-8b85-c1b66a466b0d` | Active `GHFIND_D1` binding; 261 assessments, all linked to a completed run. |
+| Feed D1 | `ghfind-feed`, `9c4ac13a-4c90-40a8-9d56-d7141f864bbf` | Active `GHFIND_FEED_D1` binding; 261 projects, 235 currently published, 1,169 proposed tags. Users/events/served items each zero at observation time. |
+| Existing dev | Feed database `bd305af9-2cab-4fe8-8c2f-324391cf105e` | Only `_cf_KV`, `d1_migrations`, `sqlite_sequence` tables; no Feed business schema. Dev and production share the core D1 in checked-in configuration. This is not isolated staging. |
+| R2 | `ghfind-assets`, `ghfind-next-cache`, `ghfind-next-cache-dev` exist | Account-pinned bucket list. The active Worker binds `ghfind-next-cache`; an existing bucket is not evidence of Feed backups. |
+| Containers / Queues / Vectorize / Workflows | No instances/applications, queues, indexes or deployed workflows listed in the target account | Read-only Wrangler listings. No operational capability, latency or recovery evidence yet. |
+| CF account | `8f19bebe359e4ec1a24c68c5f49c1584`; Workers settings report `enabled=true`, `free_tier=false` | This supports non-free Workers configuration. Subscription API returned HTTP 403, code 10000. Invoice, billing eligibility and account-specific quotas remain unverified. |
+
+Wrangler was 4.118.0. Account-wide R2 enumeration required explicit
+`CLOUDFLARE_ACCOUNT_ID`; the local OAuth context has multiple accounts. Always
+pin the target account, including commands that do not consume environment
+bindings. A transient D1 fetch failure succeeded on one bounded retry; it was
+not interpreted as a missing resource.
+
+The live Worker exposes `fetch`; OpenNext also declares generated class exports
+such as `DOQueueHandler`. These names alone do not show that business queues or
+the new Feed control plane are connected.
+
+## Migration drift and initial admission
+
+The core database records these applied migration filenames:
+
+| Filename | Applied at (UTC) |
+| --- | --- |
+| `0001_init.sql` | 2026-08-29 08:49:37 |
+| `0002_v10_risk_columns.sql` | 2026-09-06 06:32:58 |
+| `0003_v10_read_fallback.sql` | 2026-09-06 06:32:58 |
+| `0002_user_resume_libraries.sql` | 2026-09-07 13:14:28 |
+| `0004_project_assessment_sync_index.sql` | 2026-09-07 17:10:35 |
+
+The extra résumé migration is present on `origin/dev`, introduced by
+`d59c34fc5b14f5e065883534a8d676e395b202e1` on September 6. Its table shape matches
+remote `sqlite_master`: `github_id INTEGER PRIMARY KEY`, `login TEXT NOT NULL`,
+`data TEXT NOT NULL`, `updated_at INTEGER NOT NULL`. It is absent from main.
+Do not renumber, replace or remove the applied entry, table or data; reconcile
+its checked-in schema history separately without importing unrelated dev UI.
+New Feed source migrations must also test this real upgrade shape.
+
+Feed D1 has applied `0001_feed_baseline.sql` and
+`0002_feed_candidate_order.sql`. The 235 published rows reflect the current
+assessment-only gate, **not the stricter approved submission gate**.
+
+The current `POST /api/project-analyses` endpoint accepts direct submissions
+without requiring OAuth and reuses existing analyses. The persisted run schema
+has repository/run identity and completion status but no submitter, submission
+receipt, initiation channel or provenance type. The only current TypeScript
+caller of `createProjectAnalysis` is that route; this does not establish how
+each historical/imported row originated. No durable per-project submission
+evidence was established for the 261 existing candidates during this audit.
+
+Apply these admission rules in the new implementation:
+
+1. A server-recorded receipt of an explicit project submission, or a reviewed
+   historical receipt tied to the repository and analysis, establishes the
+   submission prerequisite. Record provenance and receipt identity; do not
+   infer the submitter from the repository owner. Keep existing anonymous
+   assessment submission behavior; only Feed consumption requires OAuth.
+2. A reused completed analysis still needs the new explicit-submission receipt.
+   Receipt persistence must not depend on creating a fresh analysis run.
+3. Verify valid completed assessment, current public eligibility and moderation
+   separately. Submission evidence cannot override those hard gates.
+4. Missing or ambiguous historical provenance defaults to quarantine in the
+   **new Feed admission path**. Keep public project pages and existing facts;
+   the audit itself does not unpublish production rows.
+5. Repository discovery, stars, a completed run, a catalog reconciliation,
+   a tag proposal or a migration import is insufficient submission evidence.
+   Do not bulk-approve the 1,169 pending tag proposals to manufacture admission.
+
+Therefore the strict initial admitted set is empty until receipts are supplied
+or recorded. This is not evidence that nobody submitted those projects.
+
+## Git and CI findings
+
+The named historical changes were verified using Git objects: `00e92af` and
+`117437d` were authored by AsperforMias (Go extraction and Next gateway);
+`fd9f650`, `ccdaa1e`, `06641a2` by hikariming (Cloudflare and route migration);
+`8d28106` by akou (CF release workflow); `6268726` by AsperforMias (merge).
+The current Next config has no Go backend rewrite. The deployed Feed business
+path remains in Next/TypeScript at the audited base.
+
+Ruleset `18206694`, [Protect main](https://github.com/hikariming/ghfind/rules/18206694),
+is active on the default branch. It prohibits deletion/non-fast-forward updates
+and requires a PR, one approving review, dismissal after new pushes, code-owner
+review and last-push approval. It has **no `required_status_checks` rule**.
+The response reports `current_user_can_bypass=always`; this is not authorization
+to bypass the agreed PR/review process. The legacy branch-protection endpoint
+returned 404, which is not proof that the separate ruleset is missing.
+
+`Production`, `Preview` and `copilot` environments have no protection rules or
+branch policies. The production deploy job at the base SHA does not reference
+an environment. It already gates `workflow_run` on successful upstream push CI
+for main and checks out its exact SHA; preserve those provenance checks. It
+currently deploys and rolls back one OpenNext Worker, so its rollback cannot be
+reused unchanged for a multi-service Container release.
+
+`CF_API_TOKEN` and `FEED_ADMIN_SECRET` repository secret names exist. Their
+presence says nothing about scope or future Container/queue permissions.
+The `Verify release` CI job runs Go, TypeScript, lint, local migrations and
+builds, but provisions no PostgreSQL. `feed_postgres_integration_test.go` skips
+when `FEED_TEST_DATABASE_URL` is absent. The passing CI is not a two-profile
+contract result or real OAuth E2E. Public smoke is likewise not authenticated
+Feed write/recovery evidence. No new CI run or E2E was performed by this audit.
+
+## Railway legacy surface
+
+The locally unlinked CLI was queried with explicit project
+`815ec3e1-679a-41b4-a7c0-6ba65b64db8e` (`ghfind-staging`) and environment
+`b9d929d6-a1e4-4e74-b43f-38ed529cc6f1` (`production`). Project naming does not
+establish data isolation.
+
+| Service | Latest deployment / observation |
+| --- | --- |
+| `ghfind-api` | `92293715-7c36-4183-9cee-cb5cc65e7b97`, August 30; one RUNNING instance, deployment SUCCESS; `/healthz` and `/readyz` each HTTP 200. |
+| `ghfind-worker` | `b5ce9acc-bd52-47f8-b849-b78752a2cc4a`, August 30; one RUNNING instance, deployment SUCCESS; both health endpoints HTTP 200. |
+| `ghfind-feed-backup` | `18033c56-110c-4a69-923b-f6743c7877e9`, September 8 00:21:44 UTC; CRASHED, six-hour schedule still configured. Recovery coverage cannot rely on it. |
+| Other resources | libsql, PostgreSQL/pgvector, RabbitMQ and mocks show RUNNING instances; migrate/bootstrap service records have no latest deployment. No resource was restarted or removed. |
+
+The API's public HTTP metric for September 1 02:00–September 8 02:00 UTC totals
+six requests. Read-only health probes in this task contribute to that traffic;
+the total cannot establish real business usage. Railway CLI 5.49.4 `metrics`
+failed its long-window sample-size limit; a read-only `httpMetrics` GraphQL
+query with `stepSeconds: 900` supplied the result. Private calls, queue contents,
+consumer activity, database writes, backup failure cause and actual cost were
+not audited here. Neither zero business dependency nor safe retirement is proven.
+
+## Open gates and handoff
+
+| Gate | Owner / next evidence | Blocks |
+| --- | --- | --- |
+| Billing and CF runtime feasibility | Account administrator: billing/eligibility; platform implementer: isolated startup, lifecycle and cost measurements | Claiming CF production readiness; not local implementation. |
+| GitHub release controls | Repository administrator: required checks and environment controls; release owner: workflow environment references | Production Feed cutover. |
+| Historical source differences | Data owner: verified read-only Turso snapshot/endpoint and bounded key/hash comparison | Core source migration or deleting old data; not a Feed-only implementation on D1. |
+| Initial project receipts | Data/product operator: evidence-backed manifest or new explicit receipts | Admitting those historical projects to the strict Feed. |
+| Runtime, contracts, OAuth and recovery | Subsequent implementation stages: actual two-profile tests and isolated deployment evidence | Production traffic and final operational acceptance. |
+
+Account permissions, absent resources and a first deployment failure are not
+evidence that Cloudflare cannot support the workload. The Railway fallback
+requires measured platform limitations or failure to meet the approved latency,
+recovery and USD 100/month budget after reasonable CF work.
+
+Handoff: base SHA and resource IDs above; schema versions remain unchanged;
+rollback anchor remains Worker `2d941c44-b50d-4c3c-95ab-32345858085a`. No new
+backend has been deployed. Operator follow-up is specified in
+[Feed platform prerequisites](../operations/feed-platform-prerequisites.md).

--- a/docs/contracts/feed-v1.md
+++ b/docs/contracts/feed-v1.md
@@ -1,0 +1,122 @@
+# Feed contracts, version 1
+
+Baseline: `41ce4cd`. Status: accepted implementation contract; environment
+verification and compatibility evidence are tracked separately.
+
+## Public HTTP
+
+Every route requires a real GitHub OAuth session and returns `Cache-Control:
+no-store`, including errors. Missing or invalid authentication is 401. Retain
+existing error codes such as `invalid_body`, `invalid_cursor`,
+`taxonomy_version_changed` and `feed_unavailable` where applicable.
+
+| Method / path | Contract |
+| --- | --- |
+| GET `/api/feed/projects?limit=20&cursor=…` | Limit 1–50; items, requestId, algorithmVersion, taxonomyVersion, nextCursor, degraded |
+| GET / PUT `/api/feed/preferences` | Explicit canonical preferences and taxonomy version; atomic replacement |
+| GET `/api/feed/tags` | Governed active taxonomy |
+| POST `/api/feed/events` | At most 50 typed events, 202 on acceptance, stable event IDs deduplicate |
+| PATCH `/api/feed/projects/:owner/:repo/state` | Exactly one of saved/notInterested plus a valid same-user, same-project impression token |
+| DELETE `/api/feed/profile` | Fence immediately, persist cleanup, return deletionId and status; works when serving is off |
+| GET `/api/feed/profile/deletions/:id` | Caller-owned durable cleanup status; completed only after all required sinks are clean |
+| POST `/api/feed/tags/proposals` | Proposal only; no client authority to approve or mint canonical tags |
+
+Existing public evaluation scores may remain in projects. Never expose ranking
+score, feature snapshots, embeddings or selection probability. Do not forward
+internal response headers to clients. Bound the actual received body to 128 KiB,
+independent of Content-Length. Reject unknown event fields and arbitrary JSON.
+Do not record event IP or User-Agent.
+
+## Gateway identity
+
+Header `X-Feed-Gateway` contains `base64url(claims) + '.' + base64url(signature)`.
+Signature is HMAC-SHA256 with `FEED_GATEWAY_SECRET` over UTF-8
+`feed-gateway-v1\n` followed by the encoded claims. Claims are:
+
+```json
+{"version":1,"audience":"feed-api","githubId":123,"login":"example","avatarUrl":"","issuedAt":1788825600000,"expiresAt":1788825630000,"method":"POST","target":"/api/feed/events","bodySha256":"<lowercase SHA-256 of the exact body bytes>"}
+```
+
+Times are integer Unix milliseconds. Maximum TTL 60 seconds, recommended 30,
+maximum accepted clock skew 5 seconds. Bind method, escaped path, original query
+and exact body. Strip client identity/gateway headers and construct an allowlisted
+upstream request. Reject invalid audience, identity, time, signature or binding.
+Use a dedicated secret of at least 32 bytes, distinct from OAuth, bridge and Feed
+token signing secrets. No cookie is sent to Go. Replay-safe mutations additionally
+use event/command IDs and durable generation/version checks.
+
+## Internal storage capabilities
+
+Versioned POST `/internal/feed/v1/{operation}`, `X-Feed-Contract: 1`, authenticated
+with a dedicated bridge credential. DTOs are defined by
+`internal/backend/feed_bridge_contract.go`. Use explicit private snapshot DTOs:
+public Go fields marked `json:"-"` must not disappear when sessions are persisted.
+Timestamps use RFC3339 UTC; identities and versions must be JSON-safe integers.
+
+The adapter checks persistent writer epoch and expected user profile/deletion
+version for every mutation. Old writers, sessions and delayed messages fail after
+a fence. Epoch changes use compare-and-swap. Exact command retries are safe;
+same ID with a different payload is a conflict. Reads never turn a tombstoned
+user into a fresh generation with reusable old tokens.
+
+Atomic commands include preferences+event+version+outbox, state+event+version,
+request+all served items, source finalization+outbox, and deletion fence+cleanup
+job. D1 must enforce these with transaction-backed batch, guards and constraints;
+PostgreSQL with native transactions. Do not use independent calls to simulate
+atomicity. Chunk parameter-limited reads, but do not split atomic writes across
+independent transactions.
+
+## Recommendation invariants
+
+Candidates require verifiable submission, a valid completed assessment and
+current public eligibility. Recall caps: tags 80, latest 40, quality 20, long-tail
+20; semantics may add 80; total at most 240. Missing feature weights renormalize.
+MMR defaults to 0.78. Exploration probability 0.10 with at most two exploratory
+choices in each 20-item block; any rolling 20 results contain at most two from
+the same owner. Short pages are valid when hard constraints exhaust candidates.
+
+Persist the selected sequence for 30 minutes. Page impressions do not change
+that sequence. Before serving each page recheck deletion, withdrawal and negative
+state; preference version changes invalidate the session. Compute and store the
+actual conditional policy probability after eligibility, quota, deterministic
+choice and exploration mixture; neither constant 0.9 nor branch probability alone
+is a valid propensity.
+
+Explicit preferences override behavioral signals; graph hints are weak priors.
+Deduplicated saves, outbound clicks and qualified detail dwell update future
+behavior. A bare detail_open is not positive feedback. Attribution links event,
+request, served project, source, policy and probability privately.
+
+## Required acceptance fixtures
+
+| Fixture | Required result |
+| --- | --- |
+| Missing auth; altered path/body/actor; expired gateway claims | 401, no user creation or event write |
+| Cross-user cursor, impression or deletion ID | Rejected without disclosing other user's state |
+| Assessment without submission receipt | Absent from Feed, original project page retained |
+| Existing proposed tags | Remain proposed; no canonical escalation |
+| Impression between pages | Stable snapshot order, no stale-cursor error solely due to impression |
+| Preference change / withdrawal / deletion between pages | Updated filter or explicit invalidation, never stale eligibility |
+| 21 high-quality projects from one owner | Rolling owner cap enforced, including exploration |
+| Repeated event; duplicate command with altered payload | One effect; conflicting reuse rejected |
+| Save/outbound/qualified dwell vs bare detail_open | Only qualified, deduplicated signals affect later behavior |
+| Late job after deletion / stale writer after promotion | Fenced; no user or project resurrection |
+| Source commit then queue outage / effect then lost ack | Source remains committed; retry produces one durable effect |
+| Mid-batch error / concurrent versions | Entire atomic operation rolls back or conflicts |
+| Missing required PostgreSQL test DSN | Required CI job fails; no green skipped contract suite |
+| D1-to-PG-to-D1 rehearsal | Primary keys, status, versions, tombstones and checksums agree |
+| Worker / Container version mismatch | Readiness or rollout gate blocks traffic |
+| Embedding unavailable / incompatible index | Explicit degradation, base Feed works, no fake semantic reason |
+
+## Operational policy
+
+Hot event/request retention is 30 days; archive total retention is 180 days.
+Deletion markers cover replay and backup restore windows. Every cleanup sink is
+tracked before completed status. Restore into an isolated database, validate,
+then promote under a writer fence. Migration may pause Feed writes for at most
+two minutes; timeout before promotion reopens the source. Once the target accepts
+writes, rollback requires reverse replay and another fenced promotion.
+
+Real OAuth, real evaluation, CF staging measurements, budget qualification and
+production readiness must have actual evidence. Mocks, health checks and locally
+signed cookies are supporting tests, not substitutes for those gates.

--- a/docs/contracts/feed-v1.md
+++ b/docs/contracts/feed-v1.md
@@ -16,7 +16,7 @@ existing error codes such as `invalid_body`, `invalid_cursor`,
 | GET / PUT `/api/feed/preferences` | Explicit canonical preferences and taxonomy version; atomic replacement |
 | GET `/api/feed/tags` | Governed active taxonomy |
 | POST `/api/feed/events` | At most 50 typed events, 202 on acceptance, stable event IDs deduplicate |
-| PATCH `/api/feed/projects/:owner/:repo/state` | Exactly one of saved/notInterested plus a valid same-user, same-project impression token |
+| PUT `/api/feed/projects/:owner/:repo/state` (PATCH alias) | Preserve existing PUT; exactly one of saved/notInterested plus a valid same-user, same-project impression token |
 | DELETE `/api/feed/profile` | Fence immediately, persist cleanup, return deletionId and status; works when serving is off |
 | GET `/api/feed/profile/deletions/:id` | Caller-owned durable cleanup status; completed only after all required sinks are clean |
 | POST `/api/feed/tags/proposals` | Proposal only; no client authority to approve or mint canonical tags |

--- a/docs/operations/feed-platform-prerequisites.md
+++ b/docs/operations/feed-platform-prerequisites.md
@@ -1,0 +1,196 @@
+# Feed platform prerequisites and release gates
+
+Use this checklist before enabling the independent Go Feed. The
+[September 8 audit](../audits/2026-09-08-feed-platform.md) records what was
+actually observed. This document specifies required follow-up; unchecked items
+are not provisioned infrastructure or completed acceptance tests. Implement and
+test locally while account administrators complete their respective items.
+
+## Repository administrator: required checks and environments
+
+The audited user has `WRITE` permission, not demonstrated administration access.
+Do not use the reported ruleset bypass ability to avoid a PR or required review.
+
+1. Open repository **Settings → Rules → Rulesets → Protect main**
+   (`18206694`). Keep the current PR/review, deletion and force-push rules.
+   Add **Require status checks to pass**, require the stable **Verify release**
+   check from **GitHub Actions**, and require branches to be up to date before
+   merging. Do not substitute an arbitrary check with the same display name.
+2. Preserve `Verify release` as an always-running aggregate gate. As jobs are
+   split, it must depend on Go, TypeScript, lint, both real storage contracts,
+   upgrade migrations, Worker build and Docker build; missing, skipped or failed
+   required jobs must fail the aggregate. Do not add path filters that let
+   backend or workflow changes bypass it. Add the check after a real PR run has
+   registered its exact context.
+3. Restrict the existing **Production** environment to the selected branch
+   `main`; prevent feature-branch deployment. Normal main releases remain
+   automatic after PR approval and successful CI/staging gates; do not add a
+   second manual review requirement to every normal deployment.
+4. Create **Feed staging** with separate scoped credentials and its own resources.
+   Create **Feed recovery** restricted to `main`, require the designated recovery
+   operator's review and prevent self-review. Attach only recovery workflows to
+   that environment. Record the operator/team and test that protection works
+   before accepting the recovery runbook.
+5. Set the deployment job's `environment` to the intended protected environment
+   in the implementation PR. Environment settings have no effect on jobs that
+   never reference them. The base production workflow currently has no such
+   reference, so settings alone do not complete this step.
+6. Review ruleset bypass actors with the repository owner. Retain only documented
+   emergency authority, and require its use to produce an incident record. Do
+   not remove existing administrators or alter bypass policy blindly.
+
+Read back configuration after administrator changes; these commands do not
+retrieve secret values:
+
+```sh
+gh api repos/hikariming/ghfind/rulesets/18206694
+gh api repos/hikariming/ghfind/environments --jq \
+  '{environments:[.environments[]|{name,protection_rules,deployment_branch_policy}]}'
+gh secret list --repo hikariming/ghfind
+gh run list --repo hikariming/ghfind --workflow ci.yml --limit 5
+```
+
+Save the resulting settings, check-run URL and tested rejection cases in the
+release evidence. Do not report branch protection complete from a green CI run
+alone. A passing historical run that skipped PostgreSQL is insufficient.
+
+## Cloudflare administrator and platform owner
+
+Target only account `8f19bebe359e4ec1a24c68c5f49c1584`. The audited Workers
+settings show `free_tier=false`; billing subscriptions are inaccessible with the
+available OAuth grant. Obtain dated billing-plan/eligibility evidence from an
+account administrator, with payment details redacted. Confirm Container, D1,
+Queues, R2, Vectorize/AI and registry permissions for the **Actions token**;
+local OAuth permissions do not establish that token's permissions. Check secret
+names and actual bounded operations, never print their values.
+
+Create resources through the reviewed, environment-scoped Actions provision and
+deployment workflows once implemented. Do not locally deploy production. Fill
+the release resource manifest with actual IDs returned by provision operations:
+
+| Resource | Staging isolation requirement | Production requirement |
+| --- | --- | --- |
+| Frontend/gateway | Separate Worker and OAuth callback registration | Existing frontend with rollout off by default |
+| Go API and executor | Separate Worker/Container namespaces, immutable image digests | At most two `basic` API instances and one executor; independent readiness |
+| Core assessment D1 | New isolated core D1 with reviewed fixtures | Existing core D1 `60d45096-bfe7-4de1-8b85-c1b66a466b0d`; additive source seam only |
+| Feed D1 | New isolated Feed D1 with complete migrations | Existing Feed D1 `9c4ac13a-4c90-40a8-9d56-d7141f864bbf` for first cutover |
+| Archive R2 | Dedicated bucket and restricted test data | Dedicated Feed archive bucket; do not repurpose Next cache |
+| Task queues and DLQs | Distinct queues/consumers and task secrets | Finite retries, durable task state, replay and alert evidence |
+| Identity/adapter secrets | Unique staging keys and short-lived request signatures | Separate keys from OAuth and unrelated services; environment-scoped |
+| Semantic index/AI | Disabled until model/index manifest and bounded test exist | Separate index version and budget; enable only after semantic acceptance |
+
+The existing `dev` core binding points to production. Do not use `--env dev`
+for assessment writes, destructive contract fixtures, load or recovery tests.
+The empty dev Feed database does not make the shared core safe. Do not alias an
+uncreated staging resource to a production ID to make deployment pass.
+
+All resource configurations must fail closed on unresolved IDs/credentials,
+unexpected account, unintended shared storage or unsupported schema version.
+The Go service must receive ordinary HTTP capability endpoints for CF storage,
+not a D1 management API token or arbitrary SQL gateway.
+
+## Billing and runtime acceptance
+
+The approved incremental budget is **USD 100/month across production and
+staging**, with projected operation at or below USD 80 and USD 20 headroom.
+Existing evaluation-model spending is excluded; new embeddings and observability
+are included. Validate account-specific inclusions and usage already consumed
+by other applications. Billing alerts are not hard spending caps.
+
+Containers charge for provisioned memory/disk while running and active CPU;
+Workers, Durable Objects, network and logs also contribute. Use the current
+[Container pricing](https://developers.cloudflare.com/containers/platform/pricing/)
+and [instance definitions](https://developers.cloudflare.com/containers/platform/limits/)
+when producing the estimate. Do not use the maximum instance count alone as
+proof that the monthly budget is safe.
+
+Record a dated estimate with measured active time, CPU, memory, requests, D1
+reads/writes, R2 storage/operations, queue deliveries, network, logs and embedding
+calls. Include staging, retries, DLQ replay, backfill and retained images.
+Enforce instance, concurrency, per-call and batch limits; stop discretionary
+backfills before accepted jobs or deletion recovery. Staging sleeps when idle.
+
+On isolated staging, measure the same Go image used by ordinary Docker:
+
+- Real `/healthz` and dependency-aware `/readyz`, build digest and contract/schema
+  identity; no successful readiness merely because the process started.
+- Cold start, concurrent requests, instance restart, temporary-disk loss and
+  graceful shutdown; persistent task completion must survive each case.
+- Normal p95 ≤800 ms, cold p95 ≤5 s; 10 RPS for at least ten minutes after the
+  50,000-project/5,000-user/1,000,000-event fixture passes isolated CI. Record
+  error rate, p99, D1 scanned rows, backlog and cost, not cache hits alone.
+- Queue commit/ack failures, outbox lag p95 ≤60 seconds, deletion invalidation,
+  bounded replay, application rollback ≤5 minutes and demonstrated recovery
+  RPO ≤15 minutes / RTO ≤60 minutes.
+
+Do not select Railway merely because billing evidence is inaccessible, a
+resource is unconfigured or the first deploy fails. Escalate to the approved
+external-PaaS fallback only with a documented CF platform limitation or measured
+failure to meet the latency, recovery or budget targets after reasonable tuning.
+Use fresh isolated services for that fallback, never silently reconnect the old
+Railway deployment.
+
+## Data owner: provenance and schema acceptance
+
+Keep the operational core D1 unchanged until an independently verified
+Turso/D1 comparison is available. A bounded read-only comparison must record
+the endpoint/snapshot identity, cutoff watermarks, table/key sets, row versions,
+content hashes and missing/different counts. Preserve differences for review;
+do not print user records into build logs. Historical reports of acceptable
+drift do not authorize new loss or a switch back to an outdated fallback.
+
+Preserve the applied résumé migration from dev and test both a clean core schema
+and the production upgrade shape. Never change the meaning of an applied
+migration filename, delete `d1_migrations` rows or use a destructive down-migration
+as application rollback. Feed migrations must preserve core ownership.
+
+Build an initial admission manifest from verified submission receipts. Each
+entry must identify the repository, analysis, receipt/evidence reference,
+initiation type, receipt time, reviewer and admission decision. Restrict personal
+identity/evidence records to the data system; commit only a non-sensitive
+manifest/checksum summary. Completed assessment alone is insufficient. Existing
+anonymous assessment submission remains available; new receipts can record that
+channel without claiming an OAuth identity. Reusing an old completed assessment
+must still record the current explicit submission. Missing historical evidence
+stays quarantined under the new Feed path, with public project pages preserved.
+
+Do not approve all pending tag proposals, infer submission from ownership or use
+an unreviewed manually typed project list as provenance. Review proposals through
+the protected governance interface and retain the decision maker and reason.
+
+## Release owner: evidence required before cutover
+
+Each phase hands off its base SHA, commits, public/adapter contract versions,
+schema versions, resource IDs, test URLs/results, rollback point and next entry
+conditions. Separate code built, code tested, code deployed and behavior observed.
+No unchecked prerequisite becomes complete merely because a later phase starts.
+
+Production release must verify upstream main CI provenance and exact SHA,
+isolated staging gates, then immutable image publication **before** publishing
+the Worker reference. Cloudflare's Worker/Container rollout is not atomic;
+verify the active image and preserve compatibility with old instances before
+enabling traffic. A prebuilt digest eliminates build-order exposure but not the
+rollout compatibility window. See the
+[Container deployment behavior](https://developers.cloudflare.com/containers/guides/deploy/).
+
+The ordered cutover is internal accounts → 1% → 10% → 100%, with bounded checks
+and an automated stop/rollback per step. First change runtime while retaining
+Feed D1. Database promotion requires the separate snapshot/replay/checksum and
+writer-fencing procedure, never just changing `FEED_STORE_PROFILE`.
+
+Before declaring complete, retain real OAuth E2E, submission/assessment,
+projection, Feed/pagination/preferences/events, deletion and recovery evidence
+from a dedicated test identity. Mock tokens or mocked assessments must be
+labelled as such. Production smoke has explicit request/event/cost limits and
+does not perform load testing. Failure of WAF-blocked unauthenticated probes
+does not establish Feed authorization correctness.
+
+The audit's Worker rollback anchor is
+`2d941c44-b50d-4c3c-95ab-32345858085a`; re-read before any release. After the new
+service accepts writes, roll back application code only on the same compatible
+fact source. Switching a database back requires reverse replay and a new fence.
+
+Railway services, queues, databases and credentials remain untouched. Audit
+private traffic, queue consumers, data writes, backup failure/recovery and bills
+before any retirement proposal. The current failed legacy backup is not a
+verified recovery path for the new Feed.

--- a/docs/releases/feed-phase-0.md
+++ b/docs/releases/feed-phase-0.md
@@ -1,0 +1,27 @@
+# Feed stage 0 handoff
+
+Implementation baseline: `41ce4cd829f431fa2e20133e0c2509bbe1d5fad3`.
+Documentation commits: `442970d` (ADR), `45126f9` (contract), `db88e1f`
+(audit), `17fe722` (prerequisites). Public/bridge contract target: 1.
+No migration, resource, production data or traffic changed in this stage.
+
+The [audit](../audits/2026-09-08-feed-platform.md) and
+[operator prerequisites](../operations/feed-platform-prerequisites.md) distinguish
+verified facts from missing evidence. Source differences with Turso, historical
+submission receipts, billing/quotas and repository administration remain open.
+Independent implementation can proceed; these are not waived release gates.
+
+Reviewed route compatibility includes the actual existing PUT project-state
+method, with PATCH permitted as an additive alias. Strict historical admission
+starts with no verified receipts, without modifying the current Feed or public
+project pages. The active production Worker rollback anchor remains
+`2d941c44-b50d-4c3c-95ab-32345858085a`; re-read before a future release.
+
+Validation: fresh Git/CI/platform read-only audit; schema provenance; local links,
+Markdown fences, operator shell syntax and `git diff --check`. This stage provides
+no Container feasibility, authenticated E2E or restore evidence.
+
+Next work: stage 1 runtime/platform and stage 2 storage may implement in parallel
+against ADR 001 and the versioned contract. DTO changes and schema numbers are
+serialized by the integrator. Production entry requires the documented gates and
+an approved PR, even when the current identity can bypass a ruleset.


### PR DESCRIPTION
This freezes the independently verified production topology and the contract for extracting Feed into portable Go API/executor services, with Cloudflare as the preferred runtime and the existing Feed D1 retained for first cutover.

The audit records schema drift, missing submission receipts, incomplete release protection, inaccessible billing evidence and the failed legacy Railway backup. ADR 001 and the acceptance fixtures define ownership, request-bound identity, atomic storage commands, deletion/writer fencing and staged delivery. No production resources, data or traffic are changed.

Validation: read-only Git/GitHub/Cloudflare/Railway audit; migration provenance; documentation links and operator shell syntax; git diff --check. This PR does not claim Container feasibility, real OAuth E2E, two-profile contracts or recovery acceptance. These remain explicit gates in the stage handoff.
