### PR TITLE
feat(feed): validate bounded migration journal preparation contracts

### DIFF
--- a/docs/contracts/feed-transfer-v1.md
+++ b/docs/contracts/feed-transfer-v1.md
@@ -1,0 +1,322 @@
+# Feed transfer v1: bounded journal preparation contract
+
+Status: offline protocol preparation only, based on `1bc35c3`. This is **not a
+complete change journal, a D1/PostgreSQL mapper, or permission to migrate**.
+`internal/feedtransfer` neither connects to a database nor writes, captures,
+replays, fences or promotes one. No business transaction, migration number,
+routing configuration or production resource changes in this delivery.
+
+**Known blocking limitation:** PostgreSQL `PostgresFeedStore.DeleteFeedProfile` deletes a user
+inside its source transaction (`internal/backend/feed_store.go`), cascading to
+preferences, requests, served items, events, sessions and other rows. A real
+large actor can delete 250,000 events in that transaction. The user cleanup
+command and `internal/backend/feed_maintenance.go` retention deletes can also
+exceed v1 limits. Their complete write sets cannot fit this format. No capture
+switch or production promotion may be connected to this v1 implementation until
+a separate, reviewed contract handles those real operations. Increasing the
+limit, omitting cascades or paging one source transaction is not a solution.
+The next design must prove deletion and retention semantics, not merely accept a
+smaller synthetic example.
+
+## What is delivered
+
+The package validates a closed interval of bounded, whole Feed transactions,
+explicit source coverage, canonical hashes, monotonic deletion floors and
+caller-persisted page receipts. It produces decisions and a next checkpoint;
+**it does not execute those decisions**. Every successful result reports:
+
+| Result | Meaning |
+| --- | --- |
+| `ProtocolComplete` | The supplied interval ends at its declared final commit. This is not evidence that capture included every real write. |
+| `CaptureConnected = false` | No source transaction emits this journal yet. |
+| `RowSchemaValidated = false` | Images have a safe transport shape, but column completeness, schema types, keys and ownership have not been checked. |
+| `ArchiveBytesVerified = false` | Referenced object inventory and object bytes have not been read or verified. |
+| `PromotionReady = false` | No control-plane evidence authorizes a database promotion. |
+
+The existing core assessment outbox is a projection input. Its sequence, Feed
+runtime/task outboxes, queue attempts and archive counters are **not** the
+transaction sequence defined here. `stream` must literally be
+`feed_transaction_journal`; an outbox stream identifier is rejected.
+
+## Resource identity and manifest
+
+Wire DTO field names are the exact lower-camel JSON tags in `types.go` and the
+shared fixture `testdata/transfer-v1.json`. Every field is mandatory, including
+empty arrays and explicit null actor/image fields. Unknown/misspelled fields,
+duplicate keys (including escaped duplicates), null scalar fields, trailing JSON
+and invalid UTF-8 are rejected. Isolated escaped UTF-16 surrogates are rejected
+in keys and values before Go decoding; legal pairs are accepted. All integer
+fields use literal base-10 integer JSON tokens and the range 0…9,007,199,254,740,991;
+identity epochs, actor IDs, generations and commit sequences are positive.
+Values such as `1.0` and `1e0` are not canonical integer DTO representations.
+
+Each `Identity` contains:
+
+| Field | Requirement |
+| --- | --- |
+| `profile` | `cf_d1_r2` or `postgres` |
+| `resourceId` | Lowercase UUID, version 1–8 and RFC variant, registered to one immutable database resource by the deployment controller; never a DSN, hostname, credential or human environment label |
+| `schema` | Exactly 11 for D1 or 22 for PostgreSQL in this registry |
+| `writerContract` | Exactly 2, independent of HTTP/read contract 1 |
+| `writerEpoch` | Expected epoch in that resource's own control record; source and target epochs need not have the same value |
+| `routeEpoch` | Expected global routing generation, whose target value is exactly source + 1 |
+
+Source and target must have different resource UUIDs. The same profile is
+permitted for isolated restoration; the identity still distinguishes the two
+databases. Deployment registry verification is not implemented by this package.
+Source routing/writer control rows are staged, not executed to enable the target.
+An unknown profile/schema/writer contract fails closed. A reverse migration is a
+**new** manifest with identities reversed, a new migration ID, a newly verified
+source journal and the next route epoch. Changing an environment variable is not
+reverse replay.
+
+A manifest binds version 1, stream, migration UUID, journal UUID, both identities,
+full snapshot SHA-256, archive inventory SHA-256 and object count, deletion-floor
+overlay hash and actor count, `fromSequence`, `throughSequence`, `anchorHash`, and
+coverage. The snapshot includes the prefix through `fromSequence`; the journal
+must contain every following commit up to `throughSequence`. A zero prefix uses
+64 zeroes as its anchor; a nonzero prefix requires its real nonzero commit hash.
+The source identity/schema/epochs stay fixed for that journal segment. A schema
+or writer transition closes a segment and requires a fresh verified manifest.
+
+Snapshot and object inventory hashes refer to externally verified immutable
+artifacts. This package does not invent an archive inventory encoding or claim
+the current D1 snapshot format can already map PostgreSQL. The future artifact
+adapter must declare its own version, byte encoding and verification evidence.
+The supplemental core outbox watermark remains in its source artifact; it cannot
+be substituted for either Feed sequence field.
+
+The deletion overlay is a sorted, unique `(githubId, profileFloor)` set containing
+snapshot floors **and all newer verified deletion floors available before
+replay**. Its hash and actor count are pinned in the manifest. `Begin` checks it,
+and `ValidateBatch` independently checks it again whenever the checkpoint is at
+`fromSequence`, so bypassing `Begin` cannot silently drop the initial overlay.
+Its completeness and relation to the closed source watermark require external
+source evidence. The current capacity bound is 100,000 distinct floor actors.
+
+## Coverage means inventory, not mapping completeness
+
+`RequiredRegistry` is the authoritative declaration for the two source schemas.
+Coverage must contain every registered physical relation exactly once, in ASCII
+table-name order, with its exact mode/category and nonnegative snapshot row count.
+Missing relations, duplicate entries, unknown relations, category changes and
+unjustified ignore policies fail closed. This catches a declaration omission;
+only source-side instrumentation and fault tests can prove actual capture.
+
+| Category | Obligation |
+| --- | --- |
+| `fact` | Preserve the domain fact, privacy generation, provenance, governance and idempotency meaning through a schema-aware mapper. |
+| `control` | Account for jobs, delivery/replay receipts, deletion and archive progress, rate limits and runtime controls; reconcile leases and authority explicitly. Never start target writers by copying source controls. |
+| `derived` | Account for behavior signals and embeddings/model state. A later mapper may choose a documented rebuild, with deletion/version checks; this protocol grants no automatic omission. |
+| `legacy` | Preserve or explicitly quarantine/archive older Gorse, algorithm configuration and projection maintenance data until ownership/disposition is proved. These are not asserted to be new Feed primary facts. |
+
+D1 schema 11 has 45 physical tables in the existing snapshot registry. Eight
+transaction guard tables have `mode=empty`: archive, command, delivery,
+execution, operator, projection-command, proposal and governance guards. Their
+snapshot count must be zero and journal changes to them are forbidden: temporary
+guards must never survive a committed business transaction. All other registered
+relations have `mode=capture`.
+
+PostgreSQL schema 22 has a different inventory. It includes source-aware tags,
+proposals, user generations, deletion/cleanup state and older derived/legacy
+relations. Equal table counts would not establish a mapping; this package makes
+no such claim. Future adapters must produce a reviewed per-relation mapping or
+disposition matrix for **both** directions, including runtime control and archive
+representations. SQL migration ledgers, SQLite internal metadata and views are
+not business row streams: schema identity and migration verification cover them.
+Core assessment facts, OAuth/session facts outside Feed and source outbox tables
+belong to separate resources and are outside this Feed database transfer.
+
+The unit inventory check installs all 11 D1 SQL files in local SQLite and compares
+physical table names; it is not a Workers transaction test. PostgreSQL inventory
+is checked against all 22 SQL declaration files, not by pretending that SQLite
+runs PostgreSQL migrations. Existing mandatory database suites remain necessary.
+
+## Transaction, change and page limits
+
+A sequence represents **one committed atomic source write set**, not one row or
+one task. Sequence values are consecutive. `transactionId` is exactly
+`journalId + ":" + sequence` with canonical decimal sequence; it cannot be reused
+under another sequence. Each transaction names its previous commit hash and all
+ordered changes. It must fit wholly in one page. The source must persist its
+write set and sequence atomically with the business transaction, or capture a
+proven equivalent database commit stream. Neither mechanism is implemented here.
+
+| Bound | v1 value |
+| --- | --- |
+| Manifest input | 256 KiB |
+| Batch serialized input | 8 MiB, enforced by a streaming read cap |
+| Transactions per batch | 32 |
+| Changes per transaction | 512 |
+| Total changes per batch | 2,048 |
+| One image / total image bytes in a transaction | 2 MiB |
+| Canonical mapper key | 1,024 UTF-8 bytes, no C0/DEL control characters |
+| JSON nesting / nodes | 32 / 200,000 |
+
+The transport caller must enforce its own total deadline; a bounded reader
+cannot impose a deadline on an arbitrary stalled `io.Reader`.
+
+A change has a registered `table`, opaque canonical mapper `key`, `operation`,
+explicit nullable `actor` and explicit nullable `image`. No SQL or arbitrary
+predicate is accepted. Actor scope is `{githubId, profileVersion}`. It is required
+for actor-private relations and user deletion/archive control rows. Shared
+relations reject actor metadata. Mixed legacy/outbox/proposal relations require
+a later schema-aware mapper to prove whether actor scope is required for that
+specific row. A metadata claim is not proof that the image belongs to the actor.
+
+The image is standard base64 of the **exact** UTF-8 bytes of a nonempty flat JSON
+object of SQL column names to values. Values may be null, text, boolean or a
+canonical safe integer; fractions/SQL numeric values are lossless decimal
+**strings**. SQL JSON/JSONB is represented as a text cell, not a nested decoded
+object. Timestamp and binary column encoding must be fixed by the schema mapper
+(e.g. explicit UTC precision / base64); this module does not guess them or convert
+seconds to milliseconds. The schema mapper must check every column, type,
+identity, key, source version and nullable field before any target write.
+Images are hashed exactly, without reserializing, Unicode normalization, float
+formatting, timestamp conversion or sorting their column keys. A different byte
+representation is a different image and cannot silently replace a receipt.
+
+The source capture order is immutable once hashed. Duplicate row keys within a
+transaction are rejected; one explicit `floor` metadata change may accompany a
+row after-image for that same tombstone row. Capture collapses intermediate
+updates into the complete final write set and preserves commit order. Unknown
+operations and attempted guard-table mutations fail closed.
+
+## Hash transcript, shared across runtimes
+
+SHA-256 output is lowercase hexadecimal. A token `s` contributes ASCII decimal
+`len(UTF8(s))`, then `:`, then those exact bytes; there is no trailing delimiter.
+Integers contribute their canonical decimal string, booleans `1` or `0`. Arrays
+contribute their length first. Object field names are not transcript tokens;
+fixed field order below provides their meaning. Domain tags are framed tokens.
+
+1. **Identity:** profile, resourceId, schema, writerContract, writerEpoch,
+   routeEpoch.
+2. **Floors:** domain `ghfind.feed.transfer.floors.v1`, actor count, then each
+   githubId and profileFloor sorted by numeric githubId.
+3. **Manifest:** domain `ghfind.feed.transfer.manifest.v1`, version, stream,
+   migrationId, journalId, source identity, target identity, snapshotSha256,
+   archiveInventorySha256, archiveObjects, deletionFloorsSha256,
+   deletionFloorActors, fromSequence, throughSequence, anchorHash, coverage count,
+   then each table, mode, category, snapshotRows in registry order.
+4. **Transaction:** domain `ghfind.feed.transfer.transaction.v1`, source identity,
+   journalId, sequence, transactionId, previousHash, change count, then each
+   table, key, operation, actor-present boolean, optional githubId/profileVersion,
+   decoded image byte length and SHA-256 of those bytes. A null image uses length
+   zero and SHA-256 of empty bytes. The transaction's own hash is excluded.
+5. **Batch:** domain `ghfind.feed.transfer.batch.v1`, version, manifestHash,
+   afterSequence, previousHash, transaction count, each transaction hash in order,
+   final boolean. The batch's own hash is excluded.
+
+The journal hash is source-specific and does not depend on a target migration.
+The manifest and batch bind the target as well, preventing page interchange
+between migrations. These are integrity checks, **not signatures**; storage and
+operator authorization must authenticate artifacts, manifest and checkpoint.
+
+`testdata/transfer-v1.json` contains synthetic Chinese text, HTML characters,
+U+2028, a valid escaped surrogate pair, null, actor recreation and deleted-command
+tombstones across two pages. The independent Python implementation
+`testdata/generate_fixture.py` checks the exact hashes. `unicode-v1.json` includes
+portable accepted/rejected Unicode inputs. Future TypeScript capture and target
+mapper implementations must run the same fixture, rather than minting a separate
+"equivalent" hash convention.
+
+## Legal deletion replay
+
+Before considering any upsert in a transaction, the validator merges **all** its
+floor changes into the current floor map by maximum. This prevents row order
+inside one transaction from reviving old data. Snapshot floors, later overlay
+floors and transaction floors never decrease.
+
+| Operation | Constraint and decision |
+| --- | --- |
+| `upsert` | Requires an image. Actor content at generation ≤ effective floor becomes `suppress_deleted_generation`. New generations remain eligible for schema mapping. Runtime writer/schema controls become `stage_control` and cannot activate the target. |
+| `delete` | Requires null image. The mapper must delete exactly that scoped identity, never a newer generation sharing a natural key. Deleting a floor row is forbidden. |
+| `floor` | Only D1 `feed_profile_floors` or PG `feed.user_deletion_tombstones`, with actor and null image. `retain_max_floor` preserves the maximum. |
+| `erase` | Only user proposal tables, with actor, null image and generation ≤ floor. The mapper clears private proposal slug/labels/evidence without erasing independently reviewed public classification. Mixed PG proposal source/author must be verified. |
+| `command_tombstone` | Only user proposal command tables, actor and null image, generation ≤ floor. The mapper retains the minimum actor+command+generation replay fence, replaces payload hash with `deleted`, removes proposal linkage and resets original creation time. No body or prior payload hash is present. |
+
+An upsert of a floor/tombstone control row requires a matching `floor` record for
+that table/key/actor in the same transaction; the decision is
+`merge_floor_control`. The future mapper must preserve the maximum while mapping
+remaining cleanup progress, never replacing it with an older after-image.
+Deletion/cleanup/archive control rows need their schema-specific safe progress
+mapping even below the floor; they cannot be suppressed like a preference and
+thereby lose recovery. Unknown author proposals, shared project tag evidence,
+prior governance receipts and controlled origin references also need the existing
+privacy rules in the mapper. This envelope does not validate their inner columns.
+A successful protocol check alone therefore cannot establish privacy-safe replay.
+
+The declared operation set does **not** include actor-wide purge or arbitrary
+range delete. It cannot compact the current large source cascades into an
+unreviewed promise that the target will eventually delete the right rows.
+
+## Checkpoints, duplicates and commit acknowledgement
+
+`Begin(manifest, verifiedFloors)` creates the first checkpoint. `ValidateBatch`
+requires the next page to match that checkpoint's sequence, commit hash and
+manifest identity. It verifies each transaction hash and contiguous sequence,
+then the page hash. A page is final exactly when its last sequence is
+`throughSequence`. An empty page is permitted only to close an empty interval.
+A missing page, reordered transaction, conflicting image, duplicate key,
+unknown version, incomplete coverage or premature final marker fails closed.
+No returned error contains actors, keys, image values or raw decoder text.
+
+The caller must use a **trusted durable** checkpoint loaded from its target
+ledger. After the initial overlay validation, the module cannot cryptographically
+prove later checkpoint floors came from previous committed decisions. Artifact
+hashes and caller-supplied receipts are not authentication. The apply adapter must
+commit target mutations, the exact returned receipt, next commit hash, merged
+floors and final flag atomically. If it internally commits one source transaction
+at a time, it needs an additional durable per-transaction receipt protocol; it
+cannot acknowledge the whole page after a partial commit. Neither ledger exists
+in a database yet.
+
+An exact duplicate page is accepted without decisions only when the caller
+supplies its matching durable receipt and the durable checkpoint has already
+committed that receipt's complete interval. A different digest at that receipt
+boundary is a conflict. A receipt ahead of the checkpoint is rejected. Without
+a receipt, an old/reordered page is rejected instead of assumed successful.
+The caller must enforce unique receipt boundaries and prevent concurrent
+checkpoint updates with CAS/locking. Lost acknowledgement may repeat a page;
+it may never repeat its mutations.
+
+Private images and archive inventories may contain user data. Keep transfer
+artifacts encrypted/access-controlled and apply the existing deletion/retention
+policy. Public logs may record only fixed error codes and approved aggregate
+counts; no raw payload, key, actor, image hash or decoder exception. The included
+fixtures are synthetic. This package does not add a public endpoint.
+
+## Validation and next delivery gates
+
+Local checks for this commit:
+
+```sh
+go test -race ./internal/feedtransfer
+go vet ./internal/feedtransfer
+python3 internal/feedtransfer/testdata/generate_fixture.py
+```
+
+The checks cover both source registries, real local SQLite physical inventory,
+strict wire parsing and limits, unsafe numbers and Unicode, source/target epoch
+identity, missing/conflicting/out-of-order pages, exact durable duplicate
+handling, deletion overlay omission, same-transaction floor precedence,
+recreated generations, image-free tombstones and source control staging.
+They are not real D1/PG capture, mapper, recovery or cutover tests.
+
+The next independent commit must resolve the known large deletion and retention
+transaction representation with reviewed semantics and real database fixtures.
+Only then can subsequent work instrument **every** authorized mutation path,
+including cascades, atomic state/events/profile updates, governance, projector,
+cleanup, delivery/replay, archive registration and relevant legacy writers. That
+work needs crash/failure/concurrency proof that business success and journal
+commit cannot separate. Source outbox coverage is insufficient.
+
+After capture: implement both schema-aware mappers, object inventory/byte
+verification and private-data erasure checks; persist target receipts/checkpoints
+with writes; reconcile by business identity/state/version/deletion markers; prove
+snapshot + replay consistency; complete shadow reads; then build the protected
+writer fence, bounded drain and atomic route promotion controller. Reverse replay
+must pass the same gates after the new target has accepted writes. Until those
+independent stages pass, all capture activation and production promotion gates
+remain open, regardless of a successful v1 protocol result.

