### PR TITLE
feat(feed): validate bounded segments of whole migration transactions

### DIFF
--- a/docs/contracts/feed-transfer-segments-v2.md
+++ b/docs/contracts/feed-transfer-segments-v2.md
@@ -1,0 +1,226 @@
+# Feed transfer v2: bounded segments of one source transaction
+
+Status: **protocol preparation only**. This adds no source capture, durable
+staging database, target mapper, database migration or production routing.
+Version 1 files, wire bytes, hashes and validation behavior remain unchanged.
+The v2 seal references the existing v1 resource/coverage manifest and its hash;
+segment, transaction, progress and receipt transcripts use separate v2 domains.
+A v1 transaction consumer must reject v2, not reinterpret its segments as commits.
+
+This closes the **transport representation** gap for large source transactions.
+It does not prove that the existing 250k-event PostgreSQL cascade is captured, or
+that a D1 target can atomically apply its complete mapped write set. Both remain
+mandatory gates. PostgreSQL retention can legally leave an event with a null
+`request_id`; D1 schema 11 still cannot directly represent that value. No mapper
+may silently substitute an empty string, invent a request or discard the event.
+
+## Closed source transaction, bounded content
+
+`TransactionSeal` declares one source commit: manifest identity, transaction ID
+(`journalId:sequence`), previous commit hash, total changes/content bytes/segments,
+last segment hash, floor-record count/chain, transaction hash and seal hash. It
+must cover the complete committed write set, including cascades and `SET NULL`
+after-images. Source capture must prove that claim independently; the protocol
+cannot infer a missing source mutation from an internally consistent seal.
+
+`TransactionSegment` identifies that seal and source transaction, its zero-based
+index and first change ordinal, previous segment hash, changes and hash. Each
+change wraps the existing v1 `Change` with a required nullable `beforeHash`:
+
+- `delete`, `erase` and `command_tombstone` require the exact source row digest.
+- `floor` is image-free metadata and requires `beforeHash=null`.
+- `upsert` uses null for insertion or the prior source digest for replacement.
+
+The future snapshot/capture mapper must retain source identity and digest,
+normalized target identity/digest and actor incarnation so an old delete cannot
+remove a new profile's row with the same natural key. Neither a caller-supplied
+actor field nor a source digest alone proves target ownership. This protocol
+validates the transport shape; it does not implement those schema-aware checks.
+
+Every segment retains the v1 bounds: at most 512 changes, at most 2 MiB total image
+bytes and at most 8 MiB wire bytes. The caller reserves a `SegmentQuota` before
+receiving content. Its declared totals must fit these ceilings:
+
+| Whole-transaction ceiling | Value |
+| --- | --- |
+| Changes | 1,000,000 |
+| Content bytes | 256 MiB |
+| Segments | 2,048 |
+
+Content charge per change is the UTF-8 byte length of table + key + operation,
+plus decoded image bytes, plus 16 when actor scope exists, plus 64 when
+`beforeHash` exists. This fixed formula avoids JSON whitespace/base64 ambiguity;
+separate wire, image and count bounds cover encoding/structural overhead. Empty
+segments and impossible totals are rejected. A configured reservation can be
+smaller, never larger. Exceeding it fails closed; no truncation, cascade omission
+or partial business acknowledgement is allowed.
+
+Changes are globally ordered by the tuple **(table UTF-8 bytes, key UTF-8 bytes,
+operation UTF-8 bytes)**. There is no Unicode normalization, SQL locale collation,
+or JavaScript default UTF-16 comparison. The implementation compares the same
+components separated by NUL, which is forbidden inside keys and registry names.
+U+E000 sorts before U+10000 by this rule; JavaScript's default sort reverses them.
+The shared fixture places these keys in different segments.
+
+Duplicate row identities are rejected using only the last ordering cursor.
+The sole same-key exception is `floor` followed by its matched tombstone-row
+`upsert`; both must remain in the **same segment**, preserving the existing v1
+validation rule. Source capture must emit the sorted final write set, not every
+intermediate rewrite of one row. Sorting/spooling the actual committed source
+set remains a future adapter responsibility, not in-memory accumulation here.
+
+## Hashes and complete passes
+
+All transcripts use v1's domain-separated, decimal byte-length-prefixed UTF-8
+tokens. Booleans are `1`/`0`; numbers are canonical decimal safe integers. Domain
+tags, lists and field order are frozen by `segments_hash.go` and the independent
+Python fixture generator. Important boundaries:
+
+1. Segment hash binds source identity, journal ID, v2, transaction ID/sequence,
+   previous commit hash, segment index/ordinal/previous hash and all ordered
+   changes. Changes bind actor-presence and values, before-hash-presence/value,
+   decoded image length and exact image-byte SHA-256.
+2. It deliberately excludes `sealHash`: the seal itself includes the final
+   segment hash. Including both would create a circular definition. On receipt,
+   the segment envelope's seal hash must equal the validated target-bound seal.
+3. Transaction hash binds source identity/journal, its entire commit boundary,
+   total counts/bytes, final segment hash and floor-record chain. Seal hash binds
+   version, manifest hash and transaction hash, therefore also the target.
+4. Floor-chain entries bind previous floor-chain hash, table, key, githubId and
+   profileVersion, in their actual global change order. The empty chain is 64
+   zeroes. Intermediate staging needs only that hash and count, not all actors.
+5. Stage-progress hash binds every progress field and last ordering cursor. A
+   stage-receipt hash binds version, seal, segment identity, prior progress hash
+   and next progress hash.
+6. Decision hash binds seal hash, the fully merged floor-set hash, total changes,
+   then each zero-based global ordinal and the v1 action name. This certifies the
+   protocol decision stream, not a database mapper's execution.
+7. Atomic receipt binds its exact prior checkpoint hash, stage-progress hash,
+   transaction and floor-chain hashes, decision hash, approved map version,
+   normalized result hash, unique atomic apply ID and resulting checkpoint hash.
+   Checkpoint hashes include the full floor-set hash/count and final marker.
+
+The floor pass and row pass have independently verified inputs:
+
+- First, reread exactly the declared immutable staged floor records; validate
+  their v1 shape, strict order, count and complete floor-chain hash. Merge every
+  floor by maximum with the prior applied checkpoint. The existing separate
+  bound of 100,000 distinct floor actors applies to this final merge.
+- Then reread **all** staged segments from the beginning. Revalidate each row,
+  segment hash, ordinal, global ordering, quota and entire chain/seal. Reject
+  early EOF and extra data. Apply v1's protocol rules to the already merged full
+  floor set: unfenced erase/tombstone fails, old-generation upserts are suppressed,
+  writer controls are staged, and floor controls retain their merge semantics.
+- Compute the decision digest without storing per-row decisions. The target
+  mapper must make its own independently reviewed schema/ownership/FK checks and
+  consume these same decisions from immutable content before real atomic apply.
+
+`ValidateStagedSemantics` performs these read-only passes before a future mapper
+attempt. `ProposeCheckpointAdvance` repeats them when validating the committed
+receipt. There is no `pass=true` flag that can replace the records and chains.
+A stalled reader still needs a caller-enforced deadline; counts and byte bounds
+cannot impose a deadline on an arbitrary callback or `io.Reader`.
+
+## Staged is not applied
+
+`StageProgress` contains only constant-size counts, hashes, flags and the last
+bounded ordering key. It never contains the accumulated transaction's JSON tree,
+row list or mutation receipt. `ready=true` means all content matches the seal,
+not that rows are applied or that deletion is complete.
+
+`BeginStaging` validates resource/epoch/coverage identity, total quota and the
+prior applied checkpoint, including the pinned initial deletion overlay.
+`ValidateSegment` returns a **proposal** for new stage progress and a
+`DurableStageReceipt`. The future caller must atomically persist immutable segment
+bytes, receipt and new progress before acknowledging that segment. Until then,
+the proposed receipt is not durable evidence. The module writes nothing.
+
+After restart, load the latest authenticated receipt and use `RestoreStaging`.
+Do not reconstruct progress from process memory, supplied counters, a queue ack,
+or the mere existence of an object in R2. Lost staging acknowledgement can retry
+the exact segment with its persisted receipt: it returns a duplicate without
+advancing progress. A changed digest, receipt ahead of persisted progress, wrong
+transaction, missing segment or unreceipted old segment fails closed. Concurrent
+staging writers need a unique segment key and CAS on the prior progress hash.
+These database constraints are a **caller contract**, not implemented storage.
+
+The future apply adapter must wait for complete content and semantic verification,
+then perform the complete mapped write set, maximum floors, receipt and applied
+head update in **one target database transaction**. PostgreSQL can be evaluated
+with its native transaction; D1 needs actual proof that its fixed capabilities can
+atomically handle the complete mapped set within platform limits. Persisting
+segments separately and later adding a commit marker is not atomic business
+application. If that transaction cannot run, the target capability remains blocked.
+Staging must remain private and cannot be connected to live business reads.
+
+Only an authenticated `AtomicCommitReceipt` with `outcome="applied"` permits
+`ProposeCheckpointAdvance` to propose the next applied checkpoint. The receipt
+must match the entire seal, completed stage, approved map version, protocol
+decision stream and exact merged floor set; it cannot drop a floor or add an
+unproven one. Missing/accepted-only receipts fail. Images, actor incarnation,
+nullable columns and normalized result correctness still require the mapper's
+real transaction evidence. Integrity hashes are not signatures.
+
+**Atomic commit acknowledgement loss has a separate path.** The target transaction
+must also persist `AppliedHead{checkpoint, atomicReceiptHash}`. On restart after
+commit, `ConfirmCommittedTransaction` compares that authenticated current head
+with the exact stored receipt's resulting checkpoint and receipt hash. It returns
+only duplicate confirmation of that current commit, without replay, requiring an
+old in-memory checkpoint, or advancing anything. A changed receipt, rolled-back
+head or other transaction is rejected. Historical receipts older than the current
+head need a separately authenticated ledger-status capability; this method does
+not infer ancestry from sequence numbers.
+
+## Explicit evidence boundary
+
+All staging results keep `CaptureConnected`, `DurableStorageVerified` and
+`PromotionReady` false. Advance/duplicate results keep `CaptureConnected`,
+`AtomicApplicationVerified`, `RowSchemaValidated` and `PromotionReady` false.
+`AtomicReceiptMatched` means the trusted caller's supplied ledger record matches
+the protocol; the package cannot inspect a real database commit. These APIs must
+not be exposed as an endpoint that trusts client-asserted receipts.
+
+The only final floor memory is the existing 100k-actor bounded merge. Every
+segment/content pass retains at most one segment plus constant-size progress.
+Plain errors contain fixed codes only. Transfer images, source hashes, before
+hashes, last keys, floors and receipts are private recovery artifacts; never emit
+them to public request logs. Use authenticated encrypted storage and the existing
+deletion/retention policy. No journal object may resurrect deleted content during
+restore, and a staging transport test cannot prove object erasure.
+
+## Local acceptance and next commit
+
+Tests generate 250,000 synthetic, image-free PostgreSQL event deletions through a
+replayable chunk producer. They never build a 250k-element slice or JSON tree.
+There are 489 segments of at most 512 changes; each is serialized, decoded,
+validated and restarted from a serialized modeled receipt. The largest progress
+record measured in the fixture is 506 bytes. The test checks no retained
+transaction-sized heap and no applied-checkpoint advancement; it is not a D1/PG
+benchmark or real persistence test.
+
+Additional regressions cover missing/reordered/foreign segments, duplicate and
+changed receipts, total quotas and seal tampering, global UTF-8 order, same-key
+floor pairing, invalid erasure without a floor, exact merged floors, changed
+suppression digest, independent row-pass completeness, atomic lost-ack recovery,
+and atomic receipt restart with the full 100,000-floor quota. Only the atomic
+receipt decoder has a 400k JSON-node bound for that legitimate payload; its body
+remains 8 MiB. Other decoders and all v1 limits remain unchanged.
+
+`testdata/segments-v2.json` and `generate_segments_fixture.py` independently freeze
+segment, seal, staging, decision and atomic-receipt hashes. The included atomic
+receipt is explicitly synthetic, not evidence of a database apply.
+
+```sh
+go test -race ./internal/feedtransfer
+go vet ./internal/feedtransfer
+python3 internal/feedtransfer/testdata/generate_fixture.py
+python3 internal/feedtransfer/testdata/generate_segments_fixture.py
+```
+
+The next independently reviewed commit must exercise the **existing** real large
+PostgreSQL deletion and retention transactions, establish complete capture of
+FK cascades/`SET NULL`, and implement/prove schema-aware target mapping and atomic
+application in isolated PostgreSQL and Workers/D1. No source behavior is rewritten
+to shrink its log, no arbitrary SQL predicate RPC is introduced, and no schema or
+runtime route is changed here. Until that work passes, large-transaction capture,
+null mapping, actual D1 atomic apply and production promotion remain unverified.

