### PR TITLE
docs(evidence): preserve historical runtime release readback

### DIFF
--- a/docs/evidence/feed-production-b47b2ee/README.md
+++ b/docs/evidence/feed-production-b47b2ee/README.md
@@ -1,0 +1,20 @@
+# Production readback after the runtime foundation merge
+
+At `2026-09-08T05:11:17Z`, authenticated Cloudflare readback reports production
+Worker `ghfind` version `156609fa-d14c-40c8-aec2-8170f9e66dca` at 100%. Its release
+annotation names exact main SHA `b47b2ee4ab94fb2f833a3d613886ea41524c03bd`, matching
+[the successful production workflow](https://github.com/hikariming/ghfind/actions/runs/34187756377).
+The raw response is reduced to deployment identities, release annotations,
+database bindings and a fixed allowlist of Feed routing flags in `readback.json`.
+No secret values or account contact details are retained.
+
+Core and Feed still bind their existing production D1 databases. No selected
+Feed routing flag was present as a plain-text binding. Combined with the merged
+source defaults, this establishes the existing runtime remains the default;
+it is not authenticated Feed E2E evidence. The independent staging runtime,
+new remote Feed migrations, source outbox and production Go traffic have not
+been enabled by this readback or by merging the runtime foundation.
+
+Wrangler refreshed its existing OAuth session before these reads. Read access
+to the Beiming account works; this does not create the separate Actions token
+or prove that the protected operational environment has been configured.

--- a/docs/evidence/feed-production-b47b2ee/README.md
+++ b/docs/evidence/feed-production-b47b2ee/README.md
@@ -9,12 +9,18 @@ database bindings and a fixed allowlist of Feed routing flags in `readback.json`
 No secret values or account contact details are retained.
 
 Core and Feed still bind their existing production D1 databases. No selected
-Feed routing flag was present as a plain-text binding. Combined with the merged
-source defaults, this establishes the existing runtime remains the default;
-it is not authenticated Feed E2E evidence. The independent staging runtime,
-new remote Feed migrations, source outbox and production Go traffic have not
-been enabled by this readback or by merging the runtime foundation.
+Feed routing flag was present in the retained plain-text binding subset. This
+record alone does not rule out other binding types and cannot prove the effective
+runtime selection. The later [0ca5301 readback](../feed-production-0ca5301/README.md)
+checks those flags across all binding types; neither observation is authenticated
+Feed E2E evidence. No independent staging runtime, new remote Feed migration or
+production Go traffic acceptance is established by this historical record.
 
 Wrangler refreshed its existing OAuth session before these reads. Read access
 to the Beiming account works; this does not create the separate Actions token
 or prove that the protected operational environment has been configured.
+
+The original JSON was committed on the integration branch as `7f44274` before
+being included in a main PR. It is retained byte-for-byte. This document's
+interpretation was narrowed when the delayed inclusion was reviewed; its
+September 8 05:11 UTC observation does not describe the current active version.

--- a/docs/evidence/feed-production-b47b2ee/readback.json
+++ b/docs/evidence/feed-production-b47b2ee/readback.json
@@ -1,0 +1,71 @@
+{
+  "observedAt": "2026-09-08T05:11:17.166901+00:00",
+  "worker": "ghfind",
+  "settings": {
+    "allowedFlags": [],
+    "databases": [
+      {
+        "database_id": "60d45096-bfe7-4de1-8b85-c1b66a466b0d",
+        "id": "60d45096-bfe7-4de1-8b85-c1b66a466b0d",
+        "name": "GHFIND_D1",
+        "type": "d1"
+      },
+      {
+        "database_id": "9c4ac13a-4c90-40a8-9d56-d7141f864bbf",
+        "id": "9c4ac13a-4c90-40a8-9d56-d7141f864bbf",
+        "name": "GHFIND_FEED_D1",
+        "type": "d1"
+      }
+    ]
+  },
+  "deployments": [
+    {
+      "id": "1194d70d-b745-454a-9478-96a60e3c6295",
+      "source": "wrangler",
+      "strategy": "percentage",
+      "annotations": {
+        "workers/message": "release-b47b2ee4ab94fb2f833a3d613886ea41524c03bd-from-upstream-main",
+        "workers/triggered_by": "deployment"
+      },
+      "versions": [
+        {
+          "version_id": "156609fa-d14c-40c8-aec2-8170f9e66dca",
+          "percentage": 100
+        }
+      ],
+      "created_on": "2026-09-08T04:41:11.031789Z"
+    },
+    {
+      "id": "f591958b-f96f-42c2-8f86-875ae2f125fc",
+      "source": "wrangler",
+      "strategy": "percentage",
+      "annotations": {
+        "workers/message": "release-3cdb66cc21028e1b7159ce30f769ff8fcd9b4d33-from-upstream-main",
+        "workers/triggered_by": "deployment"
+      },
+      "versions": [
+        {
+          "version_id": "7d4e2070-b1f5-4b07-9498-6a78c8e48762",
+          "percentage": 100
+        }
+      ],
+      "created_on": "2026-09-08T03:56:11.790202Z"
+    },
+    {
+      "id": "4a99cff1-801f-4ccd-ba2f-1372c3eba621",
+      "source": "wrangler",
+      "strategy": "percentage",
+      "annotations": {
+        "workers/message": "release-38985cc0bcb811801f427e162bce3dd04ed062ee-from-upstream-main",
+        "workers/triggered_by": "deployment"
+      },
+      "versions": [
+        {
+          "version_id": "97f10c42-cb76-46f8-93e3-abf70a9951fc",
+          "percentage": 100
+        }
+      ],
+      "created_on": "2026-09-08T02:35:15.542487Z"
+    }
+  ]
+}


### PR DESCRIPTION
Preserve the two historical Cloudflare readback files that remained only on the integration branch after the runtime foundation merge. The observation is dated 2026-09-08 05:11 UTC and matches production workflow 34187756377 at `b47b2ee4ab94fb2f833a3d613886ea41524c03bd`; it does not describe today's active version.

The original reduced JSON is byte-identical to integration commit `7f44274` (SHA-256 `9e26bca8cce7ca1175c974ee1164349a8411645755fb0bd93dd2e360a6b73d0a`). Narrow the accompanying interpretation: this older record retained only plain-text routing flags, so it cannot rule out other binding types or independently prove runtime selection. Link the later all-binding-type readback separately.

Validation: exact original-byte comparison, observation/release/database identity checks, and `git diff --check`. No runtime, schema, credentials, resource or traffic changes. Full CI is required before the previously authorized merge bypass.