--- a/internal/feedtransfer/decode.go
+++ b/internal/feedtransfer/decode.go
@@ -1,0 +1,217 @@
+package feedtransfer
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// DecodeManifest and DecodeBatch require every DTO field, including explicit
+// null actor/image values. JSON member names are case-sensitive. Values never
+// appear in returned errors. The caller must separately bound transport time.
+func DecodeManifest(r io.Reader) (Manifest, error) {
+	var v Manifest
+	err := decode(r, &v, 256<<10)
+	return v, err
+}
+func DecodeBatch(r io.Reader) (Batch, error) {
+	var v Batch
+	err := decode(r, &v, MaxBatchBytes)
+	return v, err
+}
+
+func decode(r io.Reader, dst any, limit int64) error {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return invalid("read_failed")
+	}
+	if int64(len(data)) > limit {
+		return invalid("body_too_large")
+	}
+	node, err := jsonTree(data)
+	if err != nil {
+		return err
+	}
+	if !shape(node, reflect.TypeOf(dst).Elem()) {
+		return invalid("json_shape")
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return invalid("json_value")
+	}
+	return nil
+}
+
+func jsonTree(data []byte) (any, error) {
+	if !utf8.Valid(data) {
+		return nil, invalid("invalid_json")
+	}
+	if !pairedSurrogates(data) {
+		return nil, invalid("invalid_unicode")
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	count := 0
+	v, err := readNode(d, 0, &count)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := d.Token(); err != io.EOF {
+		return nil, invalid("invalid_json")
+	}
+	return v, nil
+}
+func readNode(d *json.Decoder, depth int, count *int) (any, error) {
+	(*count)++
+	if depth > 32 || *count > 200000 {
+		return nil, invalid("json_complexity")
+	}
+	t, err := d.Token()
+	if err != nil {
+		return nil, invalid("invalid_json")
+	}
+	delim, ok := t.(json.Delim)
+	if !ok {
+		return t, nil
+	}
+	switch delim {
+	case '{':
+		out := map[string]any{}
+		for d.More() {
+			k, err := d.Token()
+			if err != nil {
+				return nil, invalid("invalid_json")
+			}
+			key, ok := k.(string)
+			if !ok {
+				return nil, invalid("invalid_json")
+			}
+			if _, ok = out[key]; ok {
+				return nil, invalid("duplicate_json_key")
+			}
+			v, err := readNode(d, depth+1, count)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = v
+		}
+		if t, err = d.Token(); err != nil || t != json.Delim('}') {
+			return nil, invalid("invalid_json")
+		}
+		return out, nil
+	case '[':
+		out := []any{}
+		for d.More() {
+			v, err := readNode(d, depth+1, count)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, v)
+		}
+		if t, err = d.Token(); err != nil || t != json.Delim(']') {
+			return nil, invalid("invalid_json")
+		}
+		return out, nil
+	}
+	return nil, invalid("invalid_json")
+}
+func shape(v any, t reflect.Type) bool {
+	if t.Kind() == reflect.Pointer {
+		return v == nil || shape(v, t.Elem())
+	}
+	if t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8 {
+		_, ok := v.(string)
+		return ok || v == nil
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		m, ok := v.(map[string]any)
+		if !ok || len(m) != t.NumField() {
+			return false
+		}
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			key := strings.Split(f.Tag.Get("json"), ",")[0]
+			x, ok := m[key]
+			if !ok || !shape(x, f.Type) {
+				return false
+			}
+		}
+		return true
+	case reflect.Slice:
+		a, ok := v.([]any)
+		if !ok {
+			return false
+		}
+		for _, x := range a {
+			if !shape(x, t.Elem()) {
+				return false
+			}
+		}
+		return true
+	case reflect.String:
+		_, ok := v.(string)
+		return ok
+	case reflect.Bool:
+		_, ok := v.(bool)
+		return ok
+	case reflect.Int64, reflect.Int:
+		x, ok := v.(json.Number)
+		return ok && integerPattern.MatchString(string(x))
+	}
+	return false
+}
+
+// encoding/json replaces isolated escaped UTF-16 surrogates. Reject them before
+// decoding so Go, JavaScript and Python observe the same Unicode scalar values.
+func pairedSurrogates(data []byte) bool {
+	quoted := false
+	for i := 0; i < len(data); i++ {
+		if !quoted {
+			if data[i] == '"' {
+				quoted = true
+			}
+			continue
+		}
+		if data[i] == '"' {
+			quoted = false
+			continue
+		}
+		if data[i] != 92 {
+			continue
+		}
+		i++
+		if i >= len(data) {
+			return false
+		}
+		if data[i] != 'u' {
+			continue
+		}
+		if i+5 > len(data) {
+			return false
+		}
+		value, err := strconv.ParseUint(string(data[i+1:i+5]), 16, 16)
+		if err != nil {
+			return false
+		}
+		if value >= 0xdc00 && value <= 0xdfff {
+			return false
+		}
+		if value >= 0xd800 && value <= 0xdbff {
+			if i+11 > len(data) || data[i+5] != 92 || data[i+6] != 'u' {
+				return false
+			}
+			low, err := strconv.ParseUint(string(data[i+7:i+11]), 16, 16)
+			if err != nil || low < 0xdc00 || low > 0xdfff {
+				return false
+			}
+			i += 10
+		} else {
+			i += 4
+		}
+	}
+	return true
+}