--- a/internal/feedtransfer/segments_decode.go
+++ b/internal/feedtransfer/segments_decode.go
@@ -1,0 +1,103 @@
+package feedtransfer
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"reflect"
+	"unicode/utf8"
+)
+
+// The atomic receipt may legitimately contain 100k floor objects (over 300k
+// JSON nodes). This endpoint alone has a 400k node cap and the same 8MiB body
+// bound. v1 and segment/manifest decoders keep their original 200k cap.
+func DecodeAtomicCommitReceipt(r io.Reader) (AtomicCommitReceipt, error) {
+	var out AtomicCommitReceipt
+	data, err := io.ReadAll(io.LimitReader(r, MaxBatchBytes+1))
+	if err != nil {
+		return out, invalid("read_failed")
+	}
+	if len(data) > MaxBatchBytes {
+		return out, invalid("body_too_large")
+	}
+	if !utf8.Valid(data) {
+		return out, invalid("invalid_json")
+	}
+	if !pairedSurrogates(data) {
+		return out, invalid("invalid_unicode")
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	count := 0
+	node, err := readAtomicNode(d, 0, &count)
+	if err != nil {
+		return out, err
+	}
+	if _, err = d.Token(); err != io.EOF {
+		return out, invalid("invalid_json")
+	}
+	if !shape(node, reflect.TypeOf(out)) {
+		return out, invalid("json_shape")
+	}
+	if json.Unmarshal(data, &out) != nil {
+		return out, invalid("json_value")
+	}
+	if _, err := floorMap(out.After.Floors); err != nil {
+		return AtomicCommitReceipt{}, err
+	}
+	return out, nil
+}
+func readAtomicNode(d *json.Decoder, depth int, count *int) (any, error) {
+	(*count)++
+	if depth > 32 || *count > 400000 {
+		return nil, invalid("json_complexity")
+	}
+	t, err := d.Token()
+	if err != nil {
+		return nil, invalid("invalid_json")
+	}
+	delim, ok := t.(json.Delim)
+	if !ok {
+		return t, nil
+	}
+	switch delim {
+	case '{':
+		out := map[string]any{}
+		for d.More() {
+			k, err := d.Token()
+			if err != nil {
+				return nil, invalid("invalid_json")
+			}
+			key, ok := k.(string)
+			if !ok {
+				return nil, invalid("invalid_json")
+			}
+			if _, ok = out[key]; ok {
+				return nil, invalid("duplicate_json_key")
+			}
+			v, err := readAtomicNode(d, depth+1, count)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = v
+		}
+		if t, err = d.Token(); err != nil || t != json.Delim('}') {
+			return nil, invalid("invalid_json")
+		}
+		return out, nil
+	case '[':
+		out := []any{}
+		for d.More() {
+			v, err := readAtomicNode(d, depth+1, count)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, v)
+		}
+		if t, err = d.Token(); err != nil || t != json.Delim(']') {
+			return nil, invalid("invalid_json")
+		}
+		return out, nil
+	}
+	return nil, invalid("invalid_json")
+}

--- a/internal/feedtransfer/segments_hash.go
+++ b/internal/feedtransfer/segments_hash.go
@@ -1,0 +1,208 @@
+package feedtransfer
+
+import (
+	"io"
+	"strconv"
+	"strings"
+)
+
+func DecodeTransactionSeal(r io.Reader) (TransactionSeal, error) {
+	var v TransactionSeal
+	err := decode(r, &v, 256<<10)
+	return v, err
+}
+func DecodeTransactionSegment(r io.Reader) (TransactionSegment, error) {
+	var v TransactionSegment
+	err := decode(r, &v, MaxBatchBytes)
+	return v, err
+}
+func DecodeDurableStageReceipt(r io.Reader) (DurableStageReceipt, error) {
+	var v DurableStageReceipt
+	err := decode(r, &v, 32<<10)
+	return v, err
+}
+
+func emptyChain() string { return strings.Repeat("0", 64) }
+
+// Content charge is deliberately independent of JSON whitespace/base64:
+// UTF-8 table+key+operation bytes + image bytes + 16 for actor + 64 for beforeHash.
+// The separate wire bound and change/segment count bounds cover encoding overhead.
+func segmentChangeBytes(v SegmentChange) int64 {
+	n := int64(len(v.Row.Table) + len(v.Row.Key) + len(v.Row.Operation) + len(v.Row.Image))
+	if v.Row.Actor != nil {
+		n += 16
+	}
+	if v.BeforeHash != nil {
+		n += 64
+	}
+	return n
+}
+func appendSegmentChange(t *transcript, v SegmentChange) {
+	c := v.Row
+	t.s(c.Table)
+	t.s(c.Key)
+	t.s(c.Operation)
+	t.b(c.Actor != nil)
+	if c.Actor != nil {
+		t.n(c.Actor.GitHubID)
+		t.n(c.Actor.ProfileVersion)
+	}
+	t.b(v.BeforeHash != nil)
+	if v.BeforeHash != nil {
+		t.s(*v.BeforeHash)
+	}
+	t.n(int64(len(c.Image)))
+	t.s(imageDigest(c.Image))
+}
+
+// SegmentHash excludes SealHash to avoid a cycle: the seal commits to the last
+// segment hash. Source identity, journal and source commit boundary bind content.
+func SegmentHash(m Manifest, s TransactionSegment) (string, int64, error) {
+	if err := ValidateManifest(m); err != nil {
+		return "", 0, err
+	}
+	if err := validateSegmentRows(m, s); err != nil {
+		return "", 0, err
+	}
+	t := newTranscript("ghfind.feed.transfer.segment.v2")
+	t.identity(m.Source)
+	t.s(m.JournalID)
+	t.n(s.Version)
+	t.s(s.TransactionID)
+	t.n(s.Sequence)
+	t.s(s.PreviousCommitHash)
+	t.n(s.Index)
+	t.n(s.FirstOrdinal)
+	t.s(s.PreviousSegmentHash)
+	t.n(int64(len(s.Changes)))
+	var count int64
+	for _, c := range s.Changes {
+		appendSegmentChange(t, c)
+		count += segmentChangeBytes(c)
+	}
+	return t.sum(), count, nil
+}
+func SegmentedTransactionHash(m Manifest, s TransactionSeal) (string, error) {
+	if err := ValidateManifest(m); err != nil {
+		return "", err
+	}
+	if err := sealShape(m, s, DefaultSegmentQuota()); err != nil {
+		return "", err
+	}
+	t := newTranscript("ghfind.feed.transfer.transaction.v2")
+	t.identity(m.Source)
+	t.s(m.JournalID)
+	t.n(s.Version)
+	t.s(s.TransactionID)
+	t.n(s.Sequence)
+	t.s(s.PreviousCommitHash)
+	t.n(s.TotalChanges)
+	t.n(s.ContentBytes)
+	t.n(s.SegmentCount)
+	t.s(s.LastSegmentHash)
+	t.n(s.FloorRecords)
+	t.s(s.FloorChainHash)
+	return t.sum(), nil
+}
+func TransactionSealHash(m Manifest, s TransactionSeal) (string, error) {
+	h, err := SegmentedTransactionHash(m, s)
+	if err != nil {
+		return "", err
+	}
+	if s.TransactionHash != h {
+		return "", invalid("seg_transaction_hash")
+	}
+	t := newTranscript("ghfind.feed.transfer.seal.v2")
+	t.n(s.Version)
+	t.s(s.ManifestHash)
+	t.s(h)
+	return t.sum(), nil
+}
+func floorChain(previous string, c Change) string {
+	t := newTranscript("ghfind.feed.transfer.floor-chain.v2")
+	t.s(previous)
+	t.s(c.Table)
+	t.s(c.Key)
+	t.n(c.Actor.GitHubID)
+	t.n(c.Actor.ProfileVersion)
+	return t.sum()
+}
+func progressHash(p StageProgress) string {
+	t := newTranscript("ghfind.feed.transfer.stage-progress.v2")
+	t.s(p.SealHash)
+	t.n(p.NextSegment)
+	t.n(p.NextOrdinal)
+	t.n(p.ContentBytes)
+	t.s(p.LastSegmentHash)
+	t.b(p.LastRow != nil)
+	if p.LastRow != nil {
+		t.s(p.LastRow.Table)
+		t.s(p.LastRow.Key)
+		t.s(p.LastRow.Operation)
+	}
+	t.n(p.FloorRecords)
+	t.s(p.FloorChainHash)
+	t.b(p.Ready)
+	return t.sum()
+}
+func stageReceiptHash(r DurableStageReceipt) string {
+	t := newTranscript("ghfind.feed.transfer.stage-receipt.v2")
+	t.n(r.Version)
+	t.s(r.SealHash)
+	t.n(r.SegmentIndex)
+	t.s(r.SegmentHash)
+	t.s(r.BeforeProgressHash)
+	t.s(r.After.Hash)
+	return t.sum()
+}
+func checkpointHash(c Checkpoint) (string, error) {
+	if !digest(c.ManifestHash) || !safe(c.Sequence) || !digest(c.CommitHash) {
+		return "", invalid("seg_checkpoint")
+	}
+	fh, err := DeletionFloorsHash(c.Floors)
+	if err != nil {
+		return "", err
+	}
+	t := newTranscript("ghfind.feed.transfer.applied-checkpoint.v2")
+	t.s(c.ManifestHash)
+	t.n(c.Sequence)
+	t.s(c.CommitHash)
+	t.s(fh)
+	t.n(int64(len(c.Floors)))
+	t.b(c.Final)
+	return t.sum(), nil
+}
+
+// AtomicReceiptHash only computes integrity. Calling it cannot certify commit.
+func AtomicReceiptHash(r AtomicCommitReceipt) (string, error) {
+	if r.Version != SegmentedVersion {
+		return "", invalid("unknown_version")
+	}
+	after, err := checkpointHash(r.After)
+	if err != nil {
+		return "", err
+	}
+	t := newTranscript("ghfind.feed.transfer.atomic-receipt.v2")
+	t.n(r.Version)
+	t.s(r.Outcome)
+	t.s(r.SealHash)
+	t.s(r.StageProgressHash)
+	t.s(r.BeforeCheckpointHash)
+	t.s(r.TransactionHash)
+	t.s(r.FloorChainHash)
+	t.s(r.DecisionHash)
+	t.s(r.MapVersion)
+	t.s(r.NormalizedStateHash)
+	t.s(r.AtomicApplyID)
+	t.s(after)
+	return t.sum(), nil
+}
+func cursorFor(c Change) *ChangeCursor   { return &ChangeCursor{c.Table, c.Key, c.Operation} }
+func cursorOrder(c *ChangeCursor) string { return c.Table + "\x00" + c.Key + "\x00" + c.Operation }
+func canonicalTransactionID(m Manifest, sequence int64) string {
+	return m.JournalID + ":" + strconv.FormatInt(sequence, 10)
+}
+
+// AppliedCheckpointHash is an integrity value for future authenticated ledgers,
+// never proof that the supplied checkpoint actually committed.
+func AppliedCheckpointHash(c Checkpoint) (string, error) { return checkpointHash(c) }

