### PR TITLE
fix(ghfind-py): handle Windows stdout console encoding and add __main__.py CLI entrypoint

### DIFF
--- a/packages/ghfind-py/ghfind/__main__.py
+++ b/packages/ghfind-py/ghfind/__main__.py
@@ -1,0 +1,6 @@
+﻿"""CLI entry point for python -m ghfind."""
+import sys
+from ghfind._cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/ghfind-py/ghfind/_cli.py
+++ b/packages/ghfind-py/ghfind/_cli.py
@@ -37,7 +37,13 @@ _SUB_SCORE_ORDER = [
 
 
 def _out(text: str = "") -> None:
-    sys.stdout.write(f"{text}\n")
+    try:
+        sys.stdout.write(f"{text}\n")
+        sys.stdout.flush()
+    except UnicodeEncodeError:
+        # Fallback for Windows consoles or non-UTF-8 stdout environments
+        sys.stdout.buffer.write(f"{text}\n".encode("utf-8", errors="replace"))
+        sys.stdout.buffer.flush()
 
 
 def _out_json(value: Any) -> None:
@@ -45,7 +51,12 @@ def _out_json(value: Any) -> None:
 
 
 def _fail(message: str, code: int = 1) -> "NoReturn":  # type: ignore[name-defined]
-    sys.stderr.write(f"{message}\n")
+    try:
+        sys.stderr.write(f"{message}\n")
+        sys.stderr.flush()
+    except UnicodeEncodeError:
+        sys.stderr.buffer.write(f"{message}\n".encode("utf-8", errors="replace"))
+        sys.stderr.buffer.flush()
     raise SystemExit(code)
 
 


### PR DESCRIPTION
### Summary

This PR addresses two compatibility issues in the `ghfind-py` Python package:

1. **Windows Console UnicodeEncodeError Fix**:
   - On Windows environments running default code pages (e.g. `cp1252`), running `ghfind score <user>` or `ghfind roast <user>` crashes with `UnicodeEncodeError` when outputting UTF-8 JSON payloads or localized tier text (due to `ensure_ascii=False`).
   - Fixed by adding a fallback in `_out` and `_fail` to write UTF-8 encoded bytes to `sys.stdout.buffer` / `sys.stderr.buffer` when the active text stream cannot encode non-ASCII characters.

2. **Add `ghfind/__main__.py` Entrypoint**:
   - Running `python -m ghfind ...` previously failed with `No module named ghfind.__main__; 'ghfind' is a package and cannot be directly executed`.
   - Added `packages/ghfind-py/ghfind/__main__.py` delegating to `ghfind._cli.main()`.

### Verification

- Ran `pytest packages/ghfind-py/tests` (45 passed, 1 skipped).
- Tested `python -m ghfind --help` and verified successful CLI invocation on Windows.