--- a/internal/feedtransfer/hash.go
+++ b/internal/feedtransfer/hash.go
@@ -1,0 +1,136 @@
+package feedtransfer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"strconv"
+)
+
+// Each token is framed as ASCII decimal UTF-8 byte length, ':', exact bytes.
+// There is no delimiter after a token. Arrays include their length. Domain tags
+// and field order are frozen in feed-transfer-v1.md and the shared fixture.
+type transcript struct{ h hash.Hash }
+
+func newTranscript(domain string) *transcript { t := &transcript{sha256.New()}; t.s(domain); return t }
+func (t *transcript) s(v string) {
+	t.h.Write([]byte(strconv.Itoa(len(v))))
+	t.h.Write([]byte(":"))
+	t.h.Write([]byte(v))
+}
+func (t *transcript) n(v int64) { t.s(strconv.FormatInt(v, 10)) }
+func (t *transcript) b(v bool) {
+	if v {
+		t.s("1")
+	} else {
+		t.s("0")
+	}
+}
+func (t *transcript) identity(v Identity) {
+	t.s(v.Profile)
+	t.s(v.ResourceID)
+	t.n(v.Schema)
+	t.n(v.WriterContract)
+	t.n(v.WriterEpoch)
+	t.n(v.RouteEpoch)
+}
+func (t *transcript) sum() string { return hex.EncodeToString(t.h.Sum(nil)) }
+func imageDigest(b []byte) string { s := sha256.Sum256(b); return hex.EncodeToString(s[:]) }
+
+func ManifestHash(m Manifest) (string, error) {
+	if err := ValidateManifest(m); err != nil {
+		return "", err
+	}
+	t := newTranscript("ghfind.feed.transfer.manifest.v1")
+	t.n(m.Version)
+	t.s(m.Stream)
+	t.s(m.MigrationID)
+	t.s(m.JournalID)
+	t.identity(m.Source)
+	t.identity(m.Target)
+	t.s(m.SnapshotSHA256)
+	t.s(m.ArchiveInventorySHA256)
+	t.n(m.ArchiveObjects)
+	t.s(m.DeletionFloorsSHA256)
+	t.n(m.DeletionFloorActors)
+	t.n(m.FromSequence)
+	t.n(m.ThroughSequence)
+	t.s(m.AnchorHash)
+	t.n(int64(len(m.Coverage)))
+	for _, v := range m.Coverage {
+		t.s(v.Table)
+		t.s(v.Mode)
+		t.s(v.Category)
+		t.n(v.SnapshotRows)
+	}
+	return t.sum(), nil
+}
+
+// TransactionHash binds source identity and journal, independent of a target
+// migration. Hash is excluded; all other fields, including order, are bound.
+func TransactionHash(m Manifest, v Transaction) (string, error) {
+	if err := ValidateManifest(m); err != nil {
+		return "", err
+	}
+	if err := validateTransaction(m, v); err != nil {
+		return "", err
+	}
+	t := newTranscript("ghfind.feed.transfer.transaction.v1")
+	t.identity(m.Source)
+	t.s(m.JournalID)
+	t.n(v.Sequence)
+	t.s(v.TransactionID)
+	t.s(v.PreviousHash)
+	t.n(int64(len(v.Changes)))
+	for _, c := range v.Changes {
+		t.s(c.Table)
+		t.s(c.Key)
+		t.s(c.Operation)
+		t.b(c.Actor != nil)
+		if c.Actor != nil {
+			t.n(c.Actor.GitHubID)
+			t.n(c.Actor.ProfileVersion)
+		}
+		t.n(int64(len(c.Image)))
+		t.s(imageDigest(c.Image))
+	}
+	return t.sum(), nil
+}
+func BatchHash(v Batch) (string, error) {
+	if v.Version != Version {
+		return "", invalid("unknown_version")
+	}
+	if !digest(v.ManifestHash) || !digest(v.PreviousHash) || !safe(v.AfterSequence) || len(v.Transactions) > MaxTransactions {
+		return "", invalid("batch_shape")
+	}
+	t := newTranscript("ghfind.feed.transfer.batch.v1")
+	t.n(v.Version)
+	t.s(v.ManifestHash)
+	t.n(v.AfterSequence)
+	t.s(v.PreviousHash)
+	t.n(int64(len(v.Transactions)))
+	for _, tx := range v.Transactions {
+		if !digest(tx.Hash) {
+			return "", invalid("transaction_hash")
+		}
+		t.s(tx.Hash)
+	}
+	t.b(v.Final)
+	return t.sum(), nil
+}
+
+// DeletionFloorsHash binds a sorted, duplicate-free snapshot + later deletion
+// overlay. The source must establish its completeness before closing a segment.
+func DeletionFloorsHash(f []Floor) (string, error) {
+	m, err := floorMap(f)
+	if err != nil {
+		return "", err
+	}
+	t := newTranscript("ghfind.feed.transfer.floors.v1")
+	t.n(int64(len(m)))
+	for _, v := range sortedFloors(m) {
+		t.n(v.GitHubID)
+		t.n(v.ProfileFloor)
+	}
+	return t.sum(), nil
+}

--- a/internal/feedtransfer/registry.go
+++ b/internal/feedtransfer/registry.go
@@ -1,0 +1,84 @@
+// Package feedtransfer validates bounded offline transfer protocols. It does not
+// capture mutations, connect to a database, apply rows or promote a writer.
+//
+// This is NOT a complete change journal. Current PostgreSQL user deletion can
+// cascade across hundreds of thousands of rows; retention also uses unbounded
+// deletes. These transactions cannot fit v1's row limits. Connecting capture or
+// promotion before a separately reviewed large-transaction protocol is unsafe.
+// Never split, truncate or omit those transactions to make them fit.
+package feedtransfer
+
+import "sort"
+
+type TableRule struct {
+	Table    string `json:"table"`
+	Mode     string `json:"mode"`     // capture or empty; derived facts are not silently omitted
+	Category string `json:"category"` // fact, control, derived, or legacy
+	Privacy  string `json:"privacy"`  // shared, actor, mixed, or control
+}
+
+// Registry is a coverage inventory, not a row mapper. Physical column validation
+// remains a prerequisite of a future schema-aware capture/apply adapter.
+type Registry struct {
+	Profile        string      `json:"profile"`
+	Schema         int64       `json:"schema"`
+	WriterContract int64       `json:"writerContract"`
+	Tables         []TableRule `json:"tables"`
+}
+
+func RequiredRegistry(profile string) (Registry, error) {
+	r := Registry{Profile: profile, WriterContract: 2}
+	add := func(mode, privacy string, names ...string) {
+		for _, name := range names {
+			r.Tables = append(r.Tables, TableRule{Table: name, Mode: mode, Category: "fact", Privacy: privacy})
+		}
+	}
+	switch profile {
+	case "cf_d1_r2":
+		r.Schema = 11
+		add("empty", "control", "feed_archive_guards", "feed_command_guards", "feed_delivery_guards", "feed_execution_guards", "feed_operator_guards", "feed_projection_commands", "feed_proposal_guards", "feed_governance_guards")
+		add("capture", "actor", "feed_behavior_signals", "feed_events", "feed_runtime_events", "feed_runtime_requests", "feed_runtime_served_metadata", "feed_runtime_sessions", "feed_served_items", "feed_tag_proposal_commands", "feed_user_project_states", "feed_user_proposal_authors", "feed_user_tag_preferences", "feed_user_tag_proposals", "feed_users")
+		add("capture", "control", "feed_archive_objects", "feed_cleanup_jobs", "feed_profile_deletions", "feed_profile_floors")
+		add("capture", "mixed", "feed_runtime_outbox", "feed_rate_windows")
+		add("capture", "shared", "feed_cleanup_policy", "feed_delivery_heads", "feed_delivery_terminals", "feed_execution_jobs", "feed_operator_actions", "feed_project_moderation", "feed_project_source_versions", "feed_project_tags", "feed_projects", "feed_replay_deliveries", "feed_runtime_control", "feed_schema_compatibility", "feed_submission_provenance", "feed_tag_aliases", "feed_tag_definitions", "feed_tag_proposals", "feed_taxonomy_versions", "feed_governance_commands")
+	case "postgres":
+		r.Schema = 22
+		add("capture", "actor", "feed.users", "feed.user_tag_preferences", "feed.user_project_state", "feed.user_profile_embeddings", "feed.requests", "feed.served_items", "feed.events", "feed.sessions", "feed.tag_proposal_commands", "feed.user_proposal_authors", "feed.behavior_signals")
+		add("capture", "control", "feed.user_deletion_tombstones", "feed.archive_objects")
+		add("capture", "mixed", "feed.tag_proposals", "feed.event_outbox", "feed.gorse_shadow_results")
+		add("capture", "shared", "feed.taxonomy_versions", "feed.tag_definitions", "feed.tag_aliases", "feed.projects", "feed.project_tags", "feed.project_embeddings", "feed.tag_embeddings", "feed.projection_cursors", "feed.projection_failures", "feed.algorithm_configs", "feed.project_moderation_actions", "feed.embedding_model_state", "feed.jobs", "feed.runtime_control", "feed.project_submission_evidence", "feed.governance_commands", "feed.schema_compatibility")
+	default:
+		return Registry{}, invalid("unknown_profile")
+	}
+	// Capture inventory includes every physical relation, but this is NOT a
+	// claim that legacy/derived rows map to primary facts in the other profile.
+	legacy := map[string]bool{"feed.gorse_shadow_results": true, "feed.algorithm_configs": true, "feed.projection_cursors": true, "feed.projection_failures": true}
+	derived := map[string]bool{"feed.project_embeddings": true, "feed.tag_embeddings": true, "feed.user_profile_embeddings": true, "feed.embedding_model_state": true, "feed.behavior_signals": true, "feed_behavior_signals": true}
+	controls := map[string]bool{"feed_runtime_control": true, "feed_schema_compatibility": true, "feed_cleanup_policy": true, "feed_execution_jobs": true, "feed_delivery_heads": true, "feed_delivery_terminals": true, "feed_replay_deliveries": true, "feed_operator_actions": true, "feed_runtime_outbox": true, "feed_rate_windows": true, "feed.runtime_control": true, "feed.schema_compatibility": true, "feed.jobs": true, "feed.event_outbox": true}
+	for i := range r.Tables {
+		v := &r.Tables[i]
+		switch {
+		case legacy[v.Table]:
+			v.Category = "legacy"
+		case derived[v.Table]:
+			v.Category = "derived"
+		case v.Privacy == "control" || controls[v.Table]:
+			v.Category = "control"
+		}
+	}
+	sort.Slice(r.Tables, func(i, j int) bool { return r.Tables[i].Table < r.Tables[j].Table })
+	return r, nil
+}
+
+func tableRule(profile, name string) (TableRule, bool) {
+	r, err := RequiredRegistry(profile)
+	if err != nil {
+		return TableRule{}, false
+	}
+	for _, rule := range r.Tables {
+		if rule.Table == name {
+			return rule, true
+		}
+	}
+	return TableRule{}, false
+}

