### PR TITLE
fix(routes): stop 500ing on malformed percent-escapes in route params

### DIFF
--- a/src/app/[locale]/developers/[type]/[...value]/page.tsx
+++ b/src/app/[locale]/developers/[type]/[...value]/page.tsx
@@ -32,6 +32,7 @@ import { TIER_KEY } from "@/lib/tier";
 import type { Tier } from "@/lib/types";
 import { localeAlternates, localePath } from "@/lib/site";
 import { JsonLd, breadcrumbJsonLd } from "@/components/JsonLd";
+import { decodeRouteParam } from "@/lib/route-params";
 
 // Keep this long-tail route out of ISR. The URL space is ~10k buckets × 9
 // locales, and verified crawlers overwhelmingly request each URL only once.
@@ -56,7 +57,7 @@ function parseFacetType(raw: string): FacetType | null {
  *  language/org are single-segment. Each segment is decoded, then rejoined with
  *  "/" so it matches the stored `facet_value` exactly. */
 function facetValueFromSegments(segments: string[] | undefined): string {
-  return (segments ?? []).map((s) => decodeURIComponent(s)).join("/");
+  return (segments ?? []).map((s) => decodeRouteParam(s)).join("/");
 }
 
 type BucketHeadingKey =

--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -52,6 +52,7 @@ import {
   resolveProfileArtifactState,
   shouldStartProfileRoast,
 } from "./ProfileArtifactStatus";
+import { decodeRouteParam } from "@/lib/route-params";
 
 /** True when a Referer header points at github.com (or a subdomain). GitHub sends
  *  `strict-origin-when-cross-origin`, so we only ever see the bare origin — enough
@@ -115,7 +116,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale, username } = await params;
   const t = await getTranslations({ locale, namespace: "detailMeta" });
-  const decoded = decodeURIComponent(username);
+  const decoded = decodeRouteParam(username);
   const d = (await getProfile(decoded))?.detail ?? null;
   if (!d) {
     // No persisted row yet. A cached scan or the `?roasting=1` handoff marker
@@ -186,7 +187,7 @@ export default async function AccountPage({
   setRequestLocale(locale);
   const query = await searchParams;
   const isAdvxCampaign = query.campaign === "advx";
-  const decoded = decodeURIComponent(username);
+  const decoded = decodeRouteParam(username);
   const presentation = await getProfile(decoded);
   const d = presentation?.detail ?? null;
   if (!d) {

--- a/src/app/[locale]/vs/[a]/[b]/page.tsx
+++ b/src/app/[locale]/vs/[a]/[b]/page.tsx
@@ -16,6 +16,7 @@ import { VsPlayerCard } from "@/components/VsPlayerCard";
 import { VsSummonButton } from "@/components/VsSummonButton";
 import { VsVerdictLive } from "@/components/VsVerdictLive";
 import { VsShare } from "@/components/VsShare";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const dynamic = "force-dynamic";
 
@@ -31,8 +32,8 @@ function localeSide(line: RoastLine | null | undefined, locale: string): string 
 /** Normalize + canonicalize (lowercased, dictionary order) a /vs pair, or null
  *  if either handle is invalid. */
 function canonicalize(a: string, b: string): { a: string; b: string } | null {
-  const na = normalizeUsername(decodeURIComponent(a));
-  const nb = normalizeUsername(decodeURIComponent(b));
+  const na = normalizeUsername(decodeRouteParam(a));
+  const nb = normalizeUsername(decodeRouteParam(b));
   if (!na || !nb) return null;
   const [x, y] = [na.toLowerCase(), nb.toLowerCase()].sort();
   return { a: x, b: y };
@@ -87,7 +88,7 @@ export default async function VsPage({
 
   // Redirect any non-canonical spelling (case / order) to the canonical slug so
   // /vs/b/a and /vs/A/B consolidate to one URL (and one OG image / cache entry).
-  if (decodeURIComponent(a) !== pair.a || decodeURIComponent(b) !== pair.b) {
+  if (decodeRouteParam(a) !== pair.a || decodeRouteParam(b) !== pair.b) {
     redirect({ href: `/vs/${pair.a}/${pair.b}`, locale });
   }
 

--- a/src/app/api/badge/[username]/route.ts
+++ b/src/app/api/badge/[username]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { getScoreBrief, getWeeklyBaselines, resolveWeeklyDelta } from "@/lib/db";
 import { buildBadge, type BadgeLang } from "@/lib/badge";
 import { USERNAME_RE } from "@/lib/username";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -29,7 +30,7 @@ export async function GET(
   const lang: BadgeLang =
     req.nextUrl.searchParams.get("lang") === "zh" ? "zh" : "en";
 
-  const name = decodeURIComponent(username ?? "").trim();
+  const name = decodeRouteParam(username ?? "").trim();
   if (!USERNAME_RE.test(name)) {
     return svg(buildBadge({ score: null, tier: null, lang }), UNRATED_CACHE);
   }

--- a/src/app/api/blog-comments/[slug]/route.ts
+++ b/src/app/api/blog-comments/[slug]/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/comments";
 import { getPost } from "@/lib/blog";
 import { createBlogComment, getBlogComments } from "@/lib/db";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -30,7 +31,7 @@ function jsonNoStore(body: unknown, init?: ResponseInit) {
 
 function postSlugFromParam(value: string | undefined): string | null {
   try {
-    const slug = normalizeBlogSlug(decodeURIComponent(value ?? ""));
+    const slug = normalizeBlogSlug(decodeRouteParam(value ?? ""));
     return slug && getPost(slug, "en") ? slug : null;
   } catch {
     return null;

--- a/src/app/api/card/[username]/route.tsx
+++ b/src/app/api/card/[username]/route.tsx
@@ -18,6 +18,7 @@ import {
 } from "./cards";
 import type { Identity } from "./cards";
 import { avatarDataUrl, fonts, png, qrDataUrl, qrModuleColor } from "../shared";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -27,7 +28,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ username: strin
   const theme = parseTheme(req);
   const palette = PALETTES[theme];
   const { username } = await ctx.params;
-  const name = decodeURIComponent(username ?? "").trim();
+  const name = decodeRouteParam(username ?? "").trim();
 
   // Satori rasterizes this away, so the full-size mark costs the response nothing.
   const sponsorLogo = await sponsorLogoDataUrl();

--- a/src/app/api/card/mini/[username]/route.ts
+++ b/src/app/api/card/mini/[username]/route.ts
@@ -29,6 +29,7 @@ import { tierFor } from "@/lib/score-presentation";
 import { sponsorLogoDataUrl } from "@/lib/sponsor.server";
 import { publicDisplayName, USERNAME_RE } from "@/lib/username";
 import { avatarDataUrl, CDN_CACHE } from "../../shared";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -61,7 +62,7 @@ export async function GET(
   const theme = parseMiniCardTheme(params.get("theme"));
   const lang = parseMiniCardLang(params.get("lang"));
 
-  const name = decodeURIComponent(username ?? "").trim();
+  const name = decodeRouteParam(username ?? "").trim();
   const presentation = USERNAME_RE.test(name) ? await getGoProfilePresentation(name) : null;
   const detail = presentation?.detail ?? null;
   if (!detail) {

--- a/src/app/api/card/vs/[a]/[b]/route.tsx
+++ b/src/app/api/card/vs/[a]/[b]/route.tsx
@@ -10,6 +10,7 @@ import { getGoVsPresentation } from "@/lib/go-profile.server";
 import { Brand, OgAvatarFrame, PALETTES, Shell, parseQr, parseTheme } from "../../../[username]/cards";
 import type { CardPalette } from "../../../[username]/cards";
 import { avatarDataUrl, fonts, png, qrDataUrl, qrModuleColor } from "../../../shared";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -103,10 +104,10 @@ export async function GET(
   const url = new URL(req.url);
   const locale = url.searchParams.get("lang") === "zh" ? "zh" : "en";
 
-  const na = normalizeUsername(decodeURIComponent(rawA ?? ""));
-  const nb = normalizeUsername(decodeURIComponent(rawB ?? ""));
-  const a = (na ?? decodeURIComponent(rawA ?? "")).toLowerCase();
-  const b = (nb ?? decodeURIComponent(rawB ?? "")).toLowerCase();
+  const na = normalizeUsername(decodeRouteParam(rawA ?? ""));
+  const nb = normalizeUsername(decodeRouteParam(rawB ?? ""));
+  const a = (na ?? decodeRouteParam(rawA ?? "")).toLowerCase();
+  const b = (nb ?? decodeRouteParam(rawB ?? "")).toLowerCase();
 
   const presentation = na && nb ? await getGoVsPresentation(a, b) : null;
   const da = presentation?.a ?? null;

--- a/src/app/api/collection-comments/[slug]/route.ts
+++ b/src/app/api/collection-comments/[slug]/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/comments";
 import { getCollection } from "@/lib/collections";
 import { createCollectionComment, getCollectionComments } from "@/lib/db";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -30,7 +31,7 @@ function jsonNoStore(body: unknown, init?: ResponseInit) {
 
 function collectionSlugFromParam(value: string | undefined): string | null {
   try {
-    const slug = normalizeBlogSlug(decodeURIComponent(value ?? ""));
+    const slug = normalizeBlogSlug(decodeRouteParam(value ?? ""));
     return slug && getCollection(slug) ? slug : null;
   } catch {
     return null;

--- a/src/app/api/facet-rank/[username]/route.ts
+++ b/src/app/api/facet-rank/[username]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFacetRank, getScoreBrief } from "@/lib/db";
 import { checkRateLimit, rateLimitHeaders } from "@/lib/redis";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -37,7 +38,7 @@ export async function GET(
   }
 
   const { username } = await params;
-  const decoded = decodeURIComponent(username);
+  const decoded = decodeRouteParam(username);
   const brief = await getScoreBrief(decoded);
   if (!brief) {
     return NextResponse.json({ facetRank: null }, { headers: { "Cache-Control": CACHE_CONTROL } });

--- a/src/app/api/feed/projects/[owner]/[repo]/state/route.ts
+++ b/src/app/api/feed/projects/[owner]/[repo]/state/route.ts
@@ -1,6 +1,7 @@
 import { forwardFeedRequest } from "@/lib/feed-gateway";
 import { feedErrorResponse, feedJson, feedJsonBody, isFeedResponse, requireFeedViewer } from "@/lib/feed-api";
 import { FeedError, updateFeedProjectState } from "@/lib/feed";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -19,7 +20,7 @@ export async function PUT(
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       throw new FeedError("invalid_state_patch", 400, "Expected a project state object.");
     }
-    return feedJson(await updateFeedProjectState(viewer, `${decodeURIComponent(owner)}/${decodeURIComponent(repo)}`, body as Record<string, unknown>));
+    return feedJson(await updateFeedProjectState(viewer, `${decodeRouteParam(owner)}/${decodeRouteParam(repo)}`, body as Record<string, unknown>));
   } catch (error) {
     return feedErrorResponse(error);
   }

--- a/src/app/api/follows/[username]/route.ts
+++ b/src/app/api/follows/[username]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth, authConfigured } from "../../../../lib/auth";
 import { normalizeGitHubUsername } from "../../../../lib/comments";
 import { isFollowing, removeFollow, setFollow } from "../../../../lib/db";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -31,7 +32,7 @@ export async function GET(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) return jsonNoStore({ error: "invalid_username" }, { status: 400 });
 
   const viewer = await authenticatedViewer();
@@ -47,7 +48,7 @@ export async function PUT(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) return jsonNoStore({ error: "invalid_username" }, { status: 400 });
 
   const viewer = await authenticatedViewer();
@@ -70,7 +71,7 @@ export async function DELETE(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) return jsonNoStore({ error: "invalid_username" }, { status: 400 });
 
   const viewer = await authenticatedViewer();

--- a/src/app/api/material-card/[username]/route.tsx
+++ b/src/app/api/material-card/[username]/route.tsx
@@ -8,13 +8,14 @@ import { tierAvatarFrameIconDataUrl } from "@/lib/tier-emoji.server";
 import { publicDisplayName, USERNAME_RE } from "@/lib/username";
 import { avatarDataUrl, CDN_CACHE, qrDataUrl, qrModuleColor } from "../../card/shared";
 import { parseTheme } from "../../card/[username]/cards";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request, ctx: { params: Promise<{ username: string }> }) {
   const { username } = await ctx.params;
-  const name = decodeURIComponent(username ?? "").trim();
+  const name = decodeRouteParam(username ?? "").trim();
   const detail = USERNAME_RE.test(name)
     ? (await getGoProfilePresentation(name))?.detail ?? null
     : null;

--- a/src/app/api/profile-comments/[username]/route.ts
+++ b/src/app/api/profile-comments/[username]/route.ts
@@ -8,6 +8,7 @@ import {
   type ProfileCommentsResponse,
 } from "../../../../lib/comments";
 import { createProfileComment, getProfileComments } from "../../../../lib/db";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -31,7 +32,7 @@ export async function GET(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) {
     return jsonNoStore({ error: "invalid_username" }, { status: 400 });
   }
@@ -45,7 +46,7 @@ export async function POST(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) {
     return jsonNoStore({ error: "invalid_username" }, { status: 400 });
   }

--- a/src/app/api/profile-reactions/[username]/route.ts
+++ b/src/app/api/profile-reactions/[username]/route.ts
@@ -7,6 +7,7 @@ import {
   setProfileReaction,
 } from "../../../../lib/db";
 import { isProfileReaction } from "../../../../lib/reactions";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -49,7 +50,7 @@ export async function PUT(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) return jsonNoStore({ error: "invalid_username" }, { status: 400 });
 
   const viewer = await authenticatedViewer();
@@ -81,7 +82,7 @@ export async function DELETE(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const target = normalizeGitHubUsername(decodeURIComponent(username ?? ""));
+  const target = normalizeGitHubUsername(decodeRouteParam(username ?? ""));
   if (!target) return jsonNoStore({ error: "invalid_username" }, { status: 400 });
 
   const viewer = await authenticatedViewer();

--- a/src/app/api/score/[username]/route.ts
+++ b/src/app/api/score/[username]/route.ts
@@ -21,6 +21,7 @@ import { SCORE_CACHE_VERSION } from "@/lib/cache-version";
 import { PUBLIC_SCAN_COLLECTION_VERSION } from "@/lib/scan-run-types";
 import { roundHalfEven } from "@/lib/score";
 import type { ScanResult, Tier } from "@/lib/types";
+import { decodeRouteParam } from "@/lib/route-params";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -172,7 +173,7 @@ export async function GET(
   ctx: { params: Promise<{ username: string }> },
 ) {
   const { username } = await ctx.params;
-  const handle = normalizeUsername(decodeURIComponent(username ?? ""));
+  const handle = normalizeUsername(decodeRouteParam(username ?? ""));
   if (!handle) {
     return json(
       {

--- a/src/lib/__tests__/route-params.test.ts
+++ b/src/lib/__tests__/route-params.test.ts
@@ -1,0 +1,53 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { decodeRouteParam } from "../route-params";
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir).sort()) {
+    const file = path.join(dir, entry);
+    if (statSync(file).isDirectory()) {
+      files.push(...collectSourceFiles(file));
+      continue;
+    }
+    if (/\.tsx?$/.test(file)) files.push(file);
+  }
+  return files.map((file) => file.split(path.sep).join("/"));
+}
+
+describe("decodeRouteParam", () => {
+  it("decodes well-formed escapes exactly like decodeURIComponent", () => {
+    for (const raw of ["torvalds", "%74orvalds", "a%2Fb", "%E4%B8%AD%E6%96%87", "Rust"]) {
+      expect(decodeRouteParam(raw)).toBe(decodeURIComponent(raw));
+    }
+  });
+
+  it("returns the raw segment for a malformed escape instead of throwing", () => {
+    // Next already decodes params, so `/api/badge/%25` reaches the route as "%".
+    // decodeURIComponent throws URIError on those, which turned a bad handle
+    // into a 500 on every param-decoding route.
+    for (const raw of ["%", "%zz", "50%", "%E0%A4%A", "torvalds%"]) {
+      expect(() => decodeURIComponent(raw)).toThrow();
+      expect(decodeRouteParam(raw)).toBe(raw);
+    }
+  });
+
+  it("treats missing segments as empty", () => {
+    expect(decodeRouteParam(undefined)).toBe("");
+    expect(decodeRouteParam(null)).toBe("");
+    expect(decodeRouteParam("")).toBe("");
+  });
+});
+
+describe("route param decoding discipline", () => {
+  it("never calls decodeURIComponent directly on a route segment", () => {
+    const offenders = collectSourceFiles("src/app").filter((file) =>
+      readFileSync(file, "utf8").includes("decodeURIComponent("),
+    );
+    expect(
+      offenders,
+      `use decodeRouteParam from @/lib/route-params instead: ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/lib/route-params.ts
+++ b/src/lib/route-params.ts
@@ -1,0 +1,19 @@
+/**
+ * Safe decoding for dynamic route segments.
+ *
+ * Next.js already percent-decodes `params`, so a segment can legitimately still
+ * contain a literal `%` (e.g. `/api/badge/%25` arrives as `"%"`). Calling
+ * `decodeURIComponent` on that throws `URIError`, which surfaces as a 500 from
+ * routes whose whole point is to answer with a 400/404/placeholder for input
+ * they don't recognise. Decoding through this helper keeps the existing lenient
+ * behaviour for well-formed input and degrades to the raw segment instead of
+ * crashing on a malformed escape.
+ */
+export function decodeRouteParam(value: string | null | undefined): string {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
Next.js already percent-decodes dynamic route segments, so a segment can legitimately still contain a literal `%` — `/api/badge/%25` reaches the handler as `"%"`.

Every route that calls `decodeURIComponent(param)` a second time throws `URIError` on that input, and nothing catches it, so the request ends as a 500 — on routes whose job is to answer with an unrated badge, a 400, or a 404.

Reproducible against production right now:

```bash
curl -s -o /dev/null -w '%{http_code}\n' https://ghfind.com/api/badge/%25   # 500
curl -s -o /dev/null -w '%{http_code}\n' https://ghfind.com/api/score/%25   # 500
```

Eleven routes are affected: the badge, score, card, mini-card, material-card, facet-rank, profile-comments and vs-card APIs, plus `/en/u/`, `/en/vs/` and `/en/developers/language/`.

Anything walking the URL space hits these — crawlers replaying mangled links, README badges with a stray `%` — and each one costs a 500 rather than a clean rejection.

## Fix

Adds `src/lib/route-params.ts` with `decodeRouteParam()`: `decodeURIComponent` for well-formed input, the raw segment on `URIError`.

All 24 param decodes in `src/app` go through it, so each route reaches its own validation (`USERNAME_RE`, `normalizeUsername`, `getPost`) and answers as designed.

Behaviour for valid input is unchanged; only the throwing path moves from 500 to the route's intended response.

## Tests

`src/lib/__tests__/route-params.test.ts` covers well-formed escapes, the raw-segment fallback for `%`, `%zz`, `50%`, `%E0%A4%A` and `torvalds%` (asserting `decodeURIComponent` really throws on each), and a missing segment.

It also adds a discipline check that no file under `src/app` calls `decodeURIComponent` directly, so a new route can't reintroduce the crash.

`pnpm typecheck` and `pnpm lint` are clean, and `pnpm test` matches `main` plus the 4 new tests — the pre-existing `feed-source-*` failures are Windows-only sqlite file-lock issues.

## Not fixed here

The double decode is itself observable: `/api/score/%2574orvalds` resolves to `torvalds`, and `GET /api/profile-reactions/[username]` already avoids this by reading `(await params).username` directly.

Dropping the second decode everywhere looks right, but it changes which URLs resolve, so I kept this PR to the crash.