--- a/internal/feedtransfer/segments_test.go
+++ b/internal/feedtransfer/segments_test.go
@@ -1,0 +1,549 @@
+package feedtransfer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func segmentedDelete(i int) SegmentChange {
+	h := strings.Repeat("d", 64)
+	return SegmentChange{Row: Change{Table: "feed_runtime_events", Key: fmt.Sprintf("synthetic-delete-%09d", i), Operation: "delete", Actor: &ActorScope{42, 5}}, BeforeHash: &h}
+}
+func segmentEnvelope(m Manifest, index, ordinal int64, previous string, changes []SegmentChange) TransactionSegment {
+	return TransactionSegment{Version: 2, TransactionID: canonicalTransactionID(m, m.FromSequence+1), Sequence: m.FromSequence + 1, PreviousCommitHash: m.AnchorHash, Index: index, FirstOrdinal: ordinal, PreviousSegmentHash: previous, Changes: changes}
+}
+func buildSeal(t *testing.T, m Manifest, chunks int, produce func(int) []SegmentChange) TransactionSeal {
+	t.Helper()
+	mh, err := ManifestHash(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := TransactionSeal{Version: 2, ManifestHash: mh, TransactionID: canonicalTransactionID(m, m.FromSequence+1), Sequence: m.FromSequence + 1, PreviousCommitHash: m.AnchorHash, SegmentCount: int64(chunks), LastSegmentHash: emptyChain(), FloorChainHash: emptyChain()}
+	for i := 0; i < chunks; i++ {
+		v := segmentEnvelope(m, int64(i), s.TotalChanges, s.LastSegmentHash, produce(i))
+		h, n, err := SegmentHash(m, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.LastSegmentHash = h
+		s.TotalChanges += int64(len(v.Changes))
+		s.ContentBytes += n
+		for _, c := range v.Changes {
+			if c.Row.Operation == "floor" {
+				s.FloorRecords++
+				s.FloorChainHash = floorChain(s.FloorChainHash, c.Row)
+			}
+		}
+	}
+	s.TransactionHash, err = SegmentedTransactionHash(m, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Hash, err = TransactionSealHash(m, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+func sealSegment(t *testing.T, m Manifest, s TransactionSeal, p StageProgress, changes []SegmentChange) TransactionSegment {
+	t.Helper()
+	v := segmentEnvelope(m, p.NextSegment, p.NextOrdinal, p.LastSegmentHash, changes)
+	v.SealHash = s.Hash
+	var err error
+	v.Hash, _, err = SegmentHash(m, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+func stageStart(t *testing.T, m Manifest, s TransactionSeal, cp Checkpoint) StageProgress {
+	t.Helper()
+	p, err := BeginStaging(m, s, cp, DefaultSegmentQuota())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+func stageNext(t *testing.T, m Manifest, s TransactionSeal, cp Checkpoint, p StageProgress, changes []SegmentChange) StagingProposal {
+	t.Helper()
+	v := sealSegment(t, m, s, p, changes)
+	out, err := ValidateSegment(m, s, cp, DefaultSegmentQuota(), p, v, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.CaptureConnected || out.DurableStorageVerified || out.PromotionReady {
+		t.Fatal("staging claimed implementation evidence")
+	}
+	return out
+}
+func fakeAtomicReceiptForProtocolTest(t *testing.T, m Manifest, s TransactionSeal, cp Checkpoint, p StageProgress, floors []Floor) AtomicCommitReceipt {
+	t.Helper()
+	before, err := checkpointHash(cp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	floorSet, err := floorMap(floors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	floors = sortedFloors(floorSet)
+	r := AtomicCommitReceipt{Version: 2, Outcome: "applied", SealHash: s.Hash, StageProgressHash: p.Hash, BeforeCheckpointHash: before, TransactionHash: s.TransactionHash, FloorChainHash: s.FloorChainHash, DecisionHash: strings.Repeat("b", 64), MapVersion: "synthetic-map-v1", NormalizedStateHash: strings.Repeat("c", 64), AtomicApplyID: "77777777-7777-4777-8777-777777777777", After: Checkpoint{ManifestHash: s.ManifestHash, Sequence: s.Sequence, CommitHash: s.TransactionHash, Floors: floors, Final: s.Sequence == m.ThroughSequence}}
+	r.Hash, err = AtomicReceiptHash(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+func floorReader(changes ...Change) func() (Change, error) {
+	i := 0
+	return func() (Change, error) {
+		if i >= len(changes) {
+			return Change{}, io.EOF
+		}
+		c := changes[i]
+		i++
+		return c, nil
+	}
+}
+
+func TestSegmented250kDeletesUseBoundedSegmentsAndDurableResume(t *testing.T) {
+	const count = 250000
+	chunks := (count + MaxChanges - 1) / MaxChanges
+	// Recomputing one chunk at a time permits two passes without retaining any
+	// transaction-wide slice or JSON tree. Only the current segment is marshaled.
+	peakChanges := 0
+	produce := func(index int) []SegmentChange {
+		start := index * MaxChanges
+		n := min(MaxChanges, count-start)
+		if n > peakChanges {
+			peakChanges = n
+		}
+		out := make([]SegmentChange, n)
+		for i := range out {
+			out[i] = segmentedDelete(start + i)
+			out[i].Row.Table = "feed.events"
+		}
+		return out
+	}
+	m := manifest(t, "postgres", 1, nil)
+	cp := begin(t, m, nil)
+	runtime.GC()
+	var initial runtime.MemStats
+	runtime.ReadMemStats(&initial)
+	s := buildSeal(t, m, chunks, produce)
+	p := stageStart(t, m, s, cp)
+	var latest DurableStageReceipt
+	maxProgressBytes := 0
+	for i := 0; i < chunks; i++ {
+		v := sealSegment(t, m, s, p, produce(i))
+		wire, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := DecodeTransactionSegment(bytes.NewReader(wire))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, err := ValidateSegment(m, s, cp, DefaultSegmentQuota(), p, decoded, nil)
+		if err != nil {
+			t.Fatalf("segment %d: %v", i, err)
+		}
+		latest = out.Receipt
+		// Simulate restart from SERIALIZED caller-persisted receipt. This is an
+		// in-test protocol model, not evidence of real DB persistence.
+		receiptBytes, _ := json.Marshal(latest)
+		r, err := DecodeDurableStageReceipt(bytes.NewReader(receiptBytes))
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, err = RestoreStaging(m, s, cp, DefaultSegmentQuota(), r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stateBytes, _ := json.Marshal(p)
+		maxProgressBytes = max(maxProgressBytes, len(stateBytes))
+		if cp.Sequence != 0 || cp.Final {
+			t.Fatal("segment advanced applied checkpoint")
+		}
+	}
+	if !p.Ready || p.NextOrdinal != count || peakChanges > MaxChanges || maxProgressBytes > 2048 {
+		t.Fatal("unbounded state or incomplete stream")
+	}
+	if _, err := ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), latest, "synthetic-map-v1", nil, nil, nil); err == nil {
+		t.Fatal("staging certified atomic apply")
+	}
+	runtime.GC()
+	var final runtime.MemStats
+	runtime.ReadMemStats(&final)
+	if final.HeapAlloc > initial.HeapAlloc+(32<<20) {
+		t.Fatalf("retained transaction-sized memory: delta=%d", final.HeapAlloc-initial.HeapAlloc)
+	}
+	t.Logf("synthetic changes=%d segments=%d max_changes=%d max_progress_bytes=%d; no database apply", count, chunks, peakChanges, maxProgressBytes)
+}
+func TestSegmentedMissingReorderedMixedAndConflictingReceipts(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	produce := func(i int) []SegmentChange { return []SegmentChange{segmentedDelete(i)} }
+	s := buildSeal(t, m, 2, produce)
+	p := stageStart(t, m, s, cp)
+	v0 := sealSegment(t, m, s, p, produce(0))
+	one := stageNext(t, m, s, cp, p, produce(0))
+	v1 := sealSegment(t, m, s, one.Progress, produce(1))
+	_, err := ValidateSegment(m, s, cp, DefaultSegmentQuota(), p, v1, nil)
+	code(t, err, "seg_order")
+	// A computed-but-unpersisted receipt is not usable against an older durable progress.
+	_, err = ValidateSegment(m, s, cp, DefaultSegmentQuota(), p, v0, &one.Receipt)
+	code(t, err, "seg_receipt_uncommitted")
+	retry, err := ValidateSegment(m, s, cp, DefaultSegmentQuota(), one.Progress, v0, &one.Receipt)
+	if err != nil || !retry.Duplicate || retry.Progress.Hash != one.Progress.Hash {
+		t.Fatal("ack lost retry", err)
+	}
+	_, err = ValidateSegment(m, s, cp, DefaultSegmentQuota(), one.Progress, v0, nil)
+	code(t, err, "seg_order")
+	changed := clone(v0)
+	changed.Changes[0].BeforeHash = new(string)
+	*changed.Changes[0].BeforeHash = strings.Repeat("e", 64)
+	changed.Hash, _, _ = SegmentHash(m, changed)
+	_, err = ValidateSegment(m, s, cp, DefaultSegmentQuota(), one.Progress, changed, &one.Receipt)
+	code(t, err, "seg_receipt_conflict")
+	cases := []struct {
+		code string
+		edit func(*TransactionSegment)
+	}{
+		{"unknown_version", func(v *TransactionSegment) { v.Version = 3 }},
+		{"seg_identity", func(v *TransactionSegment) { v.SealHash = strings.Repeat("f", 64) }},
+		{"seg_identity", func(v *TransactionSegment) { v.Sequence++ }},
+		{"seg_hash", func(v *TransactionSegment) { v.Hash = strings.Repeat("f", 64) }},
+		{"seg_before_hash", func(v *TransactionSegment) { v.Changes[0].BeforeHash = nil }},
+	}
+	for i, tt := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			v := clone(v1)
+			tt.edit(&v)
+			_, err := ValidateSegment(m, s, cp, DefaultSegmentQuota(), one.Progress, v, nil)
+			code(t, err, tt.code)
+		})
+	}
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), one.Receipt, "synthetic-map-v1", nil, nil, nil)
+	code(t, err, "seg_incomplete")
+	badProgress := clone(one.Progress)
+	badProgress.NextOrdinal++
+	_, err = ValidateSegment(m, s, cp, DefaultSegmentQuota(), badProgress, v1, nil)
+	code(t, err, "seg_progress")
+	badReceipt := clone(one.Receipt)
+	badReceipt.After.NextOrdinal++
+	_, err = RestoreStaging(m, s, cp, DefaultSegmentQuota(), badReceipt)
+	code(t, err, "seg_progress")
+}
+func TestSegmentedSealQuotaAndGlobalOrder(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	produce := func(i int) []SegmentChange { return []SegmentChange{segmentedDelete(i)} }
+	s := buildSeal(t, m, 2, produce)
+	q := DefaultSegmentQuota()
+	q.MaxChanges = 1
+	_, err := BeginStaging(m, s, cp, q)
+	code(t, err, "seg_quota")
+	q = DefaultSegmentQuota()
+	q.MaxContentBytes = s.ContentBytes - 1
+	_, err = BeginStaging(m, s, cp, q)
+	code(t, err, "seg_quota")
+	q = DefaultSegmentQuota()
+	q.MaxSegments = 1
+	_, err = BeginStaging(m, s, cp, q)
+	code(t, err, "seg_quota")
+	bad := s
+	bad.ContentBytes++
+	_, err = BeginStaging(m, bad, cp, DefaultSegmentQuota())
+	code(t, err, "seg_transaction_hash")
+	bad.TransactionHash, _ = SegmentedTransactionHash(m, bad)
+	bad.Hash, _ = TransactionSealHash(m, bad)
+	p := stageStart(t, m, bad, cp)
+	one := stageNext(t, m, bad, cp, p, produce(0))
+	v := sealSegment(t, m, bad, one.Progress, produce(1))
+	_, err = ValidateSegment(m, bad, cp, DefaultSegmentQuota(), one.Progress, v, nil)
+	code(t, err, "seg_seal_mismatch")
+	// Globally repeated/reversed keys are rejected with only one retained cursor.
+	p = stageStart(t, m, s, cp)
+	one = stageNext(t, m, s, cp, p, produce(0))
+	v = sealSegment(t, m, s, one.Progress, produce(0))
+	_, err = ValidateSegment(m, s, cp, DefaultSegmentQuota(), one.Progress, v, nil)
+	code(t, err, "seg_change_order")
+	// A structurally valid seal with a wrong terminal hash fails at completion.
+	bad = s
+	bad.LastSegmentHash = strings.Repeat("f", 64)
+	bad.TransactionHash, _ = SegmentedTransactionHash(m, bad)
+	bad.Hash, _ = TransactionSealHash(m, bad)
+	p = stageStart(t, m, bad, cp)
+	one = stageNext(t, m, bad, cp, p, produce(0))
+	v = sealSegment(t, m, bad, one.Progress, produce(1))
+	_, err = ValidateSegment(m, bad, cp, DefaultSegmentQuota(), one.Progress, v, nil)
+	code(t, err, "seg_seal_mismatch")
+}
+func TestSegmentedAtomicReceiptAndWholeTransactionFloors(t *testing.T) {
+	overlay := []Floor{{7, 3}}
+	m := manifest(t, "cf_d1_r2", 1, overlay)
+	cp := begin(t, m, overlay)
+	floor := Change{Table: "feed_profile_floors", Key: "42", Operation: "floor", Actor: &ActorScope{42, 5}}
+	chunks := [][]SegmentChange{{{Row: floor}}, {segmentedDelete(0)}}
+	s := buildSeal(t, m, 2, func(i int) []SegmentChange { return chunks[i] })
+	p := stageStart(t, m, s, cp)
+	one := stageNext(t, m, s, cp, p, chunks[0])
+	two := stageNext(t, m, s, cp, one.Progress, chunks[1])
+	row0 := sealSegment(t, m, s, p, chunks[0])
+	row1 := sealSegment(t, m, s, one.Progress, chunks[1])
+	readRows := func() func() (TransactionSegment, error) { return segmentReader(row0, row1) }
+	semantics, err := ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), floorReader(floor), readRows())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := fakeAtomicReceiptForProtocolTest(t, m, s, cp, two.Progress, []Floor{{7, 3}, {42, 5}})
+	r.DecisionHash = semantics.DecisionHash
+	r.Hash, _ = AtomicReceiptHash(r)
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &r, nil, readRows())
+	code(t, err, "staged_floors_required")
+	out, err := ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &r, floorReader(floor), readRows())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.AtomicReceiptMatched || out.Checkpoint.Sequence != 1 || out.PromotionReady || out.AtomicApplicationVerified || out.RowSchemaValidated || out.CaptureConnected {
+		t.Fatal("receipt interpretation claimed DB evidence")
+	}
+	if cp.Sequence != 0 || len(cp.Floors) != 1 {
+		t.Fatal("mutated applied checkpoint")
+	}
+	bad := r
+	bad.After = clone(r.After)
+	bad.After.Floors = []Floor{{7, 3}}
+	bad.Hash, _ = AtomicReceiptHash(bad)
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &bad, floorReader(floor), readRows())
+	code(t, err, "atomic_floor_mismatch")
+	bad = r
+	bad.Outcome = "accepted"
+	bad.Hash, _ = AtomicReceiptHash(bad)
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &bad, floorReader(floor), readRows())
+	code(t, err, "atomic_receipt")
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, "unapproved-map", &r, floorReader(floor), readRows())
+	code(t, err, "atomic_receipt")
+	changed := clone(floor)
+	changed.Actor.ProfileVersion = 4
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &r, floorReader(changed), readRows())
+	code(t, err, "staged_floor_hash")
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &r, floorReader(floor, floor), readRows())
+	code(t, err, "staged_floors_extra")
+}
+
+func segmentReader(rows ...TransactionSegment) func() (TransactionSegment, error) {
+	i := 0
+	return func() (TransactionSegment, error) {
+		if i >= len(rows) {
+			return TransactionSegment{}, io.EOF
+		}
+		v := rows[i]
+		i++
+		return v, nil
+	}
+}
+
+func TestSegmentedSemanticsRejectUnfencedErasureAndBindSuppression(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	hash := strings.Repeat("d", 64)
+	erase := SegmentChange{Row: Change{Table: "feed_user_tag_proposals", Key: "synthetic", Operation: "erase", Actor: &ActorScope{42, 5}}, BeforeHash: &hash}
+	s := buildSeal(t, m, 1, func(int) []SegmentChange { return []SegmentChange{erase} })
+	p := stageStart(t, m, s, cp)
+	seg := sealSegment(t, m, s, p, []SegmentChange{erase})
+	ready := stageNext(t, m, s, cp, p, []SegmentChange{erase})
+	r := fakeAtomicReceiptForProtocolTest(t, m, s, cp, ready.Progress, nil)
+	_, err := ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), nil, segmentReader(seg))
+	code(t, err, "tombstone_without_floor")
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), ready.Receipt, r.MapVersion, &r, nil, segmentReader(seg))
+	code(t, err, "tombstone_without_floor")
+	floor := Change{Table: "feed_profile_floors", Key: "42", Operation: "floor", Actor: &ActorScope{42, 5}}
+	chunks := [][]SegmentChange{{{Row: floor}}, {{Row: user("cf_d1_r2", 5)}}}
+	s = buildSeal(t, m, 2, func(i int) []SegmentChange { return chunks[i] })
+	p = stageStart(t, m, s, cp)
+	seg0 := sealSegment(t, m, s, p, chunks[0])
+	one := stageNext(t, m, s, cp, p, chunks[0])
+	seg1 := sealSegment(t, m, s, one.Progress, chunks[1])
+	two := stageNext(t, m, s, cp, one.Progress, chunks[1])
+	r = fakeAtomicReceiptForProtocolTest(t, m, s, cp, two.Progress, []Floor{{42, 5}})
+	sem, err := ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), floorReader(floor), segmentReader(seg0, seg1))
+	if err != nil || sem.Suppressed != 1 {
+		t.Fatal("lost v1 suppression", err)
+	}
+	_, err = ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), two.Receipt, r.MapVersion, &r, floorReader(floor), segmentReader(seg0, seg1))
+	code(t, err, "atomic_decision_mismatch")
+	_, err = ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), floorReader(floor), segmentReader(seg0))
+	code(t, err, "staged_rows_incomplete")
+	_, err = ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), floorReader(floor), segmentReader(seg0, seg1, seg1))
+	code(t, err, "staged_rows_extra")
+	altered := clone(seg1)
+	altered.Changes[0].Row.Actor.ProfileVersion = 6
+	altered.Hash, _, _ = SegmentHash(m, altered)
+	_, err = ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), floorReader(floor), segmentReader(seg0, altered))
+	code(t, err, "seg_seal_mismatch")
+}
+func TestSegmentedAtomicAckLostRestartsAtAppliedHead(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	cp := begin(t, m, nil)
+	chunks := []SegmentChange{segmentedDelete(0)}
+	s := buildSeal(t, m, 1, func(int) []SegmentChange { return chunks })
+	p := stageStart(t, m, s, cp)
+	seg := sealSegment(t, m, s, p, chunks)
+	ready := stageNext(t, m, s, cp, p, chunks)
+	sem, err := ValidateStagedSemantics(m, s, cp, DefaultSegmentQuota(), nil, segmentReader(seg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := fakeAtomicReceiptForProtocolTest(t, m, s, cp, ready.Progress, nil)
+	r.DecisionHash = sem.DecisionHash
+	r.Hash, _ = AtomicReceiptHash(r)
+	proposed, err := ProposeCheckpointAdvance(m, s, cp, DefaultSegmentQuota(), ready.Receipt, r.MapVersion, &r, nil, segmentReader(seg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This models a persisted target ledger, not a database transaction test.
+	head := AppliedHead{Checkpoint: proposed.Checkpoint, AtomicReceiptHash: proposed.AtomicReceiptHash}
+	wire, _ := json.Marshal(r)
+	loaded, err := DecodeAtomicCommitReceipt(bytes.NewReader(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	head = clone(head)
+	retry, err := ConfirmCommittedTransaction(m, s, head, loaded, r.MapVersion)
+	if err != nil || !retry.Duplicate || retry.Checkpoint.Sequence != 1 || !retry.Checkpoint.Final || retry.PromotionReady || retry.AtomicApplicationVerified {
+		t.Fatal("atomic lost ack recovery", err)
+	}
+	changed := loaded
+	changed.NormalizedStateHash = strings.Repeat("f", 64)
+	changed.Hash, _ = AtomicReceiptHash(changed)
+	_, err = ConfirmCommittedTransaction(m, s, head, changed, r.MapVersion)
+	code(t, err, "atomic_receipt_conflict")
+	rolledBack := head
+	rolledBack.Checkpoint = cp
+	_, err = ConfirmCommittedTransaction(m, s, rolledBack, loaded, r.MapVersion)
+	code(t, err, "atomic_head_mismatch")
+}
+func TestAtomicReceiptDecoderSupportsExactFloorQuota(t *testing.T) {
+	r := AtomicCommitReceipt{Version: 2, After: Checkpoint{Floors: make([]Floor, MaxFloorActors)}}
+	for i := range r.After.Floors {
+		r.After.Floors[i] = Floor{int64(i) + 1, MaxSafeInteger}
+	}
+	wire, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wire) > MaxBatchBytes {
+		t.Fatal("test receipt exceeded wire bound")
+	}
+	decoded, err := DecodeAtomicCommitReceipt(bytes.NewReader(wire))
+	if err != nil || len(decoded.After.Floors) != MaxFloorActors {
+		t.Fatal("legitimate floor quota cannot restart", err)
+	}
+	r.After.Floors = append(r.After.Floors, Floor{MaxFloorActors + 1, 1})
+	wire, _ = json.Marshal(r)
+	_, err = DecodeAtomicCommitReceipt(bytes.NewReader(wire))
+	code(t, err, "floor_limit")
+	bad := strings.Replace(string(wire), `"outcome":""`, `"outcome":"","outcome":""`, 1)
+	_, err = DecodeAtomicCommitReceipt(strings.NewReader(bad))
+	code(t, err, "duplicate_json_key")
+}
+func TestSegmentedSharedCrossLanguageFixture(t *testing.T) {
+	var f struct {
+		Synthetic     bool              `json:"synthetic"`
+		Manifest      json.RawMessage   `json:"manifest"`
+		InitialFloors []Floor           `json:"initialFloors"`
+		Seal          json.RawMessage   `json:"seal"`
+		Segments      []json.RawMessage `json:"segments"`
+		Receipts      []json.RawMessage `json:"receipts"`
+		Atomic        json.RawMessage   `json:"syntheticAtomicReceipt"`
+	}
+	wire, err := os.ReadFile("testdata/segments-v2.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Unmarshal(wire, &f); err != nil {
+		t.Fatal(err)
+	}
+	if !f.Synthetic {
+		t.Fatal("fixture must be synthetic")
+	}
+	m, err := DecodeManifest(bytes.NewReader(f.Manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seal, err := DecodeTransactionSeal(bytes.NewReader(f.Seal))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := begin(t, m, f.InitialFloors)
+	p := stageStart(t, m, seal, cp)
+	var last DurableStageReceipt
+	var segments []TransactionSegment
+	var floors []Change
+	for i, raw := range f.Segments {
+		seg, err := DecodeTransactionSegment(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, err := ValidateSegment(m, seal, cp, DefaultSegmentQuota(), p, seg, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		golden, err := DecodeDurableStageReceipt(bytes.NewReader(f.Receipts[i]))
+		if err != nil || golden.Hash != out.Receipt.Hash {
+			t.Fatal("independent stage receipt mismatch", err)
+		}
+		last = golden
+		p, err = RestoreStaging(m, seal, cp, DefaultSegmentQuota(), last)
+		if err != nil {
+			t.Fatal(err)
+		}
+		segments = append(segments, seg)
+		for _, c := range seg.Changes {
+			if c.Row.Operation == "floor" {
+				floors = append(floors, c.Row)
+			}
+		}
+	}
+	atomic, err := DecodeAtomicCommitReceipt(bytes.NewReader(f.Atomic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := ProposeCheckpointAdvance(m, seal, cp, DefaultSegmentQuota(), last, atomic.MapVersion, &atomic, floorReader(floors...), segmentReader(segments...))
+	if err != nil || !out.AtomicReceiptMatched {
+		t.Fatal("independent decision/atomic hash mismatch", err)
+	}
+	// U+E000 sorts before U+10000 by UTF-8 bytes; JS default UTF-16 sort reverses them.
+	if segments[1].Changes[0].Row.Key != "synthetic-\ue000" || segments[2].Changes[0].Row.Key != "synthetic-\U00010000" {
+		t.Fatal("fixture lost cross-runtime ordering case")
+	}
+}
+func TestFloorPairCannotCrossSegmentAndUTF8OrderIsStrict(t *testing.T) {
+	m := manifest(t, "cf_d1_r2", 1, nil)
+	floor := Change{Table: "feed_profile_floors", Key: "42", Operation: "floor", Actor: &ActorScope{42, 5}}
+	upsert := clone(floor)
+	upsert.Operation = "upsert"
+	upsert.Image = []byte(`{"github_id":42,"profile_floor":5}`)
+	before := strings.Repeat("d", 64)
+	good := segmentEnvelope(m, 0, 0, emptyChain(), []SegmentChange{{Row: floor}, {Row: upsert, BeforeHash: &before}})
+	if _, _, err := SegmentHash(m, good); err != nil {
+		t.Fatal(err)
+	}
+	split := segmentEnvelope(m, 1, 1, emptyChain(), []SegmentChange{{Row: upsert, BeforeHash: &before}})
+	_, _, err := SegmentHash(m, split)
+	code(t, err, "floor_missing")
+	first, second := segmentedDelete(0), segmentedDelete(1)
+	first.Row.Key = "\U00010000"
+	second.Row.Key = "\ue000"
+	wrong := segmentEnvelope(m, 0, 0, emptyChain(), []SegmentChange{first, second})
+	_, _, err = SegmentHash(m, wrong)
+	code(t, err, "seg_change_order")
+}

--- a/internal/feedtransfer/segments_types.go
+++ b/internal/feedtransfer/segments_types.go
@@ -1,0 +1,126 @@
+package feedtransfer
+
+// SegmentedVersion is an independent envelope. All v1 types, bytes and hashes
+// remain unchanged. This package still has no capture, staging DB or apply DB.
+const SegmentedVersion = 2
+
+// Quota is a caller-approved reservation, bounded by these protocol ceilings.
+// Limits are checked against the seal before accepting any content.
+type SegmentQuota struct {
+	MaxChanges      int64 `json:"maxChanges"`
+	MaxContentBytes int64 `json:"maxContentBytes"`
+	MaxSegments     int64 `json:"maxSegments"`
+}
+
+func DefaultSegmentQuota() SegmentQuota { return SegmentQuota{1000000, 256 << 20, 2048} }
+
+type TransactionSeal struct {
+	Version            int64  `json:"version"`
+	ManifestHash       string `json:"manifestHash"`
+	TransactionID      string `json:"transactionId"`
+	Sequence           int64  `json:"sequence"`
+	PreviousCommitHash string `json:"previousCommitHash"`
+	TotalChanges       int64  `json:"totalChanges"`
+	ContentBytes       int64  `json:"contentBytes"`
+	SegmentCount       int64  `json:"segmentCount"`
+	LastSegmentHash    string `json:"lastSegmentHash"`
+	FloorRecords       int64  `json:"floorRecords"`
+	FloorChainHash     string `json:"floorChainHash"`
+	TransactionHash    string `json:"transactionHash"`
+	Hash               string `json:"hash"`
+}
+type SegmentChange struct {
+	Row        Change  `json:"row"`
+	BeforeHash *string `json:"beforeHash"` // source row digest, null for insertion/floor metadata
+}
+type TransactionSegment struct {
+	Version             int64           `json:"version"`
+	SealHash            string          `json:"sealHash"`
+	TransactionID       string          `json:"transactionId"`
+	Sequence            int64           `json:"sequence"`
+	PreviousCommitHash  string          `json:"previousCommitHash"`
+	Index               int64           `json:"index"`
+	FirstOrdinal        int64           `json:"firstOrdinal"`
+	PreviousSegmentHash string          `json:"previousSegmentHash"`
+	Changes             []SegmentChange `json:"changes"`
+	Hash                string          `json:"hash"`
+}
+type ChangeCursor struct {
+	Table     string `json:"table"`
+	Key       string `json:"key"`
+	Operation string `json:"operation"`
+}
+
+// StageProgress contains no row images, keys inventory, or per-change tree.
+// Only the last ordering cursor is retained. It never advances a Feed commit.
+type StageProgress struct {
+	SealHash        string        `json:"sealHash"`
+	NextSegment     int64         `json:"nextSegment"`
+	NextOrdinal     int64         `json:"nextOrdinal"`
+	ContentBytes    int64         `json:"contentBytes"`
+	LastSegmentHash string        `json:"lastSegmentHash"`
+	LastRow         *ChangeCursor `json:"lastRow"`
+	FloorRecords    int64         `json:"floorRecords"`
+	FloorChainHash  string        `json:"floorChainHash"`
+	Ready           bool          `json:"ready"`
+	Hash            string        `json:"hash"`
+}
+
+// DurableStageReceipt MUST be loaded from authenticated durable staging storage.
+// Hashes authenticate no caller. A computed receipt is a persistence proposal.
+type DurableStageReceipt struct {
+	Version            int64         `json:"version"`
+	SealHash           string        `json:"sealHash"`
+	SegmentIndex       int64         `json:"segmentIndex"`
+	SegmentHash        string        `json:"segmentHash"`
+	BeforeProgressHash string        `json:"beforeProgressHash"`
+	After              StageProgress `json:"after"`
+	Hash               string        `json:"hash"`
+}
+type StagingProposal struct {
+	Progress               StageProgress
+	Receipt                DurableStageReceipt
+	Duplicate              bool
+	ContentComplete        bool
+	CaptureConnected       bool
+	DurableStorageVerified bool
+	PromotionReady         bool
+}
+
+// AtomicCommitReceipt is issued ONLY by the future target apply transaction.
+// No API here creates one. Pass only a receipt loaded from a trusted target
+// ledger, never a network client's assertion that a transaction was committed.
+type AtomicCommitReceipt struct {
+	Version              int64      `json:"version"`
+	Outcome              string     `json:"outcome"` // applied
+	SealHash             string     `json:"sealHash"`
+	StageProgressHash    string     `json:"stageProgressHash"`
+	BeforeCheckpointHash string     `json:"beforeCheckpointHash"`
+	TransactionHash      string     `json:"transactionHash"`
+	FloorChainHash       string     `json:"floorChainHash"`
+	DecisionHash         string     `json:"decisionHash"`
+	MapVersion           string     `json:"mapVersion"`
+	NormalizedStateHash  string     `json:"normalizedStateHash"`
+	AtomicApplyID        string     `json:"atomicApplyId"`
+	After                Checkpoint `json:"after"`
+	Hash                 string     `json:"hash"`
+}
+type AppliedHead struct {
+	Checkpoint        Checkpoint `json:"checkpoint"`
+	AtomicReceiptHash string     `json:"atomicReceiptHash"`
+}
+type StagedSemantics struct {
+	DecisionHash string
+	TotalChanges int64
+	Suppressed   int64
+}
+type AdvanceProposal struct {
+	AtomicReceiptHash         string
+	Duplicate                 bool
+	Checkpoint                Checkpoint
+	AtomicReceiptMatched      bool
+	CaptureConnected          bool
+	AtomicApplicationVerified bool
+	RowSchemaValidated        bool
+	PromotionReady            bool
+}

--- a/internal/feedtransfer/segments_validate.go
+++ b/internal/feedtransfer/segments_validate.go
@@ -1,0 +1,475 @@
+package feedtransfer
+
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+)
+
+func sealShape(m Manifest, s TransactionSeal, q SegmentQuota) error {
+	if s.Version != SegmentedVersion {
+		return invalid("unknown_version")
+	}
+	h, err := ManifestHash(m)
+	if err != nil {
+		return err
+	}
+	ceiling := DefaultSegmentQuota()
+	if !positive(q.MaxChanges) || q.MaxChanges > ceiling.MaxChanges || !positive(q.MaxContentBytes) || q.MaxContentBytes > ceiling.MaxContentBytes || !positive(q.MaxSegments) || q.MaxSegments > ceiling.MaxSegments {
+		return invalid("seg_quota")
+	}
+	if s.ManifestHash != h || !positive(s.Sequence) || s.Sequence <= m.FromSequence || s.Sequence > m.ThroughSequence || s.TransactionID != canonicalTransactionID(m, s.Sequence) || !digest(s.PreviousCommitHash) {
+		return invalid("seg_identity")
+	}
+	if !positive(s.TotalChanges) || s.TotalChanges > q.MaxChanges || !positive(s.ContentBytes) || s.ContentBytes > q.MaxContentBytes || !positive(s.SegmentCount) || s.SegmentCount > q.MaxSegments || s.TotalChanges < s.SegmentCount || s.TotalChanges > s.SegmentCount*MaxChanges {
+		return invalid("seg_quota")
+	}
+	if !digest(s.LastSegmentHash) || s.LastSegmentHash == emptyChain() || !safe(s.FloorRecords) || s.FloorRecords > s.TotalChanges || !digest(s.FloorChainHash) || (s.FloorRecords == 0) != (s.FloorChainHash == emptyChain()) {
+		return invalid("seg_seal_shape")
+	}
+	return nil
+}
+func validateSeal(m Manifest, s TransactionSeal, q SegmentQuota) error {
+	if err := sealShape(m, s, q); err != nil {
+		return err
+	}
+	h, err := TransactionSealHash(m, s)
+	if err != nil {
+		return err
+	}
+	if s.Hash != h {
+		return invalid("seg_seal_hash")
+	}
+	return nil
+}
+func validateSegmentRows(m Manifest, s TransactionSegment) error {
+	if s.Version != SegmentedVersion {
+		return invalid("unknown_version")
+	}
+	if !safe(s.Index) || s.Index >= DefaultSegmentQuota().MaxSegments || !safe(s.FirstOrdinal) || s.FirstOrdinal >= DefaultSegmentQuota().MaxChanges || !digest(s.PreviousSegmentHash) {
+		return invalid("seg_shape")
+	}
+	if len(s.Changes) > MaxChanges {
+		return invalid("seg_shape")
+	}
+	rows := make([]Change, len(s.Changes))
+	for i, c := range s.Changes {
+		rows[i] = c.Row
+		if c.BeforeHash != nil && !digest(*c.BeforeHash) {
+			return invalid("seg_before_hash")
+		}
+		if (c.Row.Operation == "delete" || c.Row.Operation == "erase" || c.Row.Operation == "command_tombstone") && c.BeforeHash == nil {
+			return invalid("seg_before_hash")
+		}
+		if c.Row.Operation == "floor" && c.BeforeHash != nil {
+			return invalid("seg_before_hash")
+		}
+		if i > 0 {
+			if err := nextCursor(cursorFor(s.Changes[i-1].Row), cursorFor(c.Row)); err != nil {
+				return err
+			}
+		}
+	}
+	// v1's per-transaction bound is reused as a per-segment bound. A floor and
+	// its matching tombstone after-image remain together in one segment.
+	return validateTransaction(m, Transaction{Sequence: s.Sequence, TransactionID: s.TransactionID, PreviousHash: s.PreviousCommitHash, Changes: rows})
+}
+func nextCursor(previous, next *ChangeCursor) error {
+	if previous == nil {
+		return nil
+	}
+	if cursorOrder(previous) >= cursorOrder(next) {
+		return invalid("seg_change_order")
+	}
+	if previous.Table == next.Table && previous.Key == next.Key && !(previous.Operation == "floor" && next.Operation == "upsert") {
+		return invalid("duplicate_change")
+	}
+	return nil
+}
+func validateAppliedBefore(m Manifest, s TransactionSeal, c Checkpoint) error {
+	h, err := ManifestHash(m)
+	if err != nil {
+		return err
+	}
+	if c.ManifestHash != h || !safe(c.Sequence) || c.Sequence < m.FromSequence || c.Sequence >= m.ThroughSequence || c.Sequence+1 != s.Sequence || c.CommitHash != s.PreviousCommitHash || c.Final {
+		return invalid("seg_checkpoint")
+	}
+	if _, err := floorMap(c.Floors); err != nil {
+		return err
+	}
+	if c.Sequence == m.FromSequence {
+		fh, _ := DeletionFloorsHash(c.Floors)
+		if c.CommitHash != m.AnchorHash || fh != m.DeletionFloorsSHA256 || int64(len(c.Floors)) != m.DeletionFloorActors {
+			return invalid("floor_overlay")
+		}
+	}
+	return nil
+}
+func BeginStaging(m Manifest, s TransactionSeal, c Checkpoint, q SegmentQuota) (StageProgress, error) {
+	if err := validateSeal(m, s, q); err != nil {
+		return StageProgress{}, err
+	}
+	if err := validateAppliedBefore(m, s, c); err != nil {
+		return StageProgress{}, err
+	}
+	p := StageProgress{SealHash: s.Hash, LastSegmentHash: emptyChain(), FloorChainHash: emptyChain()}
+	p.Hash = progressHash(p)
+	return p, nil
+}
+func validateProgress(m Manifest, s TransactionSeal, p StageProgress) error {
+	if p.SealHash != s.Hash || p.Hash != progressHash(p) || !safe(p.NextSegment) || p.NextSegment > s.SegmentCount || !safe(p.NextOrdinal) || p.NextOrdinal > s.TotalChanges || !safe(p.ContentBytes) || p.ContentBytes > s.ContentBytes || !digest(p.LastSegmentHash) || !safe(p.FloorRecords) || p.FloorRecords > s.FloorRecords || !digest(p.FloorChainHash) || (p.FloorRecords == 0) != (p.FloorChainHash == emptyChain()) {
+		return invalid("seg_progress")
+	}
+	if p.NextSegment == 0 {
+		if p.NextOrdinal != 0 || p.ContentBytes != 0 || p.LastSegmentHash != emptyChain() || p.LastRow != nil || p.FloorRecords != 0 || p.Ready {
+			return invalid("seg_progress")
+		}
+	} else {
+		if p.NextOrdinal < p.NextSegment || p.NextOrdinal > p.NextSegment*MaxChanges || p.ContentBytes == 0 || p.LastSegmentHash == emptyChain() || p.LastRow == nil || !clean(p.LastRow.Key, 1024) {
+			return invalid("seg_progress")
+		}
+		rule, ok := tableRule(m.Source.Profile, p.LastRow.Table)
+		if !ok || rule.Mode != "capture" {
+			return invalid("seg_progress")
+		}
+		switch p.LastRow.Operation {
+		case "upsert", "delete", "erase", "floor", "command_tombstone":
+		default:
+			return invalid("seg_progress")
+		}
+	}
+	if p.Ready != (p.NextSegment == s.SegmentCount) {
+		return invalid("seg_progress")
+	}
+	if p.Ready && (p.NextOrdinal != s.TotalChanges || p.ContentBytes != s.ContentBytes || p.LastSegmentHash != s.LastSegmentHash || p.FloorRecords != s.FloorRecords || p.FloorChainHash != s.FloorChainHash) {
+		return invalid("seg_seal_mismatch")
+	}
+	return nil
+}
+
+// RestoreStaging does not find or persist receipts. The caller must load the
+// latest receipt atomically committed with immutable segment bytes. Receipts
+// supplied by an unauthenticated client are not durable proof.
+func RestoreStaging(m Manifest, s TransactionSeal, c Checkpoint, q SegmentQuota, r DurableStageReceipt) (StageProgress, error) {
+	initial, err := BeginStaging(m, s, c, q)
+	if err != nil {
+		return StageProgress{}, err
+	}
+	if r.Version != SegmentedVersion || r.SealHash != s.Hash || !safe(r.SegmentIndex) || r.SegmentIndex+1 != r.After.NextSegment || r.SegmentHash != r.After.LastSegmentHash || !digest(r.BeforeProgressHash) || r.Hash != stageReceiptHash(r) {
+		return StageProgress{}, invalid("seg_receipt")
+	}
+	if r.SegmentIndex == 0 && r.BeforeProgressHash != initial.Hash {
+		return StageProgress{}, invalid("seg_receipt")
+	}
+	if err := validateProgress(m, s, r.After); err != nil {
+		return StageProgress{}, err
+	}
+	p := r.After
+	if p.LastRow != nil {
+		v := *p.LastRow
+		p.LastRow = &v
+	}
+	return p, nil
+}
+
+// ValidateSegment returns a proposed receipt. Persist bytes+receipt+progress in
+// one staging transaction before acknowledging. There is no applied checkpoint
+// in this result; Ready only permits preparation of a future atomic apply.
+func ValidateSegment(m Manifest, s TransactionSeal, c Checkpoint, q SegmentQuota, p StageProgress, v TransactionSegment, prior *DurableStageReceipt) (StagingProposal, error) {
+	out := StagingProposal{}
+	if _, err := BeginStaging(m, s, c, q); err != nil {
+		return out, err
+	}
+	if err := validateProgress(m, s, p); err != nil {
+		return out, err
+	}
+	if v.SealHash != s.Hash || v.TransactionID != s.TransactionID || v.Sequence != s.Sequence || v.PreviousCommitHash != s.PreviousCommitHash || v.Index >= s.SegmentCount {
+		return out, invalid("seg_identity")
+	}
+	hash, size, err := SegmentHash(m, v)
+	if err != nil {
+		return out, err
+	}
+	if v.Hash != hash {
+		return out, invalid("seg_hash")
+	}
+	wire, err := json.Marshal(v)
+	if err != nil || len(wire) > MaxBatchBytes {
+		return out, invalid("body_too_large")
+	}
+	if prior != nil {
+		r, err := RestoreStaging(m, s, c, q, *prior)
+		if err != nil {
+			return out, err
+		}
+		if prior.SegmentIndex != v.Index || prior.SegmentHash != v.Hash || r.NextOrdinal != v.FirstOrdinal+int64(len(v.Changes)) {
+			return out, invalid("seg_receipt_conflict")
+		}
+		if p.NextSegment < r.NextSegment || (p.NextSegment == r.NextSegment && p.Hash != r.Hash) {
+			return out, invalid("seg_receipt_uncommitted")
+		}
+		out.Progress = p
+		out.Receipt = *prior
+		out.Duplicate = true
+		out.ContentComplete = p.Ready
+		return out, nil
+	}
+	if p.Ready || v.Index != p.NextSegment || v.FirstOrdinal != p.NextOrdinal || v.PreviousSegmentHash != p.LastSegmentHash {
+		return out, invalid("seg_order")
+	}
+	if err := nextCursor(p.LastRow, cursorFor(v.Changes[0].Row)); err != nil {
+		return out, err
+	}
+	n := p
+	n.NextSegment++
+	n.NextOrdinal += int64(len(v.Changes))
+	n.ContentBytes += size
+	n.LastSegmentHash = v.Hash
+	n.LastRow = cursorFor(v.Changes[len(v.Changes)-1].Row)
+	for _, c := range v.Changes {
+		if c.Row.Operation == "floor" {
+			n.FloorRecords++
+			n.FloorChainHash = floorChain(n.FloorChainHash, c.Row)
+		}
+	}
+	n.Ready = n.NextSegment == s.SegmentCount
+	n.Hash = progressHash(n)
+	if err := validateProgress(m, s, n); err != nil {
+		return out, err
+	}
+	r := DurableStageReceipt{Version: SegmentedVersion, SealHash: s.Hash, SegmentIndex: v.Index, SegmentHash: v.Hash, BeforeProgressHash: p.Hash, After: n}
+	r.Hash = stageReceiptHash(r)
+	out.Progress = n
+	out.Receipt = r
+	out.ContentComplete = n.Ready
+	return out, nil
+}
+
+// ProposeCheckpointAdvance checks a caller-authenticated atomic commit receipt.
+// It cannot observe DB commit or validate row mapping, and therefore explicitly
+// leaves AtomicApplicationVerified and PromotionReady false. A staging receipt
+// alone, an omitted apply receipt, or an "accepted" outcome never advances.
+func ProposeCheckpointAdvance(m Manifest, s TransactionSeal, before Checkpoint, q SegmentQuota, stage DurableStageReceipt, expectedMapVersion string, committed *AtomicCommitReceipt, readFloor func() (Change, error), readSegments func() (TransactionSegment, error)) (AdvanceProposal, error) {
+	out := AdvanceProposal{}
+	p, err := RestoreStaging(m, s, before, q, stage)
+	if err != nil {
+		return out, err
+	}
+	if !p.Ready {
+		return out, invalid("seg_incomplete")
+	}
+	if committed == nil {
+		return out, invalid("atomic_receipt_required")
+	}
+	r := *committed
+	bh, err := checkpointHash(before)
+	if err != nil {
+		return out, err
+	}
+	if r.Version != SegmentedVersion || r.Outcome != "applied" || r.SealHash != s.Hash || r.StageProgressHash != p.Hash || r.BeforeCheckpointHash != bh || r.TransactionHash != s.TransactionHash || r.FloorChainHash != s.FloorChainHash || !clean(expectedMapVersion, 80) || r.MapVersion != expectedMapVersion || !digest(r.DecisionHash) || !digest(r.NormalizedStateHash) || !uuidPattern.MatchString(r.AtomicApplyID) {
+		return out, invalid("atomic_receipt")
+	}
+	ah, err := AtomicReceiptHash(r)
+	if err != nil {
+		return out, err
+	}
+	if r.Hash != ah {
+		return out, invalid("atomic_receipt_hash")
+	}
+	if r.After.ManifestHash != s.ManifestHash || r.After.Sequence != s.Sequence || r.After.CommitHash != s.TransactionHash || r.After.Final != (s.Sequence == m.ThroughSequence) {
+		return out, invalid("atomic_checkpoint")
+	}
+	floors, err := floorMap(r.After.Floors)
+	if err != nil {
+		return out, err
+	}
+	for _, f := range before.Floors {
+		if floors[f.GitHubID] < f.ProfileFloor {
+			return out, invalid("atomic_floor_regression")
+		}
+	}
+	expected, err := verifyStagedFloors(m, s, before, readFloor)
+	if err != nil {
+		return out, err
+	}
+	if !reflect.DeepEqual(sortedFloors(floors), expected) {
+		return out, invalid("atomic_floor_mismatch")
+	}
+	semantics, err := verifyStagedRows(m, s, before, q, expected, readSegments)
+	if err != nil {
+		return out, err
+	}
+	if r.DecisionHash != semantics.DecisionHash {
+		return out, invalid("atomic_decision_mismatch")
+	}
+	out.AtomicReceiptHash = r.Hash
+	out.Checkpoint = r.After
+	out.Checkpoint.Floors = expected
+	out.AtomicReceiptMatched = true
+	return out, nil
+}
+
+// A final pass over just the immutable staged floor records proves their entire
+// seal-bound chain before checking the receipt's merged floor set. Segments do
+// not retain these rows in memory. This separate pass has v1's MaxFloorActors cap.
+func verifyStagedFloors(m Manifest, s TransactionSeal, before Checkpoint, read func() (Change, error)) ([]Floor, error) {
+	floors, err := floorMap(before.Floors)
+	if err != nil {
+		return nil, err
+	}
+	chain := emptyChain()
+	var last *ChangeCursor
+	if s.FloorRecords > 0 && read == nil {
+		return nil, invalid("staged_floors_required")
+	}
+	for i := int64(0); i < s.FloorRecords; i++ {
+		c, err := read()
+		if err != nil {
+			return nil, invalid("staged_floors_incomplete")
+		}
+		tx := Transaction{Sequence: s.Sequence, TransactionID: s.TransactionID, PreviousHash: s.PreviousCommitHash, Changes: []Change{c}}
+		if c.Operation != "floor" || validateTransaction(m, tx) != nil {
+			return nil, invalid("staged_floor_shape")
+		}
+		if err := nextCursor(last, cursorFor(c)); err != nil {
+			return nil, err
+		}
+		last = cursorFor(c)
+		chain = floorChain(chain, c)
+		if c.Actor.ProfileVersion > floors[c.Actor.GitHubID] {
+			floors[c.Actor.GitHubID] = c.Actor.ProfileVersion
+		}
+		if len(floors) > MaxFloorActors {
+			return nil, invalid("floor_limit")
+		}
+	}
+	if read != nil {
+		if _, err := read(); err != io.EOF {
+			return nil, invalid("staged_floors_extra")
+		}
+	}
+	if chain != s.FloorChainHash {
+		return nil, invalid("staged_floor_hash")
+	}
+	return sortedFloors(floors), nil
+}
+
+// ValidateStagedSemantics independently rereads the seal-bound floors and every
+// immutable staged segment. It prepares a digest of v1's replay decisions,
+// without executing a mapper or claiming any target write has committed.
+func ValidateStagedSemantics(m Manifest, s TransactionSeal, before Checkpoint, q SegmentQuota, readFloor func() (Change, error), readSegments func() (TransactionSegment, error)) (StagedSemantics, error) {
+	if _, err := BeginStaging(m, s, before, q); err != nil {
+		return StagedSemantics{}, err
+	}
+	floors, err := verifyStagedFloors(m, s, before, readFloor)
+	if err != nil {
+		return StagedSemantics{}, err
+	}
+	return verifyStagedRows(m, s, before, q, floors, readSegments)
+}
+func verifyStagedRows(m Manifest, s TransactionSeal, before Checkpoint, q SegmentQuota, merged []Floor, read func() (TransactionSegment, error)) (StagedSemantics, error) {
+	out := StagedSemantics{}
+	if read == nil {
+		return out, invalid("staged_rows_required")
+	}
+	p, err := BeginStaging(m, s, before, q)
+	if err != nil {
+		return out, err
+	}
+	floors, err := floorMap(merged)
+	if err != nil {
+		return out, err
+	}
+	fh, _ := DeletionFloorsHash(merged)
+	t := newTranscript("ghfind.feed.transfer.decisions.v2")
+	t.s(s.Hash)
+	t.s(fh)
+	t.n(s.TotalChanges)
+	for !p.Ready {
+		segment, err := read()
+		if err != nil {
+			return StagedSemantics{}, invalid("staged_rows_incomplete")
+		}
+		next, err := ValidateSegment(m, s, before, q, p, segment, nil)
+		if err != nil {
+			return StagedSemantics{}, err
+		}
+		for _, v := range segment.Changes {
+			c := v.Row
+			action := "apply"
+			switch c.Operation {
+			case "floor":
+				action = "retain_max_floor"
+			case "erase", "command_tombstone":
+				if c.Actor.ProfileVersion > floors[c.Actor.GitHubID] {
+					return StagedSemantics{}, invalid("tombstone_without_floor")
+				}
+				if c.Operation == "erase" {
+					action = "erase"
+				} else {
+					action = "tombstone"
+				}
+			case "upsert":
+				rule, _ := tableRule(m.Source.Profile, c.Table)
+				if isAuthority(c.Table) {
+					action = "stage_control"
+				} else if isFloor(c.Table) {
+					action = "merge_floor_control"
+				} else if c.Actor != nil && c.Actor.ProfileVersion <= floors[c.Actor.GitHubID] && rule.Privacy != "control" {
+					action = "suppress_deleted_generation"
+					out.Suppressed++
+				}
+			}
+			t.n(out.TotalChanges)
+			t.s(action)
+			out.TotalChanges++
+		}
+		p = next.Progress
+	}
+	if _, err := read(); err != io.EOF {
+		return StagedSemantics{}, invalid("staged_rows_extra")
+	}
+	out.DecisionHash = t.sum()
+	return out, nil
+}
+
+// ConfirmCommittedTransaction is ONLY for lost-ack recovery of the currently
+// applied head. The caller loads head+receipt from the authenticated DB ledger.
+// No old in-memory Before checkpoint is needed. It performs no replay/advance.
+func ConfirmCommittedTransaction(m Manifest, s TransactionSeal, head AppliedHead, r AtomicCommitReceipt, expectedMapVersion string) (AdvanceProposal, error) {
+	out := AdvanceProposal{}
+	if err := validateSeal(m, s, DefaultSegmentQuota()); err != nil {
+		return out, err
+	}
+	hash, err := AtomicReceiptHash(r)
+	if err != nil {
+		return out, err
+	}
+	if r.Hash != hash || head.AtomicReceiptHash != r.Hash {
+		return out, invalid("atomic_receipt_conflict")
+	}
+	if r.Outcome != "applied" || r.SealHash != s.Hash || r.TransactionHash != s.TransactionHash || r.FloorChainHash != s.FloorChainHash || !digest(r.StageProgressHash) || !digest(r.BeforeCheckpointHash) || !digest(r.DecisionHash) || !digest(r.NormalizedStateHash) || !uuidPattern.MatchString(r.AtomicApplyID) || !clean(expectedMapVersion, 80) || r.MapVersion != expectedMapVersion {
+		return out, invalid("atomic_receipt")
+	}
+	if r.After.ManifestHash != s.ManifestHash || r.After.Sequence != s.Sequence || r.After.CommitHash != s.TransactionHash || r.After.Final != (s.Sequence == m.ThroughSequence) {
+		return out, invalid("atomic_checkpoint")
+	}
+	current, err := checkpointHash(head.Checkpoint)
+	if err != nil {
+		return out, err
+	}
+	after, err := checkpointHash(r.After)
+	if err != nil {
+		return out, err
+	}
+	if current != after {
+		return out, invalid("atomic_head_mismatch")
+	}
+	out.Checkpoint = head.Checkpoint
+	f, _ := floorMap(head.Checkpoint.Floors)
+	out.Checkpoint.Floors = sortedFloors(f)
+	out.AtomicReceiptHash = r.Hash
+	out.AtomicReceiptMatched = true
+	out.Duplicate = true
+	return out, nil
+}

--- a/internal/feedtransfer/testdata/generate_segments_fixture.py
+++ b/internal/feedtransfer/testdata/generate_segments_fixture.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Independent synthetic v2 hashes; no database/persistence evidence.
+UTF-8 byte order is explicit. Python's source values never reserialize row images.
+"""
+import base64
+import copy
+import json
+import pathlib
+import sys
+from generate_fixture import frame, digest, identity, hashes as v1_hashes
+
+PATH = pathlib.Path(__file__).with_name("segments-v2.json")
+ZERO = "0" * 64
+
+def hashed(tokens):
+    return digest(frame(tokens))
+
+def floor_digest(floors):
+    rows = sorted(floors, key=lambda f: f["githubId"])
+    return hashed(["ghfind.feed.transfer.floors.v1", len(rows),
+                   *(n for f in rows for n in (f["githubId"], f["profileFloor"]))])
+
+def progress_hash(p):
+    row = p["lastRow"]
+    return hashed(["ghfind.feed.transfer.stage-progress.v2", p["sealHash"],
+                   p["nextSegment"], p["nextOrdinal"], p["contentBytes"], p["lastSegmentHash"],
+                   int(row is not None), *([] if row is None else [row["table"], row["key"], row["operation"]]),
+                   p["floorRecords"], p["floorChainHash"], int(p["ready"])])
+
+def checkpoint_hash(c):
+    return hashed(["ghfind.feed.transfer.applied-checkpoint.v2", c["manifestHash"],
+                   c["sequence"], c["commitHash"], floor_digest(c["floors"]), len(c["floors"]), int(c["final"])])
+
+def hashes(f):
+    m = f["manifest"]
+    mh = v1_hashes({"manifest": m, "floors": f["initialFloors"], "batches": []})["manifestHash"]
+    seq = m["fromSequence"] + 1
+    txid = f'{m["journalId"]}:{seq}'
+    ordinal = content = floors = 0
+    previous = floor_chain = ZERO
+    after_floors = {r["githubId"]: r["profileFloor"] for r in f["initialFloors"]}
+    checkpoints = []
+    last_key = None
+    for i, segment in enumerate(f["segments"]):
+        segment.update(version=2, transactionId=txid, sequence=seq, previousCommitHash=m["anchorHash"],
+                       index=i, firstOrdinal=ordinal, previousSegmentHash=previous)
+        tokens = ["ghfind.feed.transfer.segment.v2", *identity(m["source"]), m["journalId"],
+                  2, txid, seq, m["anchorHash"], i, ordinal, previous, len(segment["changes"])]
+        for change in segment["changes"]:
+            row = change["row"]
+            key = tuple(row[n].encode("utf-8") for n in ("table", "key", "operation"))
+            if last_key is not None and key <= last_key:
+                raise ValueError("fixture must follow UTF-8 byte key order")
+            last_key = key
+            actor, before = row["actor"], change["beforeHash"]
+            image = b"" if row["image"] is None else base64.b64decode(row["image"], validate=True)
+            tokens += [row["table"], row["key"], row["operation"], int(actor is not None)]
+            if actor is not None:
+                tokens += [actor["githubId"], actor["profileVersion"]]
+            tokens += [int(before is not None), *([] if before is None else [before]), len(image), digest(image)]
+            content += sum(len(row[n].encode("utf-8")) for n in ("table", "key", "operation")) + len(image)
+            content += (16 if actor is not None else 0) + (64 if before is not None else 0)
+            if row["operation"] == "floor":
+                floors += 1
+                floor_chain = hashed(["ghfind.feed.transfer.floor-chain.v2", floor_chain,
+                                      row["table"], row["key"], actor["githubId"], actor["profileVersion"]])
+                after_floors[actor["githubId"]] = max(after_floors.get(actor["githubId"], 0), actor["profileVersion"])
+        ordinal += len(segment["changes"])
+        previous = segment["hash"] = hashed(tokens)
+        checkpoints.append(dict(nextSegment=i+1, nextOrdinal=ordinal, contentBytes=content,
+                                lastSegmentHash=previous, lastRow=dict(zip(("table", "key", "operation"),
+                                                                         (segment["changes"][-1]["row"][n] for n in ("table", "key", "operation")))),
+                                floorRecords=floors, floorChainHash=floor_chain, ready=i+1 == len(f["segments"])))
+    s = dict(version=2, manifestHash=mh, transactionId=txid, sequence=seq, previousCommitHash=m["anchorHash"],
+             totalChanges=ordinal, contentBytes=content, segmentCount=len(f["segments"]), lastSegmentHash=previous,
+             floorRecords=floors, floorChainHash=floor_chain)
+    s["transactionHash"] = hashed(["ghfind.feed.transfer.transaction.v2", *identity(m["source"]), m["journalId"],
+                                   2, txid, seq, m["anchorHash"], ordinal, content, len(f["segments"]), previous, floors, floor_chain])
+    s["hash"] = hashed(["ghfind.feed.transfer.seal.v2", 2, mh, s["transactionHash"]])
+    f["seal"] = s
+    p = dict(sealHash=s["hash"], nextSegment=0, nextOrdinal=0, contentBytes=0,
+             lastSegmentHash=ZERO, lastRow=None, floorRecords=0, floorChainHash=ZERO, ready=False)
+    p["hash"] = progress_hash(p)
+    f["receipts"] = []
+    for i, after in enumerate(checkpoints):
+        f["segments"][i]["sealHash"] = s["hash"]
+        after["sealHash"] = s["hash"]
+        after["hash"] = progress_hash(after)
+        receipt = dict(version=2, sealHash=s["hash"], segmentIndex=i, segmentHash=f["segments"][i]["hash"],
+                       beforeProgressHash=p["hash"], after=after)
+        receipt["hash"] = hashed(["ghfind.feed.transfer.stage-receipt.v2", 2, s["hash"], i,
+                                  receipt["segmentHash"], p["hash"], after["hash"]])
+        f["receipts"].append(receipt)
+        p = after
+    cp = dict(manifestHash=mh, sequence=m["fromSequence"], commitHash=m["anchorHash"], floors=f["initialFloors"], final=False)
+    decision_tokens = ["ghfind.feed.transfer.decisions.v2", s["hash"],
+                       floor_digest([dict(githubId=k, profileFloor=v) for k, v in after_floors.items()]), ordinal]
+    decision_ordinal = 0
+    for segment in f["segments"]:
+        for change in segment["changes"]:
+            row, action = change["row"], "apply"
+            if row["operation"] == "floor":
+                action = "retain_max_floor"
+            elif row["operation"] in ("erase", "command_tombstone"):
+                assert row["actor"]["profileVersion"] <= after_floors.get(row["actor"]["githubId"], 0)
+                action = "erase" if row["operation"] == "erase" else "tombstone"
+            elif row["operation"] == "upsert" and row["actor"] is not None:
+                if row["actor"]["profileVersion"] <= after_floors.get(row["actor"]["githubId"], 0):
+                    action = "suppress_deleted_generation"
+            decision_tokens += [decision_ordinal, action]
+            decision_ordinal += 1
+    decision_hash = hashed(decision_tokens)
+    r = dict(version=2, outcome="applied", sealHash=s["hash"], stageProgressHash=p["hash"],
+             beforeCheckpointHash=checkpoint_hash(cp), transactionHash=s["transactionHash"], floorChainHash=floor_chain,
+             decisionHash=decision_hash, mapVersion="synthetic-map-v1", normalizedStateHash="c"*64, atomicApplyId="77777777-7777-4777-8777-777777777777",
+             after=dict(manifestHash=mh, sequence=seq, commitHash=s["transactionHash"],
+                        floors=[dict(githubId=k, profileFloor=v) for k, v in sorted(after_floors.items())], final=seq==m["throughSequence"]))
+    r["hash"] = hashed(["ghfind.feed.transfer.atomic-receipt.v2", 2, r["outcome"], s["hash"], p["hash"],
+                        r["beforeCheckpointHash"], s["transactionHash"], floor_chain, decision_hash, r["mapVersion"],
+                        r["normalizedStateHash"], r["atomicApplyId"], checkpoint_hash(r["after"])])
+    f["syntheticAtomicReceipt"] = r
+    return f
+
+if __name__ == "__main__":
+    original = json.loads(PATH.read_text())
+    updated = hashes(copy.deepcopy(original))
+    if sys.argv[1:] == ["--write"]:
+        PATH.write_text(json.dumps(updated, ensure_ascii=False, indent=2)+"\n")
+    elif sys.argv[1:]:
+        raise SystemExit("usage: generate_segments_fixture.py [--write]")
+    elif updated != original:
+        raise SystemExit("v2 fixture mismatch")
+    print("synthetic v2 segment/seal/stage/atomic-receipt hashes verified; no DB apply")

--- a/internal/feedtransfer/testdata/segments-v2.json
+++ b/internal/feedtransfer/testdata/segments-v2.json
@@ -1,0 +1,523 @@
+{
+  "synthetic": true,
+  "manifest": {
+    "version": 1,
+    "stream": "feed_transaction_journal",
+    "migrationId": "11111111-1111-4111-8111-111111111111",
+    "journalId": "22222222-2222-4222-8222-222222222222",
+    "source": {
+      "profile": "cf_d1_r2",
+      "resourceId": "33333333-3333-4333-8333-333333333333",
+      "schema": 11,
+      "writerContract": 2,
+      "writerEpoch": 4,
+      "routeEpoch": 8
+    },
+    "target": {
+      "profile": "postgres",
+      "resourceId": "44444444-4444-4444-8444-444444444444",
+      "schema": 22,
+      "writerContract": 2,
+      "writerEpoch": 1,
+      "routeEpoch": 9
+    },
+    "snapshotSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "archiveInventorySha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "archiveObjects": 0,
+    "deletionFloorsSha256": "af5844e3044d83ab3a9c23f69e033d6ea24b8b5e82828fb25e4f0f127fd269f0",
+    "deletionFloorActors": 1,
+    "fromSequence": 0,
+    "throughSequence": 1,
+    "anchorHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "coverage": [
+      {
+        "table": "feed_archive_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_archive_objects",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_behavior_signals",
+        "mode": "capture",
+        "category": "derived",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_cleanup_jobs",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_cleanup_policy",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_command_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_delivery_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_delivery_heads",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_delivery_terminals",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_events",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_execution_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_execution_jobs",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_governance_commands",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_governance_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_operator_actions",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_operator_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_profile_deletions",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_profile_floors",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_project_moderation",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_project_source_versions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_project_tags",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_projection_commands",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_projects",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_proposal_guards",
+        "mode": "empty",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_rate_windows",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_replay_deliveries",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_control",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_events",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_outbox",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_requests",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_served_metadata",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_runtime_sessions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_schema_compatibility",
+        "mode": "capture",
+        "category": "control",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_served_items",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_submission_provenance",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_aliases",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_definitions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_proposal_commands",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_tag_proposals",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_taxonomy_versions",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_project_states",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_proposal_authors",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_tag_preferences",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_user_tag_proposals",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      },
+      {
+        "table": "feed_users",
+        "mode": "capture",
+        "category": "fact",
+        "snapshotRows": 0
+      }
+    ]
+  },
+  "initialFloors": [
+    {
+      "githubId": 7,
+      "profileFloor": 3
+    }
+  ],
+  "seal": {
+    "version": 2,
+    "manifestHash": "f19d5e3cc3e845031427f65c42609cc9e097cfc8007f16417313ff292d5c23fc",
+    "transactionId": "22222222-2222-4222-8222-222222222222:1",
+    "sequence": 1,
+    "previousCommitHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "totalChanges": 4,
+    "contentBytes": 398,
+    "segmentCount": 3,
+    "lastSegmentHash": "ebda38cabad12dd723aa1ed140cbaee9a9e0bf497b16b9088f9823e196e9c3ec",
+    "floorRecords": 1,
+    "floorChainHash": "097ceaa6527614bc62059854044e4b5765e76e24af5069407d6fe46366b6b01e",
+    "transactionHash": "0cfcae6a15746298821e78aae257e539e3f4a7f89d20c891629522bac31a7ec1",
+    "hash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d"
+  },
+  "segments": [
+    {
+      "changes": [
+        {
+          "row": {
+            "table": "feed_profile_floors",
+            "key": "42",
+            "operation": "floor",
+            "actor": {
+              "githubId": 42,
+              "profileVersion": 5
+            },
+            "image": null
+          },
+          "beforeHash": null
+        }
+      ],
+      "version": 2,
+      "transactionId": "22222222-2222-4222-8222-222222222222:1",
+      "sequence": 1,
+      "previousCommitHash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "index": 0,
+      "firstOrdinal": 0,
+      "previousSegmentHash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "hash": "8f2e4016a38c675acfb688b16c5dcff46768319d98af5ebb63da843dacb53d2a",
+      "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d"
+    },
+    {
+      "changes": [
+        {
+          "row": {
+            "table": "feed_runtime_events",
+            "key": "synthetic-",
+            "operation": "delete",
+            "actor": {
+              "githubId": 42,
+              "profileVersion": 5
+            },
+            "image": null
+          },
+          "beforeHash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        }
+      ],
+      "version": 2,
+      "transactionId": "22222222-2222-4222-8222-222222222222:1",
+      "sequence": 1,
+      "previousCommitHash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "index": 1,
+      "firstOrdinal": 1,
+      "previousSegmentHash": "8f2e4016a38c675acfb688b16c5dcff46768319d98af5ebb63da843dacb53d2a",
+      "hash": "3d1e7a57b12526cd476cd8c7736aca22dcf0f6c10b17649d083f2c2ac991d8c1",
+      "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d"
+    },
+    {
+      "changes": [
+        {
+          "row": {
+            "table": "feed_runtime_events",
+            "key": "synthetic-𐀀",
+            "operation": "delete",
+            "actor": {
+              "githubId": 42,
+              "profileVersion": 5
+            },
+            "image": null
+          },
+          "beforeHash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        },
+        {
+          "row": {
+            "table": "feed_users",
+            "key": "synthetic:42",
+            "operation": "upsert",
+            "actor": {
+              "githubId": 42,
+              "profileVersion": 6
+            },
+            "image": "eyJnaXRodWJfaWQiOjQyLCJwcm9maWxlX3ZlcnNpb24iOjYsImxvZ2luIjoi5ZCI5oiQIDw+Jlx1MjAyOFx1ZDgzZFx1ZGUwMCJ9"
+          },
+          "beforeHash": null
+        }
+      ],
+      "version": 2,
+      "transactionId": "22222222-2222-4222-8222-222222222222:1",
+      "sequence": 1,
+      "previousCommitHash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "index": 2,
+      "firstOrdinal": 2,
+      "previousSegmentHash": "3d1e7a57b12526cd476cd8c7736aca22dcf0f6c10b17649d083f2c2ac991d8c1",
+      "hash": "ebda38cabad12dd723aa1ed140cbaee9a9e0bf497b16b9088f9823e196e9c3ec",
+      "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d"
+    }
+  ],
+  "receipts": [
+    {
+      "version": 2,
+      "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+      "segmentIndex": 0,
+      "segmentHash": "8f2e4016a38c675acfb688b16c5dcff46768319d98af5ebb63da843dacb53d2a",
+      "beforeProgressHash": "cc38e4b49d82ac15fe4acbb44250b26ab5e053386e7a840e21c31143c536ba0f",
+      "after": {
+        "nextSegment": 1,
+        "nextOrdinal": 1,
+        "contentBytes": 42,
+        "lastSegmentHash": "8f2e4016a38c675acfb688b16c5dcff46768319d98af5ebb63da843dacb53d2a",
+        "lastRow": {
+          "table": "feed_profile_floors",
+          "key": "42",
+          "operation": "floor"
+        },
+        "floorRecords": 1,
+        "floorChainHash": "097ceaa6527614bc62059854044e4b5765e76e24af5069407d6fe46366b6b01e",
+        "ready": false,
+        "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+        "hash": "ed1acd8e8330eeab45bfe57b326827be03b1f93be38c2639fb662703782226d9"
+      },
+      "hash": "4ad541d3e37c162c37cd0e1f55013a39d3e2b6bc9b678d065e824b3952aa7441"
+    },
+    {
+      "version": 2,
+      "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+      "segmentIndex": 1,
+      "segmentHash": "3d1e7a57b12526cd476cd8c7736aca22dcf0f6c10b17649d083f2c2ac991d8c1",
+      "beforeProgressHash": "ed1acd8e8330eeab45bfe57b326827be03b1f93be38c2639fb662703782226d9",
+      "after": {
+        "nextSegment": 2,
+        "nextOrdinal": 2,
+        "contentBytes": 160,
+        "lastSegmentHash": "3d1e7a57b12526cd476cd8c7736aca22dcf0f6c10b17649d083f2c2ac991d8c1",
+        "lastRow": {
+          "table": "feed_runtime_events",
+          "key": "synthetic-",
+          "operation": "delete"
+        },
+        "floorRecords": 1,
+        "floorChainHash": "097ceaa6527614bc62059854044e4b5765e76e24af5069407d6fe46366b6b01e",
+        "ready": false,
+        "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+        "hash": "e33c17545029ca8efa4798bc54dd6c900ed4ad4437f23ca4e82be068be8dc879"
+      },
+      "hash": "57778f975b5e3da5a506cad57cda70e8c0ac980482d4b4a1e777f3274f530e9b"
+    },
+    {
+      "version": 2,
+      "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+      "segmentIndex": 2,
+      "segmentHash": "ebda38cabad12dd723aa1ed140cbaee9a9e0bf497b16b9088f9823e196e9c3ec",
+      "beforeProgressHash": "e33c17545029ca8efa4798bc54dd6c900ed4ad4437f23ca4e82be068be8dc879",
+      "after": {
+        "nextSegment": 3,
+        "nextOrdinal": 4,
+        "contentBytes": 398,
+        "lastSegmentHash": "ebda38cabad12dd723aa1ed140cbaee9a9e0bf497b16b9088f9823e196e9c3ec",
+        "lastRow": {
+          "table": "feed_users",
+          "key": "synthetic:42",
+          "operation": "upsert"
+        },
+        "floorRecords": 1,
+        "floorChainHash": "097ceaa6527614bc62059854044e4b5765e76e24af5069407d6fe46366b6b01e",
+        "ready": true,
+        "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+        "hash": "85054484d2e3d79a6106616a1904bd5309df50fe9813c84b64f260f1c7e48e24"
+      },
+      "hash": "e02013dd654042ceb1003d4267c3c9603b0e65573582c43e10a34da8062ec6ed"
+    }
+  ],
+  "syntheticAtomicReceipt": {
+    "version": 2,
+    "outcome": "applied",
+    "sealHash": "9a8dd02d5e2cb2fe1d47b3e9214fbc81a70e8f149eeb2c05c2522ae0309dfc7d",
+    "stageProgressHash": "85054484d2e3d79a6106616a1904bd5309df50fe9813c84b64f260f1c7e48e24",
+    "beforeCheckpointHash": "fdab18e48d879de68c772e0195feb26ff03b35358ba477b940a1e9bf6693e3be",
+    "transactionHash": "0cfcae6a15746298821e78aae257e539e3f4a7f89d20c891629522bac31a7ec1",
+    "floorChainHash": "097ceaa6527614bc62059854044e4b5765e76e24af5069407d6fe46366b6b01e",
+    "decisionHash": "c0a7635ff630713690a517fa874cfbc0068fb6b81df4433540d5e521e5c3baa5",
+    "mapVersion": "synthetic-map-v1",
+    "normalizedStateHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "atomicApplyId": "77777777-7777-4777-8777-777777777777",
+    "after": {
+      "manifestHash": "f19d5e3cc3e845031427f65c42609cc9e097cfc8007f16417313ff292d5c23fc",
+      "sequence": 1,
+      "commitHash": "0cfcae6a15746298821e78aae257e539e3f4a7f89d20c891629522bac31a7ec1",
+      "floors": [
+        {
+          "githubId": 7,
+          "profileFloor": 3
+        },
+        {
+          "githubId": 42,
+          "profileFloor": 5
+        }
+      ],
+      "final": true
+    },
+    "hash": "52aacd881da0e76790627ff5e538d5534c60c4c524384a625494edc20c365414"
+  }
+}


### PR DESCRIPTION
A source transaction containing a large deletion cascade cannot fit the v1 whole-transaction transport bound. V2 adds sealed, bounded segments while keeping staging progress separate from the applied database checkpoint. The original v1 files and hashes remain unchanged.

Segments verify total quotas, chain hashes, UTF-8 key order, replay identity and durable-receipt retry semantics. Final validation independently rereads the complete floor and row streams, preserves deletion-generation suppression, and binds the decision digest to the caller's trusted atomic receipt. Lost commit acknowledgements can confirm the exact persisted applied head without replay. Hash integrity never substitutes for authenticated storage or proof of an actual database commit.

Validation: 250,000 synthetic image-free deletions across 489 serialized segments, at most 512 changes per segment and 506-byte staging progress; full package race tests, vet, and independent Python v1/v2 fixtures passed. Regressions cover incomplete/reordered/conflicting segments, erased-generation replay, atomic acknowledgement loss, and the full 100,000-floor receipt quota.

This is protocol preparation only: no source capture, target mapper, migrations, remote resources or production routing. Real cascade/SET NULL capture, PostgreSQL-to-D1 nullable-field mapping, target atomic application and promotion remain explicit acceptance gates. Results keep implementation-evidence and promotion flags false.