--- a/internal/feedtransfer/testdata/generate_fixture.py
+++ b/internal/feedtransfer/testdata/generate_fixture.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Independent standard-library reference transcript. Synthetic data only.
+Recompute golden hashes with --write; default checks the committed fixture.
+Neither mode executes SQL, applies rows or prints private payloads.
+"""
+import base64
+import hashlib
+import json
+import pathlib
+import sys
+
+PATH = pathlib.Path(__file__).with_name("transfer-v1.json")
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+def frame(tokens):
+    return b"".join(str(len(b)).encode("ascii") + b":" + b
+                    for b in (str(t).encode("utf-8") for t in tokens))
+
+def identity(v):
+    return [v[k] for k in ("profile", "resourceId", "schema", "writerContract", "writerEpoch", "routeEpoch")]
+
+def hashes(f):
+    m = f["manifest"]
+    floors = sorted(f["floors"], key=lambda v: v["githubId"])
+    m["deletionFloorsSha256"] = digest(frame([
+        "ghfind.feed.transfer.floors.v1", len(floors),
+        *(token for floor in floors for token in (floor["githubId"], floor["profileFloor"]))]))
+    mh = digest(frame([
+        "ghfind.feed.transfer.manifest.v1", m["version"], m["stream"], m["migrationId"], m["journalId"],
+        *identity(m["source"]), *identity(m["target"]), m["snapshotSha256"], m["archiveInventorySha256"],
+        m["archiveObjects"], m["deletionFloorsSha256"], m["deletionFloorActors"], m["fromSequence"],
+        m["throughSequence"], m["anchorHash"], len(m["coverage"]),
+        *(token for c in m["coverage"] for token in (c["table"], c["mode"], c["category"], c["snapshotRows"]))]))
+    f["manifestHash"] = mh
+    previous = m["anchorHash"]
+    sequence = m["fromSequence"]
+    for batch in f["batches"]:
+        batch["manifestHash"] = mh
+        batch["previousHash"] = previous
+        batch["afterSequence"] = sequence
+        for tx in batch["transactions"]:
+            sequence += 1
+            tx.update(sequence=sequence, transactionId=f'{m["journalId"]}:{sequence}', previousHash=previous)
+            tokens = ["ghfind.feed.transfer.transaction.v1", *identity(m["source"]), m["journalId"],
+                      sequence, tx["transactionId"], previous, len(tx["changes"])]
+            for change in tx["changes"]:
+                actor = change["actor"]
+                image = base64.b64decode(change["image"], validate=True) if change["image"] is not None else b""
+                tokens += [change["table"], change["key"], change["operation"], int(actor is not None)]
+                if actor is not None:
+                    tokens += [actor["githubId"], actor["profileVersion"]]
+                tokens += [len(image), digest(image)]
+            previous = tx["hash"] = digest(frame(tokens))
+        batch["hash"] = digest(frame([
+            "ghfind.feed.transfer.batch.v1", batch["version"], mh, batch["afterSequence"],
+            batch["previousHash"], len(batch["transactions"]),
+            *(tx["hash"] for tx in batch["transactions"]), int(batch["final"])]))
+    return f
+
+if __name__ == "__main__":
+    original = json.loads(PATH.read_text())
+    updated = hashes(json.loads(json.dumps(original)))
+    if sys.argv[1:] == ["--write"]:
+        PATH.write_text(json.dumps(updated, ensure_ascii=False, indent=2) + "\n")
+    elif sys.argv[1:]:
+        raise SystemExit("usage: generate_fixture.py [--write]")
+    elif updated != original:
+        raise SystemExit("fixture hash mismatch")
+    print("synthetic transfer-v1 fixture hashes verified")

--- a/internal/feedtransfer/testdata/transfer-v1.json
+++ b/internal/feedtransfer/testdata/transfer-v1.json
@@ -1,0 +1,411 @@
+{
+  "synthetic": true,
+  "manifest": {
+    "version": 1,
+    "stream": "feed_transaction_journal",
+    "migrationId": "11111111-1111-4111-8111-111111111111",
+    "journalId": "22222222-2222-4222-8222-222222222222",
+    "source": {
+      "profile": "cf_d1_r2",
+      "resourceId": "33333333-3333-4333-8333-333333333333",
+      "schema": 11,
+      "writerContract": 2,
+      "writerEpoch": 4,
+      "routeEpoch": 8
+    },
+    "target": {
+      "profile": "postgres",
+      "resourceId": "44444444-4444-4444-8444-444444444444",
+      "schema": 22,
+      "writerContract": 2,
+      "writerEpoch": 1,
+      "routeEpoch": 9
+    },
+    "snapshotSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "archiveInventorySha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "archiveObjects": 0,
+    "deletionFloorsSha256": "02e27c6de1dcc32f7c0c629d7b015011c4e0fb032cea28259d38a03aa1ce8a0b",
+    "deletionFloorActors": 1,
+    "fromSequence": 0,
+    "throughSequence": 2,
+    "anchorHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "coverage": [
+      {
+        "table": "feed_archive_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_archive_objects",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_behavior_signals",
+        "mode": "capture",
+        "category": "derived",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_cleanup_jobs",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_cleanup_policy",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_command_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_delivery_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_delivery_heads",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_delivery_terminals",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_events",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_execution_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_execution_jobs",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_governance_commands",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_governance_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_operator_actions",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_operator_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_profile_deletions",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_profile_floors",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_project_moderation",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_project_source_versions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_project_tags",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_projection_commands",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_projects",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_proposal_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_rate_windows",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_replay_deliveries",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_control",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_events",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_outbox",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_requests",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_served_metadata",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_sessions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_schema_compatibility",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_served_items",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_submission_provenance",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_aliases",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_definitions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_proposal_commands",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_proposals",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_taxonomy_versions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_project_states",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_proposal_authors",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_tag_preferences",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_tag_proposals",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_users",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      }
+    ]
+  },
+  "manifestHash": "2bc6cbc68ecaa8a0ae5961826c281b5c94f8592701840dc30a9818baa9630859",
+  "floors": [
+    {
+      "githubId": 42,
+      "profileFloor": 5
+    }
+  ],
+  "batches": [
+    {
+      "version": 1,
+      "manifestHash": "2bc6cbc68ecaa8a0ae5961826c281b5c94f8592701840dc30a9818baa9630859",
+      "afterSequence": 0,
+      "previousHash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "transactions": [
+        {
+          "sequence": 1,
+          "transactionId": "22222222-2222-4222-8222-222222222222:1",
+          "previousHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "changes": [
+            {
+              "table": "feed_users",
+              "key": "synthetic:42",
+              "operation": "upsert",
+              "actor": {
+                "githubId": 42,
+                "profileVersion": 5
+              },
+              "image": "eyJnaXRodWJfaWQiOjQyLCJnaXRodWJfbG9naW4iOiLlkIjmiJAgPD4mXHUyMDI4XHVkODNkXHVkZTAwIiwibnVsbGFibGUiOm51bGwsInByb2ZpbGVfdmVyc2lvbiI6NX0="
+            },
+            {
+              "table": "feed_profile_floors",
+              "key": "42",
+              "operation": "floor",
+              "actor": {
+                "githubId": 42,
+                "profileVersion": 5
+              },
+              "image": null
+            }
+          ],
+          "hash": "a0981152669caf5b596f0b83bc1ae28e9b8b1a3406abd25922cca49d9474abe7"
+        }
+      ],
+      "final": false,
+      "hash": "f2d82b95d7c261e97d1cd68fc0b107db90f883db92b364a514d3573bb993cd04"
+    },
+    {
+      "version": 1,
+      "manifestHash": "2bc6cbc68ecaa8a0ae5961826c281b5c94f8592701840dc30a9818baa9630859",
+      "afterSequence": 1,
+      "previousHash": "a0981152669caf5b596f0b83bc1ae28e9b8b1a3406abd25922cca49d9474abe7",
+      "transactions": [
+        {
+          "sequence": 2,
+          "transactionId": "22222222-2222-4222-8222-222222222222:2",
+          "previousHash": "a0981152669caf5b596f0b83bc1ae28e9b8b1a3406abd25922cca49d9474abe7",
+          "changes": [
+            {
+              "table": "feed_users",
+              "key": "synthetic:42",
+              "operation": "upsert",
+              "actor": {
+                "githubId": 42,
+                "profileVersion": 6
+              },
+              "image": "eyJnaXRodWJfaWQiOjQyLCJnaXRodWJfbG9naW4iOiJuZXcgc3ludGhldGljIiwicHJvZmlsZV92ZXJzaW9uIjo2fQ=="
+            },
+            {
+              "table": "feed_tag_proposal_commands",
+              "key": "synthetic-command",
+              "operation": "command_tombstone",
+              "actor": {
+                "githubId": 42,
+                "profileVersion": 5
+              },
+              "image": null
+            },
+            {
+              "table": "feed_user_tag_proposals",
+              "key": "synthetic-proposal",
+              "operation": "erase",
+              "actor": {
+                "githubId": 42,
+                "profileVersion": 5
+              },
+              "image": null
+            }
+          ],
+          "hash": "498a8d305b7f4fc75a1df15c31fbe8eda88d4686ab532a0d8e72c8171a2b64cd"
+        }
+      ],
+      "final": true,
+      "hash": "e2276bf00457a93d55e4f3f077ae28b4d9af10d9ff5b57e4e19f684c0b971ada"
+    }
+  ],
+  "expectedActions": [
+    [
+      "suppress_deleted_generation",
+      "retain_max_floor"
+    ],
+    [
+      "apply",
+      "tombstone",
+      "erase"
+    ]
+  ]
+}

--- a/internal/feedtransfer/testdata/unicode-v1.json
+++ b/internal/feedtransfer/testdata/unicode-v1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "json": "{\"n\":\"\\ud800\"}",
+    "error": "invalid_unicode"
+  },
+  {
+    "json": "{\"\\udc00\":1}",
+    "error": "invalid_unicode"
+  },
+  {
+    "json": "{\"n\":\"\\ud800\\\\udc00\"}",
+    "error": "invalid_unicode"
+  },
+  {
+    "json": "{\"n\":\"\\ud83d\\ude00\"}",
+    "error": null
+  },
+  {
+    "json": "{\"n\":\"😀\"}",
+    "error": null
+  },
+  {
+    "json": "{\"n\":\"\\\\ud800\"}",
+    "error": null
+  },
+  {
+    "json": "{\"n\":\"\\u2028\"}",
+    "error": null
+  }
+]

--- a/internal/feedtransfer/transfer_test.go
+++ b/internal/feedtransfer/transfer_test.go
@@ -1,0 +1,603 @@
+package feedtransfer
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func manifest(t *testing.T, profile string, through int64, floors []Floor) Manifest {
+	t.Helper()
+	r, err := RequiredRegistry(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	other := "postgres"
+	if profile == other {
+		other = "cf_d1_r2"
+	}
+	target, _ := RequiredRegistry(other)
+	fh, err := DeletionFloorsHash(floors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{Version: 1, Stream: "feed_transaction_journal", MigrationID: "11111111-1111-4111-8111-111111111111", JournalID: "22222222-2222-4222-8222-222222222222", Source: Identity{profile, "33333333-3333-4333-8333-333333333333", r.Schema, 2, 4, 8}, Target: Identity{other, "44444444-4444-4444-8444-444444444444", target.Schema, 2, 1, 9}, SnapshotSHA256: strings.Repeat("a", 64), ArchiveInventorySHA256: strings.Repeat("b", 64), DeletionFloorsSHA256: fh, DeletionFloorActors: int64(len(floors)), FromSequence: 0, ThroughSequence: through, AnchorHash: strings.Repeat("0", 64), Coverage: []Coverage{}}
+	for _, v := range r.Tables {
+		m.Coverage = append(m.Coverage, Coverage{v.Table, v.Mode, v.Category, 0})
+	}
+	return m
+}
+func seal(t *testing.T, m Manifest, cp Checkpoint, final bool, sets ...[]Change) Batch {
+	t.Helper()
+	b := Batch{Version: 1, ManifestHash: cp.ManifestHash, AfterSequence: cp.Sequence, PreviousHash: cp.CommitHash, Transactions: []Transaction{}, Final: final}
+	prev := cp.CommitHash
+	for i, changes := range sets {
+		seq := cp.Sequence + int64(i) + 1
+		tx := Transaction{Sequence: seq, TransactionID: fmt.Sprintf("%s:%d", m.JournalID, seq), PreviousHash: prev, Changes: changes}
+		h, err := TransactionHash(m, tx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx.Hash = h
+		b.Transactions = append(b.Transactions, tx)
+		prev = h
+	}
+	h, err := BatchHash(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Hash = h
+	return b
+}
+func begin(t *testing.T, m Manifest, floors []Floor) Checkpoint {
+	t.Helper()
+	c, err := Begin(m, floors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+func user(profile string, gen int64) Change {
+	table := "feed_users"
+	if profile == "postgres" {
+		table = "feed.users"
+	}
+	return Change{Table: table, Key: "synthetic:42", Operation: "upsert", Actor: &ActorScope{42, gen}, Image: []byte(fmt.Sprintf(`{"github_id":42,"profile_version":%d,"github_login":"合成 <>&"}`, gen))}
+}
+func code(t *testing.T, err error, want string) {
+	t.Helper()
+	var e *Error
+	if !errors.As(err, &e) || e.Code != want {
+		t.Fatalf("expected fixed %s, got %v", want, err)
+	}
+}
+func noPromotion(t *testing.T, v Validation) {
+	t.Helper()
+	if v.CaptureConnected || v.RowSchemaValidated || v.ArchiveBytesVerified || v.PromotionReady {
+		t.Fatal("protocol result claimed unimplemented evidence")
+	}
+}
+func clone[T any](v T) T { b, _ := json.Marshal(v); var out T; _ = json.Unmarshal(b, &out); return out }
+
+func TestBothProfilesOrderedPagesAndDurableDuplicate(t *testing.T) {
+	for _, p := range []string{"cf_d1_r2", "postgres"} {
+		t.Run(p, func(t *testing.T) {
+			m := manifest(t, p, 2, nil)
+			cp := begin(t, m, nil)
+			b1 := seal(t, m, cp, false, []Change{user(p, 1)})
+			v1, err := ValidateBatch(m, b1, cp, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			noPromotion(t, v1)
+			if v1.ProtocolComplete {
+				t.Fatal("partial stream completed")
+			}
+			b2 := seal(t, m, v1.Checkpoint, true, []Change{user(p, 2)})
+			v2, err := ValidateBatch(m, b2, v1.Checkpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			noPromotion(t, v2)
+			if !v2.ProtocolComplete || v2.Checkpoint.Sequence != 2 {
+				t.Fatal("final checkpoint")
+			}
+			retry, err := ValidateBatch(m, b1, v2.Checkpoint, &v1.Receipt)
+			if err != nil || !retry.Duplicate || len(retry.Decisions) != 0 {
+				t.Fatal("durable duplicate was reapplied", err)
+			}
+			_, err = ValidateBatch(m, b1, v2.Checkpoint, nil)
+			code(t, err, "page_order")
+			_, err = ValidateBatch(m, b1, cp, &v1.Receipt)
+			code(t, err, "receipt_uncommitted")
+			changed := clone(b1)
+			changed.Transactions[0].Changes[0].Image = []byte(`{"github_id":99}`)
+			changed.Transactions[0].Hash, _ = TransactionHash(m, changed.Transactions[0])
+			changed.Hash, _ = BatchHash(changed)
+			_, err = ValidateBatch(m, changed, v1.Checkpoint, &v1.Receipt)
+			code(t, err, "receipt_conflict")
+		})
+	}
+}
+func TestCoverageFailsClosedForEveryRelation(t *testing.T) {
+	for _, p := range []string{"cf_d1_r2", "postgres"} {
+		m := manifest(t, p, 0, nil)
+		for i := range m.Coverage {
+			bad := clone(m)
+			bad.Coverage = append(bad.Coverage[:i], bad.Coverage[i+1:]...)
+			code(t, ValidateManifest(bad), "coverage")
+		}
+		for _, mutate := range []func(*Manifest){func(v *Manifest) { v.Coverage[0] = v.Coverage[1] }, func(v *Manifest) { v.Coverage[0].Category = "fact"; v.Coverage[1].Category = "legacy" }, func(v *Manifest) { v.Coverage[0].Mode = "ignore" }, func(v *Manifest) { v.Coverage[0].SnapshotRows = -1 }} {
+			bad := clone(m)
+			mutate(&bad)
+			code(t, ValidateManifest(bad), "coverage")
+		}
+	}
+	m := manifest(t, "cf_d1_r2", 0, nil)
+	for i, v := range m.Coverage {
+		if v.Mode == "empty" {
+			m.Coverage[i].SnapshotRows = 1
+			break
+		}
+	}
+	code(t, ValidateManifest(m), "coverage")
+}
+func TestIdentityVersionAndEpochFences(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cases := []struct {
+		name, want string
+		change     func(*Manifest)
+	}{
+		{"core outbox", "wrong_stream", func(v *Manifest) { v.Stream = "core_feed_outbox_sequence" }},
+		{"version", "unknown_version", func(v *Manifest) { v.Version = 2 }},
+		{"unknown profile", "unknown_profile", func(v *Manifest) { v.Source.Profile = "turso" }},
+		{"schema", "identity", func(v *Manifest) { v.Source.Schema = 10 }},
+		{"writer contract", "identity", func(v *Manifest) { v.Target.WriterContract = 1 }},
+		{"epoch unsafe", "identity", func(v *Manifest) { v.Target.WriterEpoch = MaxSafeInteger + 1 }},
+		{"same resource", "same_resource", func(v *Manifest) { v.Target.ResourceID = v.Source.ResourceID }},
+		{"route reused", "route_epoch", func(v *Manifest) { v.Target.RouteEpoch = v.Source.RouteEpoch }},
+		{"nil UUID", "manifest_identity", func(v *Manifest) { v.JournalID = "00000000-0000-0000-0000-000000000000" }},
+		{"missing anchor", "anchor", func(v *Manifest) { v.FromSequence = 1; v.ThroughSequence = 1 }},
+		{"unsafe sequence", "manifest_range", func(v *Manifest) { v.ThroughSequence = MaxSafeInteger + 1 }},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) { v := clone(m); tt.change(&v); code(t, ValidateManifest(v), tt.want) })
+	}
+}
+func TestPagesRejectGapsReorderingTamperingAndUnknownChanges(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 2, nil)
+	cp := begin(t, m, nil)
+	b := seal(t, m, cp, true, []Change{user(m.Source.Profile, 1)}, []Change{user(m.Source.Profile, 2)})
+	cases := []struct {
+		name, want string
+		edit       func(*Batch)
+	}{
+		{"missing commit", "transaction_order", func(v *Batch) { v.Transactions = v.Transactions[1:] }},
+		{"reordered", "transaction_order", func(v *Batch) { v.Transactions[0], v.Transactions[1] = v.Transactions[1], v.Transactions[0] }},
+		{"reused transaction ID", "duplicate_transaction", func(v *Batch) { v.Transactions[1].TransactionID = v.Transactions[0].TransactionID }},
+		{"unknown table", "change_coverage", func(v *Batch) { v.Transactions[0].Changes[0].Table = "core_feed_outbox" }},
+		{"guard mutation", "change_coverage", func(v *Batch) { v.Transactions[0].Changes[0].Table = "feed_command_guards" }},
+		{"same key twice", "duplicate_change", func(v *Batch) {
+			v.Transactions[0].Changes = append(v.Transactions[0].Changes, v.Transactions[0].Changes[0])
+		}},
+		{"tamper image", "transaction_hash", func(v *Batch) { v.Transactions[0].Changes[0].Image = []byte(`{"github_id":43}`) }},
+		{"wrong target", "batch_identity", func(v *Batch) { v.ManifestHash = strings.Repeat("b", 64) }},
+		{"invalid chain", "transaction_order", func(v *Batch) { v.Transactions[1].PreviousHash = strings.Repeat("b", 64) }},
+		{"unknown op", "unknown_operation", func(v *Batch) { v.Transactions[0].Changes[0].Operation = "execute_sql" }},
+		{"missing actor", "actor_scope", func(v *Batch) { v.Transactions[0].Changes[0].Actor = nil }},
+		{"changed final bit", "batch_hash", func(v *Batch) { v.Final = false }},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			v := clone(b)
+			tt.edit(&v)
+			_, err := ValidateBatch(m, v, cp, nil)
+			code(t, err, tt.want)
+		})
+	}
+	early := seal(t, m, cp, true, []Change{user(m.Source.Profile, 1)})
+	_, err := ValidateBatch(m, early, cp, nil)
+	code(t, err, "final_boundary")
+	missingFinal := clone(b)
+	missingFinal.Final = false
+	missingFinal.Hash, _ = BatchHash(missingFinal)
+	_, err = ValidateBatch(m, missingFinal, cp, nil)
+	code(t, err, "final_boundary")
+	empty := seal(t, m, cp, false)
+	_, err = ValidateBatch(m, empty, cp, nil)
+	code(t, err, "empty_page")
+	terminal := manifest(t, "cf_d1_r2", 0, nil)
+	tc := begin(t, terminal, nil)
+	v, err := ValidateBatch(terminal, seal(t, terminal, tc, true), tc, nil)
+	if err != nil || !v.ProtocolComplete {
+		t.Fatal("legitimate empty closed interval", err)
+	}
+	noPromotion(t, v)
+}
+func TestDeletionOverlayAndAtomicTombstones(t *testing.T) {
+	for _, p := range []string{"cf_d1_r2", "postgres"} {
+		t.Run(p, func(t *testing.T) {
+			floors := []Floor{{42, 5}}
+			m := manifest(t, p, 1, floors)
+			cp := begin(t, m, floors)
+			floorTable, commandTable, proposalTable := "feed_profile_floors", "feed_tag_proposal_commands", "feed_user_tag_proposals"
+			if p == "postgres" {
+				floorTable, commandTable, proposalTable = "feed.user_deletion_tombstones", "feed.tag_proposal_commands", "feed.tag_proposals"
+			}
+			changes := []Change{user(p, 5), user(p, 6), {Table: commandTable, Key: "synthetic-command", Operation: "command_tombstone", Actor: &ActorScope{42, 5}}, {Table: proposalTable, Key: "synthetic-proposal", Operation: "erase", Actor: &ActorScope{42, 5}}, {Table: floorTable, Key: "42", Operation: "floor", Actor: &ActorScope{42, 4}}}
+			changes[1].Key = "synthetic:new-generation"
+			v, err := ValidateBatch(m, seal(t, m, cp, true, changes), cp, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got []string
+			for _, d := range v.Decisions {
+				got = append(got, d.Action)
+			}
+			if !reflect.DeepEqual(got, []string{"suppress_deleted_generation", "apply", "tombstone", "erase", "retain_max_floor"}) || v.Checkpoint.Floors[0].ProfileFloor != 5 {
+				t.Fatal("floor regression", got)
+			}
+			noPromotion(t, v)
+			_, err = Begin(m, nil)
+			code(t, err, "floor_overlay")
+			fresh := manifest(t, p, 1, nil)
+			fc := begin(t, fresh, nil)
+			atomic := []Change{user(p, 5), {Table: floorTable, Key: "42", Operation: "floor", Actor: &ActorScope{42, 5}}}
+			v, err = ValidateBatch(fresh, seal(t, fresh, fc, true, atomic), fc, nil)
+			if err != nil || v.Decisions[0].Action != "suppress_deleted_generation" {
+				t.Fatal("row order resurrected", err)
+			}
+			orphan := []Change{changes[2]}
+			_, err = ValidateBatch(fresh, seal(t, fresh, fc, true, orphan), fc, nil)
+			code(t, err, "tombstone_without_floor")
+			withBody := changes[2]
+			withBody.Image = []byte(`{"proposal_id":"private"}`)
+			_, err = TransactionHash(m, Transaction{Sequence: 1, TransactionID: m.JournalID + ":1", PreviousHash: cp.CommitHash, Changes: []Change{withBody}})
+			code(t, err, "tombstone_shape")
+			if cp.Floors[0].ProfileFloor != 5 || len(fc.Floors) != 0 {
+				t.Fatal("input checkpoint mutated")
+			}
+		})
+	}
+}
+func TestImageNumbersAndPrivateErrors(t *testing.T) {
+	for _, image := range []string{`{"n":9007199254740992}`, `{"n":1.5}`, `{"n":1e1}`, `{"n":-0}`, `{"n":1.0}`} {
+		code(t, validateImage([]byte(image)), "image_number")
+	}
+	for _, image := range []string{`{"n":9007199254740991}`, `{"n":-9007199254740991}`, `{"weight":"0.78","at":"2026-09-09T00:00:00.000Z","null":null,"ok":true}`} {
+		if err := validateImage([]byte(image)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	code(t, validateImage([]byte(`{"secret":"do-not-log","secret":1}`)), "duplicate_json_key")
+	code(t, validateImage([]byte(`{"nested":{"secret":"do-not-log"}}`)), "image_shape")
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	b := seal(t, m, cp, true, []Change{user(m.Source.Profile, 1)})
+	b.Transactions[0].Changes[0].Image = []byte(`{"secret":"do-not-log"}`)
+	_, err := ValidateBatch(m, b, cp, nil)
+	if err == nil || strings.Contains(err.Error(), "do-not-log") {
+		t.Fatal("raw row leaked")
+	}
+}
+func TestStrictDecodeAndStreamingLimit(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	b := seal(t, m, cp, true, []Change{user(m.Source.Profile, 1)})
+	wire, _ := json.Marshal(b)
+	if _, err := DecodeBatch(bytes.NewReader(wire)); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct{ wire, want string }{
+		{strings.Replace(string(wire), `"version":1`, `"version":1,"version":1`, 1), "duplicate_json_key"},
+		{strings.Replace(string(wire), `"version":1`, `"Version":1`, 1), "json_shape"},
+		{strings.Replace(string(wire), `"final":true,`, "", 1), "json_shape"},
+		{strings.Replace(string(wire), `"version":1`, `"version":null`, 1), "json_shape"},
+		{strings.Replace(string(wire), `"version":1`, `"version":1.0`, 1), "json_shape"},
+		{strings.Replace(string(wire), `"version":1`, `"version":1,"extra":1`, 1), "json_shape"},
+		{string(wire) + `{}`, "invalid_json"},
+		{strings.Replace(string(wire), `"githubId":42`, `"githubId":42,"github\u0049d":42`, 1), "duplicate_json_key"},
+		{strings.Replace(string(wire), `"image":"`, `"image":"!`, 1), "json_value"},
+	}
+	for i, tt := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) { _, err := DecodeBatch(strings.NewReader(tt.wire)); code(t, err, tt.want) })
+	}
+	reader := &countingReader{remaining: MaxBatchBytes + 100}
+	_, err := DecodeBatch(reader)
+	code(t, err, "body_too_large")
+	if reader.read != MaxBatchBytes+1 {
+		t.Fatal("did not bound streaming read", reader.read)
+	}
+	bad := append([]byte(`{"x":"`), 255)
+	bad = append(bad, []byte(`"}`)...)
+	_, err = DecodeBatch(bytes.NewReader(bad))
+	code(t, err, "invalid_json")
+}
+
+type countingReader struct{ remaining, read int }
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := len(p)
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := 0; i < n; i++ {
+		p[i] = ' '
+	}
+	r.remaining -= n
+	r.read += n
+	return n, nil
+}
+
+func TestCoverageTracksPhysicalSchemasWithoutClaimingMapping(t *testing.T) {
+	// This is a local SQLite inventory check, not a Workers/D1 transaction test.
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	files, err := filepath.Glob("../../migrations-feed/*.sql")
+	if err != nil || len(files) != 11 {
+		t.Fatal("register the new D1 schema before use")
+	}
+	for _, path := range files {
+		sqlBytes, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = db.Exec(string(sqlBytes)); err != nil {
+			t.Fatalf("local inventory migration %s: %v", filepath.Base(path), err)
+		}
+	}
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'feed_%' ORDER BY name`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cf []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatal(err)
+		}
+		cf = append(cf, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	rows.Close()
+	assertNames := func(profile string, names []string) {
+		r, _ := RequiredRegistry(profile)
+		var want []string
+		for _, v := range r.Tables {
+			want = append(want, v.Table)
+		}
+		sort.Strings(names)
+		if !reflect.DeepEqual(names, want) {
+			t.Fatalf("%s inventory drift: actual %v registry %v", profile, names, want)
+		}
+	}
+	assertNames("cf_d1_r2", cf)
+	if len(cf) != 45 {
+		t.Fatal("snapshot11 inventory")
+	}
+	// PG check inventories declarations only; actual PG migration/row semantics
+	// remain the existing mandatory database suite, not this protocol test.
+	files, err = filepath.Glob("../feedmigration/migrations/*.sql")
+	if err != nil || len(files) != 22 {
+		t.Fatal("register the new PG schema before use")
+	}
+	create := regexp.MustCompile(`(?i)CREATE TABLE (?:IF NOT EXISTS )?(feed\.[a-z_]+)`)
+	var pg []string
+	for _, path := range files {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range create.FindAllStringSubmatch(string(b), -1) {
+			pg = append(pg, m[1])
+		}
+	}
+	assertNames("postgres", pg)
+	r, _ := RequiredRegistry("postgres")
+	legacy := map[string]bool{}
+	for _, v := range r.Tables {
+		if v.Category == "legacy" {
+			legacy[v.Table] = true
+		}
+	}
+	if !legacy["feed.gorse_shadow_results"] {
+		t.Fatal("legacy was called primary fact")
+	}
+}
+
+func TestInitialCheckpointCannotBypassDeletionOverlay(t *testing.T) {
+	floors := []Floor{{42, 5}}
+	m := manifest(t, "cf_d1_r2", 1, floors)
+	cp := begin(t, m, floors)
+	b := seal(t, m, cp, true, []Change{user(m.Source.Profile, 5)})
+	for _, f := range [][]Floor{nil, {{42, 4}}, {{43, 5}}} {
+		bad := clone(cp)
+		bad.Floors = f
+		_, err := ValidateBatch(m, b, bad, nil)
+		code(t, err, "floor_overlay")
+	}
+}
+func TestUnicodeSurrogatesAcrossEnvelopeAndImages(t *testing.T) {
+	for _, raw := range []string{`{"\ud800":1}`, `{"n":"\udc00"}`, `{"n":"\ud800x"}`, `{"n":"\ud800\ud800"}`, `{"n":"\ud800\\udc00"}`} {
+		_, err := jsonTree([]byte(raw))
+		code(t, err, "invalid_unicode")
+		code(t, validateImage([]byte(raw)), "invalid_unicode")
+	}
+	for _, raw := range []string{`{"n":"\ud83d\ude00"}`, `{"n":"😀"}`, `{"n":"\\ud800"}`, `{"n":"\u2028"}`} {
+		if _, err := jsonTree([]byte(raw)); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateImage([]byte(raw)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := manifest(t, "cf_d1_r2", 0, nil)
+	wire, _ := json.Marshal(m)
+	bad := strings.Replace(string(wire), `"stream":`, `"\ud800":null,"stream":`, 1)
+	_, err := DecodeManifest(strings.NewReader(bad))
+	code(t, err, "invalid_unicode")
+}
+func TestSharedGoldenFixture(t *testing.T) {
+	var f struct {
+		Synthetic       bool              `json:"synthetic"`
+		Manifest        json.RawMessage   `json:"manifest"`
+		ManifestHash    string            `json:"manifestHash"`
+		Floors          []Floor           `json:"floors"`
+		Batches         []json.RawMessage `json:"batches"`
+		ExpectedActions [][]string        `json:"expectedActions"`
+	}
+	wire, err := os.ReadFile("testdata/transfer-v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Unmarshal(wire, &f); err != nil {
+		t.Fatal(err)
+	}
+	if !f.Synthetic {
+		t.Fatal("fixture must be synthetic")
+	}
+	m, err := DecodeManifest(bytes.NewReader(f.Manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh, err := ManifestHash(m)
+	if err != nil || mh != f.ManifestHash {
+		t.Fatal("independent manifest hash mismatch", err)
+	}
+	cp := begin(t, m, f.Floors)
+	for i, wire := range f.Batches {
+		b, err := DecodeBatch(bytes.NewReader(wire))
+		if err != nil {
+			t.Fatal(err)
+		}
+		v, err := ValidateBatch(m, b, cp, nil)
+		if err != nil {
+			t.Fatalf("golden batch %d: %v", i, err)
+		}
+		var actions []string
+		for _, d := range v.Decisions {
+			actions = append(actions, d.Action)
+		}
+		if !reflect.DeepEqual(actions, f.ExpectedActions[i]) {
+			t.Fatal("golden deletion decisions")
+		}
+		noPromotion(t, v)
+		cp = v.Checkpoint
+	}
+	if !cp.Final {
+		t.Fatal("golden interval not closed")
+	}
+}
+func TestBoundedTransactionsAndControlStaging(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	authority := Change{Table: "feed_runtime_control", Key: "1", Operation: "upsert", Image: []byte(`{"writer_epoch":99,"writes_enabled":1}`)}
+	v, err := ValidateBatch(m, seal(t, m, cp, true, []Change{authority}), cp, nil)
+	if err != nil || v.Decisions[0].Action != "stage_control" {
+		t.Fatal("source routing controls could activate target", err)
+	}
+	tx := Transaction{Sequence: 1, TransactionID: m.JournalID + ":1", PreviousHash: cp.CommitHash, Changes: make([]Change, MaxChanges+1)}
+	_, err = TransactionHash(m, tx)
+	code(t, err, "transaction_shape")
+	big := user(m.Source.Profile, 1)
+	big.Image = []byte(`{"body":"` + strings.Repeat("x", MaxImageBytes) + `"}`)
+	tx.Changes = []Change{big}
+	_, err = TransactionHash(m, tx)
+	code(t, err, "image_size")
+	half := user(m.Source.Profile, 1)
+	half.Image = []byte(`{"body":"` + strings.Repeat("x", MaxImageBytes/2) + `"}`)
+	other := clone(half)
+	other.Key = "other"
+	tx.Changes = []Change{half, other}
+	_, err = TransactionHash(m, tx)
+	code(t, err, "transaction_size")
+	floor := Change{Table: "feed_profile_floors", Key: "42", Operation: "upsert", Actor: &ActorScope{42, 5}, Image: []byte(`{"github_id":42,"profile_floor":5}`)}
+	tx.Changes = []Change{floor}
+	_, err = TransactionHash(m, tx)
+	code(t, err, "floor_missing")
+	tx.Changes[0].Operation = "delete"
+	tx.Changes[0].Image = nil
+	_, err = TransactionHash(m, tx)
+	code(t, err, "delete_shape")
+}
+
+func TestSharedUnicodeFixture(t *testing.T) {
+	var cases []struct {
+		JSON  string  `json:"json"`
+		Error *string `json:"error"`
+	}
+	b, err := os.ReadFile("testdata/unicode-v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Unmarshal(b, &cases); err != nil {
+		t.Fatal(err)
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			_, err := jsonTree([]byte(c.JSON))
+			if c.Error == nil {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				code(t, err, *c.Error)
+			}
+		})
+	}
+}
+
+func TestAggregateBoundsAndCanonicalIntegerTokens(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 33, nil)
+	cp := begin(t, m, nil)
+	sets := make([][]Change, 33)
+	for i := range sets {
+		sets[i] = []Change{user(m.Source.Profile, 1)}
+	}
+	// Hashing rejects oversized pages even before their final validation.
+	b := Batch{Version: 1, ManifestHash: cp.ManifestHash, AfterSequence: 0, PreviousHash: cp.CommitHash, Transactions: make([]Transaction, MaxTransactions+1)}
+	_, err := BatchHash(b)
+	code(t, err, "batch_shape")
+	m.ThroughSequence = 5
+	cp = begin(t, m, nil)
+	sets = make([][]Change, 5)
+	for i := range sets {
+		for j := 0; j < 512; j++ {
+			c := user(m.Source.Profile, 1)
+			c.Key = fmt.Sprintf("synthetic:%d", j)
+			sets[i] = append(sets[i], c)
+		}
+	}
+	b = seal(t, m, cp, true, sets...)
+	_, err = ValidateBatch(m, b, cp, nil)
+	code(t, err, "batch_size")
+	wire, _ := json.Marshal(m)
+	for _, token := range []string{"-0", "0.0", "0e0"} {
+		raw := strings.Replace(string(wire), `"fromSequence":0`, `"fromSequence":`+token, 1)
+		_, err := DecodeManifest(strings.NewReader(raw))
+		code(t, err, "json_shape")
+	}
+	_, err = Begin(m, []Floor{{42, 5}, {42, 6}})
+	code(t, err, "duplicate_floor")
+}

--- a/internal/feedtransfer/types.go
+++ b/internal/feedtransfer/types.go
@@ -1,0 +1,117 @@
+package feedtransfer
+
+// All integers use the interoperable JSON-safe range. Commit sequences belong
+// to this Feed journal, never the independent core assessment outbox.
+const (
+	Version               = 1
+	MaxSafeInteger  int64 = 9007199254740991
+	MaxBatchBytes         = 8 << 20
+	MaxImageBytes         = 2 << 20
+	MaxTransactions       = 32
+	MaxChanges            = 512
+	MaxBatchChanges       = 2048
+	MaxFloorActors        = 100000
+)
+
+type Identity struct {
+	Profile        string `json:"profile"`
+	ResourceID     string `json:"resourceId"` // deployment-registered UUID, never a DSN
+	Schema         int64  `json:"schema"`
+	WriterContract int64  `json:"writerContract"`
+	WriterEpoch    int64  `json:"writerEpoch"`
+	RouteEpoch     int64  `json:"routeEpoch"`
+}
+type Coverage struct {
+	Table        string `json:"table"`
+	Mode         string `json:"mode"`
+	Category     string `json:"category"`
+	SnapshotRows int64  `json:"snapshotRows"`
+}
+type Manifest struct {
+	Version                int64      `json:"version"`
+	Stream                 string     `json:"stream"` // feed_transaction_journal, not a core/task outbox
+	MigrationID            string     `json:"migrationId"`
+	JournalID              string     `json:"journalId"`
+	Source                 Identity   `json:"source"`
+	Target                 Identity   `json:"target"`
+	SnapshotSHA256         string     `json:"snapshotSha256"`
+	ArchiveInventorySHA256 string     `json:"archiveInventorySha256"`
+	ArchiveObjects         int64      `json:"archiveObjects"`
+	DeletionFloorsSHA256   string     `json:"deletionFloorsSha256"`
+	DeletionFloorActors    int64      `json:"deletionFloorActors"`
+	FromSequence           int64      `json:"fromSequence"`    // snapshot includes this committed prefix
+	ThroughSequence        int64      `json:"throughSequence"` // closed, externally established interval
+	AnchorHash             string     `json:"anchorHash"`
+	Coverage               []Coverage `json:"coverage"`
+}
+type ActorScope struct {
+	GitHubID       int64 `json:"githubId"`
+	ProfileVersion int64 `json:"profileVersion"`
+}
+type Change struct {
+	Table     string      `json:"table"`
+	Key       string      `json:"key"`       // opaque schema-mapper canonical business key; not SQL
+	Operation string      `json:"operation"` // upsert, delete, erase, floor, command_tombstone
+	Actor     *ActorScope `json:"actor"`     // explicit null for unscoped facts
+	Image     []byte      `json:"image"`     // base64 UTF-8 JSON object after-image; no value logging
+}
+type Transaction struct {
+	Sequence      int64    `json:"sequence"`
+	TransactionID string   `json:"transactionId"`
+	PreviousHash  string   `json:"previousHash"`
+	Changes       []Change `json:"changes"` // complete atomic write set, never a page fragment
+	Hash          string   `json:"hash"`
+}
+type Batch struct {
+	Version       int64         `json:"version"`
+	ManifestHash  string        `json:"manifestHash"`
+	AfterSequence int64         `json:"afterSequence"`
+	PreviousHash  string        `json:"previousHash"`
+	Transactions  []Transaction `json:"transactions"`
+	Final         bool          `json:"final"`
+	Hash          string        `json:"hash"`
+}
+
+// Checkpoint/Receipt are caller-owned durable facts. Persist them atomically with
+// the target transaction. The verifier cannot substitute memory for persistence.
+type Floor struct {
+	GitHubID     int64 `json:"githubId"`
+	ProfileFloor int64 `json:"profileFloor"`
+}
+type Checkpoint struct {
+	ManifestHash string  `json:"manifestHash"`
+	Sequence     int64   `json:"sequence"`
+	CommitHash   string  `json:"commitHash"`
+	Floors       []Floor `json:"floors"`
+	Final        bool    `json:"final"`
+}
+type Receipt struct {
+	ManifestHash    string `json:"manifestHash"`
+	AfterSequence   int64  `json:"afterSequence"`
+	ThroughSequence int64  `json:"throughSequence"`
+	BatchHash       string `json:"batchHash"`
+}
+type Decision struct {
+	Sequence    int64
+	ChangeIndex int
+	Action      string // apply, suppress_deleted_generation, retain_max_floor, erase, tombstone
+}
+type Validation struct {
+	Checkpoint       Checkpoint
+	Receipt          Receipt
+	Decisions        []Decision
+	Duplicate        bool
+	ProtocolComplete bool
+	// These are ALWAYS false. External evidence and adapters do not exist here.
+	CaptureConnected     bool
+	RowSchemaValidated   bool
+	ArchiveBytesVerified bool
+	PromotionReady       bool
+}
+
+// Error intentionally contains only a fixed code. Keys, actors, row images and
+// decoder errors must never be copied into public logs by this protocol layer.
+type Error struct{ Code string }
+
+func (e *Error) Error() string  { return "feed_transfer:" + e.Code }
+func invalid(code string) error { return &Error{Code: code} }

--- a/internal/feedtransfer/validate.go
+++ b/internal/feedtransfer/validate.go
@@ -1,0 +1,389 @@
+package feedtransfer
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+var digestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+var columnPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
+var integerPattern = regexp.MustCompile(`^(0|-?[1-9][0-9]*)$`)
+
+func digest(s string) bool  { return digestPattern.MatchString(s) }
+func safe(v int64) bool     { return v >= 0 && v <= MaxSafeInteger }
+func positive(v int64) bool { return v > 0 && v <= MaxSafeInteger }
+func clean(s string, max int) bool {
+	if s == "" || len(s) > max || !utf8.ValidString(s) {
+		return false
+	}
+	for _, r := range s {
+		if r < 32 || r == 127 {
+			return false
+		}
+	}
+	return true
+}
+func validIdentity(v Identity) error {
+	r, err := RequiredRegistry(v.Profile)
+	if err != nil {
+		return err
+	}
+	if !uuidPattern.MatchString(v.ResourceID) || v.Schema != r.Schema || v.WriterContract != r.WriterContract || !positive(v.WriterEpoch) || !positive(v.RouteEpoch) {
+		return invalid("identity")
+	}
+	return nil
+}
+func ValidateManifest(m Manifest) error {
+	if m.Version != Version {
+		return invalid("unknown_version")
+	}
+	if m.Stream != "feed_transaction_journal" {
+		return invalid("wrong_stream")
+	}
+	if !uuidPattern.MatchString(m.MigrationID) || !uuidPattern.MatchString(m.JournalID) {
+		return invalid("manifest_identity")
+	}
+	if err := validIdentity(m.Source); err != nil {
+		return err
+	}
+	if err := validIdentity(m.Target); err != nil {
+		return err
+	}
+	if m.Source.ResourceID == m.Target.ResourceID {
+		return invalid("same_resource")
+	}
+	// Writer epochs belong to each database; route epoch belongs to this promotion.
+	if m.Target.RouteEpoch != m.Source.RouteEpoch+1 {
+		return invalid("route_epoch")
+	}
+	if !digest(m.SnapshotSHA256) || !digest(m.ArchiveInventorySHA256) || !safe(m.ArchiveObjects) || !digest(m.DeletionFloorsSHA256) || !safe(m.DeletionFloorActors) || m.DeletionFloorActors > MaxFloorActors || !digest(m.AnchorHash) || !safe(m.FromSequence) || !safe(m.ThroughSequence) || m.ThroughSequence < m.FromSequence {
+		return invalid("manifest_range")
+	}
+	zero := strings.Repeat("0", 64)
+	if (m.FromSequence == 0) != (m.AnchorHash == zero) {
+		return invalid("anchor")
+	}
+	r, _ := RequiredRegistry(m.Source.Profile)
+	if len(m.Coverage) != len(r.Tables) {
+		return invalid("coverage")
+	}
+	for i, v := range m.Coverage {
+		want := r.Tables[i]
+		if v.Table != want.Table || v.Mode != want.Mode || v.Category != want.Category || !safe(v.SnapshotRows) || (v.Mode == "empty" && v.SnapshotRows != 0) {
+			return invalid("coverage")
+		}
+	}
+	return nil
+}
+func isFloor(table string) bool {
+	return table == "feed_profile_floors" || table == "feed.user_deletion_tombstones"
+}
+func isCommand(table string) bool {
+	return table == "feed_tag_proposal_commands" || table == "feed.tag_proposal_commands"
+}
+func isProposal(table string) bool {
+	return table == "feed_user_tag_proposals" || table == "feed.tag_proposals"
+}
+func isAuthority(table string) bool {
+	return table == "feed_runtime_control" || table == "feed_schema_compatibility" || table == "feed.runtime_control" || table == "feed.schema_compatibility"
+}
+
+// Images are flat SQL-column objects. SQL JSON/text is preserved as a string;
+// decimals and timestamps are schema-mapper strings, never lossy JSON floats.
+// This validates the envelope only, NOT column completeness, types or ownership.
+func validateImage(b []byte) error {
+	if len(b) == 0 || len(b) > MaxImageBytes {
+		return invalid("image_size")
+	}
+	node, err := jsonTree(b)
+	if err != nil {
+		return err
+	}
+	m, ok := node.(map[string]any)
+	if !ok || len(m) == 0 || len(m) > 512 {
+		return invalid("image_shape")
+	}
+	for k, v := range m {
+		if !columnPattern.MatchString(k) {
+			return invalid("image_shape")
+		}
+		switch x := v.(type) {
+		case nil, string, bool:
+		case json.Number:
+			if !integerPattern.MatchString(string(x)) {
+				return invalid("image_number")
+			}
+			n, err := strconv.ParseInt(string(x), 10, 64)
+			if err != nil || n < -MaxSafeInteger || n > MaxSafeInteger {
+				return invalid("image_number")
+			}
+		default:
+			return invalid("image_shape")
+		}
+	}
+	return nil
+}
+func validateTransaction(m Manifest, v Transaction) error {
+	if !positive(v.Sequence) || v.TransactionID != m.JournalID+":"+strconv.FormatInt(v.Sequence, 10) || !digest(v.PreviousHash) || len(v.Changes) == 0 || len(v.Changes) > MaxChanges {
+		return invalid("transaction_shape")
+	}
+	seen := map[string]bool{}
+	images := 0
+	for _, c := range v.Changes {
+		rule, ok := tableRule(m.Source.Profile, c.Table)
+		if !ok || rule.Mode != "capture" {
+			return invalid("change_coverage")
+		}
+		if !clean(c.Key, 1024) {
+			return invalid("change_key")
+		}
+		key := c.Table + "\x00" + c.Key
+		if c.Operation == "floor" {
+			key += "\x00floor"
+		}
+		if seen[key] {
+			return invalid("duplicate_change")
+		}
+		seen[key] = true
+		if c.Actor != nil && (!positive(c.Actor.GitHubID) || !positive(c.Actor.ProfileVersion)) {
+			return invalid("actor_scope")
+		}
+		if rule.Privacy == "actor" && c.Actor == nil {
+			return invalid("actor_scope")
+		}
+		if rule.Privacy == "shared" && c.Actor != nil {
+			return invalid("actor_scope")
+		}
+		if (isFloor(c.Table) || c.Table == "feed_profile_deletions" || c.Table == "feed_cleanup_jobs" || c.Table == "feed_archive_objects" || c.Table == "feed.archive_objects") && c.Actor == nil {
+			return invalid("actor_scope")
+		}
+		switch c.Operation {
+		case "upsert":
+			if err := validateImage(c.Image); err != nil {
+				return err
+			}
+			images += len(c.Image)
+		case "delete":
+			if c.Image != nil || isFloor(c.Table) {
+				return invalid("delete_shape")
+			}
+		case "floor":
+			if !isFloor(c.Table) || c.Actor == nil || c.Image != nil {
+				return invalid("floor_shape")
+			}
+		case "erase":
+			if !isProposal(c.Table) || c.Actor == nil || c.Image != nil {
+				return invalid("erase_shape")
+			}
+		case "command_tombstone":
+			if !isCommand(c.Table) || c.Actor == nil || c.Image != nil {
+				return invalid("tombstone_shape")
+			}
+		default:
+			return invalid("unknown_operation")
+		}
+	}
+	if images > MaxImageBytes {
+		return invalid("transaction_size")
+	}
+	// A tombstone table after-image cannot quietly lower a floor. Capture emits
+	// a separate, image-free floor record in the same source transaction.
+	for _, c := range v.Changes {
+		if c.Operation == "upsert" && isFloor(c.Table) {
+			found := false
+			for _, f := range v.Changes {
+				if f.Operation == "floor" && f.Table == c.Table && f.Key == c.Key && *f.Actor == *c.Actor {
+					found = true
+				}
+			}
+			if !found {
+				return invalid("floor_missing")
+			}
+		}
+	}
+	return nil
+}
+
+func floorMap(floors []Floor) (map[int64]int64, error) {
+	if len(floors) > MaxFloorActors {
+		return nil, invalid("floor_limit")
+	}
+	m := map[int64]int64{}
+	for _, f := range floors {
+		if !positive(f.GitHubID) || !positive(f.ProfileFloor) {
+			return nil, invalid("floor_value")
+		}
+		if _, ok := m[f.GitHubID]; ok {
+			return nil, invalid("duplicate_floor")
+		}
+		m[f.GitHubID] = f.ProfileFloor
+	}
+	return m, nil
+}
+func sortedFloors(m map[int64]int64) []Floor {
+	out := make([]Floor, 0, len(m))
+	for id, floor := range m {
+		out = append(out, Floor{id, floor})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GitHubID < out[j].GitHubID })
+	return out
+}
+
+// Begin requires the snapshot's deletion floors plus every newer independently
+// verified deletion overlay available before replay. It cannot prove that the
+// supplied overlay is complete, and never returns permission to promote.
+func Begin(m Manifest, floors []Floor) (Checkpoint, error) {
+	h, err := ManifestHash(m)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	f, err := floorMap(floors)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	fh, _ := DeletionFloorsHash(floors)
+	if fh != m.DeletionFloorsSHA256 || int64(len(floors)) != m.DeletionFloorActors {
+		return Checkpoint{}, invalid("floor_overlay")
+	}
+	return Checkpoint{ManifestHash: h, Sequence: m.FromSequence, CommitHash: m.AnchorHash, Floors: sortedFloors(f)}, nil
+}
+
+// ValidateBatch returns a plan only. Apply the entire batch, receipt and next
+// checkpoint in one target transaction, or subdivide solely at source commit
+// boundaries with a separate durable per-commit ledger. Never partially ack.
+// A duplicate is accepted only with the caller's matching durable receipt.
+func ValidateBatch(m Manifest, b Batch, checkpoint Checkpoint, prior *Receipt) (Validation, error) {
+	out := Validation{}
+	h, err := ManifestHash(m)
+	if err != nil {
+		return out, err
+	}
+	if checkpoint.ManifestHash != h || !safe(checkpoint.Sequence) || checkpoint.Sequence < m.FromSequence || checkpoint.Sequence > m.ThroughSequence || !digest(checkpoint.CommitHash) || (checkpoint.Final && checkpoint.Sequence != m.ThroughSequence) {
+		return out, invalid("checkpoint")
+	}
+	if checkpoint.Sequence == m.FromSequence && checkpoint.CommitHash != m.AnchorHash {
+		return out, invalid("checkpoint")
+	}
+	floors, err := floorMap(checkpoint.Floors)
+	if err != nil {
+		return out, err
+	}
+	if checkpoint.Sequence == m.FromSequence {
+		fh, _ := DeletionFloorsHash(checkpoint.Floors)
+		if fh != m.DeletionFloorsSHA256 || int64(len(checkpoint.Floors)) != m.DeletionFloorActors {
+			return out, invalid("floor_overlay")
+		}
+	}
+	if b.Version != Version {
+		return out, invalid("unknown_version")
+	}
+	if b.ManifestHash != h || !safe(b.AfterSequence) || b.AfterSequence < m.FromSequence || b.AfterSequence > m.ThroughSequence || !digest(b.PreviousHash) || len(b.Transactions) > MaxTransactions {
+		return out, invalid("batch_identity")
+	}
+	if len(b.Transactions) == 0 && !(b.Final && b.AfterSequence == m.ThroughSequence) {
+		return out, invalid("empty_page")
+	}
+	sequence, previous := b.AfterSequence, b.PreviousHash
+	total := 0
+	txIDs := map[string]bool{}
+	for _, tx := range b.Transactions {
+		if sequence == MaxSafeInteger || tx.Sequence != sequence+1 || tx.Sequence > m.ThroughSequence || tx.PreviousHash != previous {
+			return out, invalid("transaction_order")
+		}
+		if txIDs[tx.TransactionID] {
+			return out, invalid("duplicate_transaction")
+		}
+		txIDs[tx.TransactionID] = true
+		hash, err := TransactionHash(m, tx)
+		if err != nil {
+			return out, err
+		}
+		if tx.Hash != hash {
+			return out, invalid("transaction_hash")
+		}
+		sequence, previous = tx.Sequence, hash
+		total += len(tx.Changes)
+	}
+	if total > MaxBatchChanges {
+		return out, invalid("batch_size")
+	}
+	wire, err := json.Marshal(b)
+	if err != nil || len(wire) > MaxBatchBytes {
+		return out, invalid("body_too_large")
+	}
+	bh, err := BatchHash(b)
+	if err != nil {
+		return out, err
+	}
+	if b.Hash != bh {
+		return out, invalid("batch_hash")
+	}
+	if b.Final != (sequence == m.ThroughSequence) {
+		return out, invalid("final_boundary")
+	}
+	receipt := Receipt{ManifestHash: h, AfterSequence: b.AfterSequence, ThroughSequence: sequence, BatchHash: bh}
+	if prior != nil {
+		if *prior != receipt {
+			return out, invalid("receipt_conflict")
+		}
+		if checkpoint.Sequence < sequence || (checkpoint.Sequence == sequence && (checkpoint.CommitHash != previous || checkpoint.Final != b.Final)) {
+			return out, invalid("receipt_uncommitted")
+		}
+		out.Checkpoint = checkpoint
+		out.Checkpoint.Floors = sortedFloors(floors)
+		out.Receipt = receipt
+		out.Duplicate = true
+		out.ProtocolComplete = checkpoint.Final
+		return out, nil
+	}
+	if checkpoint.Final || b.AfterSequence != checkpoint.Sequence || b.PreviousHash != checkpoint.CommitHash {
+		return out, invalid("page_order")
+	}
+	for _, tx := range b.Transactions {
+		// Merge floors before evaluating ANY write in this transaction, independent
+		// of capture's row order. Deleted generations never become live again.
+		for _, c := range tx.Changes {
+			if c.Operation == "floor" && c.Actor.ProfileVersion > floors[c.Actor.GitHubID] {
+				floors[c.Actor.GitHubID] = c.Actor.ProfileVersion
+			}
+		}
+		if len(floors) > MaxFloorActors {
+			return Validation{}, invalid("floor_limit")
+		}
+		for i, c := range tx.Changes {
+			action := "apply"
+			switch c.Operation {
+			case "floor":
+				action = "retain_max_floor"
+			case "erase", "command_tombstone":
+				if c.Actor.ProfileVersion > floors[c.Actor.GitHubID] {
+					return Validation{}, invalid("tombstone_without_floor")
+				}
+				if c.Operation == "erase" {
+					action = "erase"
+				} else {
+					action = "tombstone"
+				}
+			case "upsert":
+				rule, _ := tableRule(m.Source.Profile, c.Table)
+				if isAuthority(c.Table) {
+					action = "stage_control"
+				} else if isFloor(c.Table) {
+					action = "merge_floor_control"
+				} else if c.Actor != nil && c.Actor.ProfileVersion <= floors[c.Actor.GitHubID] && rule.Privacy != "control" {
+					action = "suppress_deleted_generation"
+				}
+			}
+			out.Decisions = append(out.Decisions, Decision{Sequence: tx.Sequence, ChangeIndex: i, Action: action})
+		}
+	}
+	out.Checkpoint = Checkpoint{ManifestHash: h, Sequence: sequence, CommitHash: previous, Floors: sortedFloors(floors), Final: b.Final}
+	out.Receipt = receipt
+	out.ProtocolComplete = b.Final
+	return out, nil
+}


### PR DESCRIPTION
The existing assessment and task outboxes do not cover all Feed fact changes, so their watermarks cannot authorize a D1/PostgreSQL cutover. Add an offline, versioned preparation contract that validates complete declarations, bounded whole-transaction intervals, chained hashes, exact replay receipts, resource identities and deletion-generation floors.

This does not connect capture, apply rows, map schemas, verify archive bytes or promote a target. Every validation result keeps those readiness flags false. In particular, the current 250,000-event cascade and unbounded retention transactions exceed this format: the next design must explicitly handle them before any capture integration. Truncating changes, increasing a limit or silently omitting cascades is prohibited.

Validation includes 14 top-level tests with both profiles, race/vet checks, an independent Python hash fixture, an actual local SQLite D1-table inventory check and PostgreSQL migration declaration inventory. Regressions reject missing/altered initial deletion overlays, isolated UTF-16 surrogates, missing tables, transaction/page gaps, duplicate conflicts, tampering and unsafe row shapes. This is protocol validation, not real database capture or migration acceptance; no business transaction, migration number, production credential or route changes.
