### PR TITLE
fix(feed): verify storage writer identity in runtime readiness

### DIFF
--- a/docs/operations/feed-platform-prerequisites.md
+++ b/docs/operations/feed-platform-prerequisites.md
@@ -114,6 +114,11 @@ On isolated staging, measure the same Go image used by ordinary Docker:
 
 - Real `/healthz` and dependency-aware `/readyz`, build digest and contract/schema
   identity; no successful readiness merely because the process started.
+  Go responses distinguish HTTP `contractVersion:"1"` from the compiled numeric
+  `storageWriterVersion:2`, including when readiness fails. The storage writer
+  field describes the binary's protocol, not an inferred live schema version.
+  Container lifecycle probes require both fields on each API/executor response;
+  missing or mismatched writer identity fails the probe.
 - Cold start, concurrent requests, instance restart, temporary-disk loss and
   graceful shutdown; persistent task completion must survive each case.
 - Normal p95 ≤800 ms, cold p95 ≤5 s; 10 RPS for at least ten minutes after the

--- a/internal/feed/runtime/config.go
+++ b/internal/feed/runtime/config.go
@@ -109,7 +109,7 @@ func WithHealth(handler http.Handler, c Config, version, service string, ready f
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
-		writeStatus(w, 200, map[string]any{"healthy": true, "service": service, "version": version, "contractVersion": backend.FeedBridgeVersion})
+		writeStatus(w, 200, map[string]any{"healthy": true, "service": service, "version": version, "contractVersion": backend.FeedBridgeVersion, "storageWriterVersion": backend.FeedStorageWriterVersion})
 	})
 	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 4*time.Second)
@@ -119,7 +119,7 @@ func WithHealth(handler http.Handler, c Config, version, service string, ready f
 		if err != nil {
 			status = 503
 		}
-		writeStatus(w, status, map[string]any{"ready": err == nil, "service": service, "version": version, "contractVersion": backend.FeedBridgeVersion, "storeProfile": c.StoreProfile, "writerEpoch": c.WriterEpoch})
+		writeStatus(w, status, map[string]any{"ready": err == nil, "service": service, "version": version, "contractVersion": backend.FeedBridgeVersion, "storageWriterVersion": backend.FeedStorageWriterVersion, "storeProfile": c.StoreProfile, "writerEpoch": c.WriterEpoch})
 	})
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")

--- a/internal/feed/runtime/worker_test.go
+++ b/internal/feed/runtime/worker_test.go
@@ -65,6 +65,17 @@ func TestCFWorkerReadinessIncludesArchiveBinding(t *testing.T) {
 		if recorder.Header().Get("Cache-Control") != "no-store" {
 			t.Fatal("health caching must remain disabled")
 		}
+		var identity struct {
+			Version              string `json:"version"`
+			ContractVersion      string `json:"contractVersion"`
+			StorageWriterVersion int    `json:"storageWriterVersion"`
+		}
+		if err := json.Unmarshal(recorder.Body.Bytes(), &identity); err != nil {
+			t.Fatal(err)
+		}
+		if identity.Version != "readiness-contract-test" || identity.ContractVersion != "1" || identity.StorageWriterVersion != 2 {
+			t.Fatalf("missing distinct runtime/HTTP/storage writer identity on %s status %d: %+v", path, status, identity)
+		}
 	}
 	probe("/readyz", http.StatusOK)
 	archiveDown.Store(true)

--- a/scripts/feed-platform-probe.mjs
+++ b/scripts/feed-platform-probe.mjs
@@ -52,6 +52,7 @@ function version(data, target) {
     data.ready !== true ||
     data.version !== sha ||
     data.contractVersion !== "1" ||
+    data.storageWriterVersion !== 2 ||
     data.storeProfile !== "cf_d1_r2" ||
     String(data.writerEpoch) !== "1" ||
     data.service !== (target === "executor-0" ? "feed-worker" : "feed-api")


### PR DESCRIPTION
Go health/readiness previously exposed HTTP contract 1 without identifying the compiled storage writer protocol, making the privacy-compatible writer-2 runtime harder to verify from deployed responses. Both endpoints now report numeric `storageWriterVersion: 2` separately from string `contractVersion: "1"`, including dependency-failure responses. The staging lifecycle probe requires the writer identity on every API/executor instance.

The field identifies the binary's protocol; it does not claim a live schema version or bypass dependency checks. API behavior, storage migrations and production routing are unchanged.

Validation: `go test -count=1 ./internal/feed/runtime` passed, including identity checks throughout the existing real HTTP archive-dependency failure/recovery test; `node --check scripts/feed-platform-probe.mjs` and `git diff --check` passed. Actual CF staging remains a separate acceptance gate.
