### PR TITLE
fix(mosoo): align project assessment with current thread identity contract

### DIFF
--- a/scripts/feed-e2e/provider-fixtures.mjs
+++ b/scripts/feed-e2e/provider-fixtures.mjs
@@ -134,12 +134,25 @@ export function installProviders() {
       const path = url.pathname.replace(/^\/api\/v1/, "");
       if (path === "/agents/local-e2e-agent/threads" && request.method === "POST") {
         const body = await request.json();
-        const prompt = body.input?.content?.[0]?.text ?? "";
+        const prompt = body?.input?.content?.[0]?.text ?? "";
         const repo = /^repository_url: https:\/\/github.com\/([a-z0-9-]+\/[a-z0-9-]+)$/m.exec(prompt)?.[1];
-        if (!repo || !body.client_external_ref) throw new Error("invalid_fixture_assessment_request");
-        runs.set(body.client_external_ref, { repo, files: artifacts(body.client_external_ref, repo) });
+        const analysisId = /^analysis_id: ([A-Za-z0-9-]+)$/m.exec(prompt)?.[1];
+        // Model the current Public Thread API, so an obsolete request cannot
+        // make the complete local journey pass while failing against Mosoo.
+        if (!body || typeof body !== "object" || Array.isArray(body) ||
+            Object.keys(body).some(key => !["userId", "input"].includes(key)) ||
+            typeof body.userId !== "string" || !body.userId.trim() || body.userId.length > 255 ||
+            body.input?.type !== "user.message" || Object.keys(body.input).some(key => !["type", "content"].includes(key)) ||
+            !Array.isArray(body.input.content) || body.input.content.length !== 1 ||
+            body.input.content[0]?.type !== "text" ||
+            Object.keys(body.input.content[0]).some(key => !["type", "text"].includes(key)) ||
+            typeof prompt !== "string" || !prompt || prompt.length > 32_000 ||
+            !repo || !analysisId || !request.headers.get("Idempotency-Key")) {
+          return Response.json({ error: { code: "invalid_request", message: "Invalid fixture assessment request." } }, { status: 400 });
+        }
+        runs.set(analysisId, { repo, userId: body.userId, files: artifacts(analysisId, repo) });
         counts.assessmentCreate++;
-        return Response.json(thread(body.client_external_ref));
+        return Response.json(thread(analysisId));
       }
       const match = /^\/threads\/([^/]+)(?:\/(events|files))?$/.exec(path);
       if (match && runs.has(match[1])) {
@@ -157,7 +170,7 @@ export function installProviders() {
   };
   function thread(id) {
     const now = new Date().toISOString();
-    return { thread: { id, agent_id: "local-e2e-agent", kind: "cattle", status: "IDLE", client_external_ref: id }, run: { id: `run-${id}`, status: "completed", createdAt: now, startedAt: now, completedAt: now, updatedAt: now, trigger: "user_prompt" } };
+    return { thread: { id, agent_id: "local-e2e-agent", kind: "cattle", status: "IDLE", userId: runs.get(id).userId }, run: { id: `run-${id}`, status: "completed", createdAt: now, startedAt: now, completedAt: now, updatedAt: now, trigger: "user_prompt" } };
   }
   return counts;
 }

--- a/src/lib/__tests__/mosoo-project-analysis.test.ts
+++ b/src/lib/__tests__/mosoo-project-analysis.test.ts
@@ -48,7 +48,7 @@ function threadResponse(
       agent_id: "agent-1",
       kind,
       status: "RUNNING",
-      client_external_ref: "analysis-1",
+      userId: "ghfind",
     },
     run: {
       id: "run-1",
@@ -67,6 +67,7 @@ beforeEach(() => {
   process.env.MOSOO_API_BASE = "https://mosoo.test/api/v1";
   process.env.MOSOO_API_TOKEN = "test-token";
   process.env.MOSOO_PROJECT_AGENT_ID = "agent-1";
+  delete process.env.MOSOO_PROJECT_USER_ID;
 });
 
 afterEach(() => {
@@ -74,6 +75,7 @@ afterEach(() => {
   delete process.env.MOSOO_API_BASE;
   delete process.env.MOSOO_API_TOKEN;
   delete process.env.MOSOO_PROJECT_AGENT_ID;
+  delete process.env.MOSOO_PROJECT_USER_ID;
 });
 
 describe("Mosoo project analysis client", () => {
@@ -129,7 +131,9 @@ describe("Mosoo project analysis client", () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       expect(new Headers(init?.headers).get("Idempotency-Key")).toBe(run.idempotencyKey);
       const body = JSON.parse(String(init?.body));
-      expect(body.client_external_ref).toBe(run.id);
+      expect(Object.keys(body).sort()).toEqual(["input", "userId"]);
+      expect(body.userId).toBe("ghfind");
+      expect(body.input.content[0].text).toContain(`analysis_id: ${run.id}`);
       expect(body.input.content[0].text).toContain("[GHFIND_PROJECT_ANALYSIS_V3]");
       expect(body.input.content[0].text).toContain("schema_version: ghfind.project-analysis.v3");
       expect(body.input.content[0].text).toContain("execution_mode: source_only");
@@ -143,6 +147,51 @@ describe("Mosoo project analysis client", () => {
       runStatus: "running",
       kind: "cattle",
     });
+  });
+
+  it("uses the trusted configured integration identity and preserves an explicit API base", async () => {
+    process.env.MOSOO_PROJECT_USER_ID = "  ghfind-feed-staging  ";
+    process.env.MOSOO_API_BASE = "https://dedicated.mosoo.test/api/v1/";
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://dedicated.mosoo.test/api/v1/agents/agent-1/threads");
+      expect(JSON.parse(String(init?.body)).userId).toBe("ghfind-feed-staging");
+      return Response.json({ ...threadResponse(), thread: { ...threadResponse().thread, userId: "ghfind-feed-staging" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await createMosooProjectAnalysisThread(run, "source_only");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an oversized integration identity before making a provider request", async () => {
+    process.env.MOSOO_PROJECT_USER_ID = "x".repeat(256);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(createMosooProjectAnalysisThread(run, "source_only")).rejects.toMatchObject({ code: "mosoo_not_ready" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["analysis-1", null])("reads historical responses with client_external_ref=%s", async (reference) => {
+    const response = threadResponse();
+    const { userId: _userId, ...thread } = response.thread;
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => String(input).includes("/events")
+      ? Response.json({ events: [], truncated: false })
+      : Response.json({ ...response, thread: { ...thread, client_external_ref: reference } })));
+    await expect(createMosooProjectAnalysisThread(run, "source_only")).resolves.toMatchObject({ threadId: "thread-1" });
+    await expect(getMosooProjectAnalysisSnapshot("thread-1")).resolves.toMatchObject({ threadId: "thread-1" });
+  });
+
+  it.each([{}, { userId: "" }, { userId: 42 }])("rejects malformed response identity metadata %j", async (identity) => {
+    const response = threadResponse();
+    const { userId: _userId, ...thread } = response.thread;
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({ ...response, thread: { ...thread, ...identity } })));
+    await expect(createMosooProjectAnalysisThread(run, "source_only")).rejects.toMatchObject({ code: "mosoo_invalid_response" });
+  });
+
+  it("does not fall back to an obsolete request shape after a current API rejection", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ error: { code: "invalid_request" } }, { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(createMosooProjectAnalysisThread(run, "source_only")).rejects.toBeInstanceOf(MosooProjectAnalysisError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a pet Agent response", async () => {

--- a/src/lib/__tests__/mosoo-provider-fixture.test.ts
+++ b/src/lib/__tests__/mosoo-provider-fixture.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installProviders } from "../../../scripts/feed-e2e/provider-fixtures.mjs";
+
+const endpoint = "https://feed-e2e-provider.invalid/api/v1/agents/local-e2e-agent/threads";
+const input = {
+  type: "user.message",
+  content: [{ type: "text", text: "analysis_id: analysis-1\nrepository_url: https://github.com/owner/useful-tool\n" }],
+};
+const create = (body: unknown, idempotencyKey = "fixture-analysis-1") => fetch(endpoint, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}) },
+  body: JSON.stringify(body),
+});
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("Unexpected real transport in provider fixture test."); }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("complete local E2E Mosoo transport contract", () => {
+  it("accepts userId and correlates artifacts through the analysis prompt", async () => {
+    const counts = installProviders();
+    const response = await create({ userId: "ghfind-feed-staging", input });
+    expect(response.status).toBe(200);
+    const created = await response.json();
+    expect(created.thread).toMatchObject({ id: "analysis-1", userId: "ghfind-feed-staging", kind: "cattle" });
+    expect(created.thread).not.toHaveProperty("client_external_ref");
+    const snapshot = await fetch("https://feed-e2e-provider.invalid/api/v1/threads/analysis-1");
+    expect((await snapshot.json()).thread.userId).toBe("ghfind-feed-staging");
+    const files = await fetch("https://feed-e2e-provider.invalid/api/v1/threads/analysis-1/files");
+    expect((await files.json()).files.map((file: { name: string }) => file.name).sort()).toEqual([
+      "project-analysis-analysis-1.json", "project-report-analysis-1.md", "runtime-evidence-analysis-1.json",
+    ]);
+    expect(counts.assessmentCreate).toBe(1);
+    expect(counts.unexpectedExternal).toBe(0);
+  });
+
+  it.each([
+    { input, client_external_ref: "analysis-1" },
+    { input, userId: "ghfind", client_external_ref: "analysis-1" },
+    { input },
+    { input, userId: "" },
+    { input, userId: " " },
+    { input, userId: 42 },
+    { input, userId: "x".repeat(256) },
+    { input, userId: "ghfind", provider: "unauthorized" },
+    { input: { ...input, extra: true }, userId: "ghfind" },
+    { input: { ...input, content: [{ ...input.content[0], extra: true }] }, userId: "ghfind" },
+    null,
+  ])("rejects an invalid API body without recording an assessment (%#)", async (body) => {
+    const counts = installProviders();
+    const response = await create(body);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { code: "invalid_request" } });
+    expect(counts.assessmentCreate).toBe(0);
+  });
+
+  it("requires the application's stable idempotency key", async () => {
+    const counts = installProviders();
+    expect((await create({ userId: "ghfind", input }, "")).status).toBe(400);
+    expect(counts.assessmentCreate).toBe(0);
+  });
+});

--- a/src/lib/mosoo-project-analysis.ts
+++ b/src/lib/mosoo-project-analysis.ts
@@ -43,8 +43,10 @@ const threadResponseSchema = z.object({
     agent_id: z.string().min(1),
     kind: z.enum(["pet", "cattle"]),
     status: z.enum(["IDLE", "RUNNING", "RESCHEDULING", "TERMINATED"]),
-    client_external_ref: z.string().nullable(),
-  }),
+    userId: z.string().min(1).max(255).optional(),
+    // Older persisted Threads used this field; current responses omit it.
+    client_external_ref: z.string().nullable().optional(),
+  }).refine((thread) => thread.userId !== undefined || thread.client_external_ref !== undefined),
   run: runSchema.nullable(),
 });
 
@@ -103,6 +105,7 @@ export interface MosooProjectAnalysisConfig {
   apiBase: string;
   apiToken: string;
   agentId: string;
+  userId: string;
   requestTimeoutMs: number;
 }
 
@@ -182,10 +185,21 @@ function projectAgentConfig(): MosooProjectAnalysisConfig {
     );
   }
   const rawTimeout = Number(process.env.MOSOO_PROJECT_REQUEST_TIMEOUT_MS);
+  // Match the existing Go client. This is a trusted integration identity, not
+  // a client-supplied GitHub identity or an analysis correlation ID.
+  const userId = process.env.MOSOO_PROJECT_USER_ID?.trim() || "ghfind";
+  if (userId.length > 255) {
+    throw new MosooProjectAnalysisError(
+      "mosoo_not_ready",
+      "MOSOO_PROJECT_USER_ID must be at most 255 characters.",
+      503,
+    );
+  }
   return {
     apiBase: (process.env.MOSOO_API_BASE || DEFAULT_API_BASE).replace(/\/$/, ""),
     apiToken,
     agentId,
+    userId,
     requestTimeoutMs:
       Number.isFinite(rawTimeout) && rawTimeout >= 1_000
         ? Math.floor(rawTimeout)
@@ -305,7 +319,7 @@ export async function createMosooProjectAnalysisThread(
       "Idempotency-Key": run.idempotencyKey,
     },
     body: JSON.stringify({
-      client_external_ref: run.id,
+      userId: config.userId,
       input: {
         type: "user.message",
         content: [{ type: "text", text: buildProjectAnalysisPrompt(run, executionMode) }],


### PR DESCRIPTION
## Problem and behavior
The Next project-assessment client still sends `client_external_ref` and requires that field in thread responses. Current Mosoo Public Thread API requires `userId`, rejects unknown request fields, and returns `userId`; the existing Go client had already been updated. The complete local E2E provider fixture also accepted the obsolete contract, so its success did not establish compatibility with the real provider.

This change sends the trusted `MOSOO_PROJECT_USER_ID` (default `ghfind`, matching Go), preserves the existing analysis prompt and idempotency key, and reads both current and historical thread responses. The local fixture now rejects obsolete, missing, and extra fields and derives its analysis correlation from the existing prompt.

## Scope and ordered commits
1. `dc64f28703364209bff6d701fd89dfdfa9b085cc` — `fix(mosoo): align project analysis with current thread contract`

Four files: the Next provider client, its unit tests, the local provider fixture, and regression tests for that fixture. No database, migration, source finalization transaction, ranking, gateway, provider endpoint default, or production configuration changes. The public Feed HTTP contract remains 1; storage writer/schema contracts remain unchanged. Historical nullable `client_external_ref` responses remain readable. This PR contains no credentials.

Official contract inspected: https://mosoo.ai/docs/openapi/mosoo-openapi.en.generated.json (SHA256 `e36dcaffb596559a4854923b289cf15707999a1f9e8047a7fc938093e62ec462`, fetched 2026-09-09). Homepage redirects are not used as evidence to change the configured API origin.

## Validation before push
Base main: `58e741069efbb423714c8b57d2fe39ea2df842ae`.
Tested HEAD: `dc64f28703364209bff6d701fd89dfdfa9b085cc`; clean tree `4253df2385e2fa5a86e06d1923478859e9a86585`.

- 26 targeted Vitest tests passed; four-file ESLint, `tsc --noEmit --incremental false`, and `git diff --check` passed.
- Harness self-tests: 6 passed; durable ack-loss self-tests: 4 passed.
- `python3 scripts/run-feed-e2e.py --release-sha dc64f28703364209bff6d701fd89dfdfa9b085cc --directory /tmp/ghfind-provider-e2e-20260909-1512 --execute` passed at 07:02:40–07:03:13 UTC (2026-09-09).
- Both `cf_d1_r2` (real local workerd D1/R2) and `postgres` (real PostgreSQL/pgvector + MinIO) passed all eight milestones: OAuth callback, assessment finalization, source outbox, executor projection, governance, preferences, events, and completed deletion. Each profile observed three assessments/outbox receipts/projections and completed→duplicate durable redelivery. Resource cleanup passed.
- Root independently validated the receipt against exact SHA/tree before pushing. Local external GitHub and Mosoo transport fixtures are explicitly recorded as `realOAuth=false`; they are not real CF/provider acceptance evidence.
- First attempt `/tmp/ghfind-provider-e2e-20260909-1510/run.json` failed for missing locked worktree dependencies. Preserved unchanged. Locked dependencies were installed; the clean source did not change before the new successful attempt. Raw local receipts and sanitized journey copies are retained in the local handoff; exact-SHA CI artifacts will be linked below when complete.

## Remote acceptance and resources
Draft: exact push CI and PR merge-compatibility CI are separate requirements. Real CF staging OAuth/provider E2E is still pending and this draft must not be merged solely because local fixture E2E passes. CI actual-checkout receipts will be verified before staging release.

Staging target account `8f19bebe359e4ec1a24c68c5f49c1584`: Web `ghfind-feed-web-staging`, runtime `ghfind-feed-runtime-staging`, adapter `ghfind-feed-adapter-staging`; isolated core D1 `69bdae1c-ac36-4883-8fa4-9ffa54ebd033`, Feed D1 `7526684c-b57d-412e-89ba-812cd30798e8`. No image has been deployed for this SHA; image digest is not yet available. A dedicated CF token was created and installed into the protected `Feed staging` environment separately; no production token was reused.

The staging OAuth App has been registered with an exact staging callback, and its independent AUTH_GITHUB_SECRET has been installed and read back at 07:13:04 UTC. CF_FEED_STAGING_API_TOKEN was independently installed at 07:01:31 UTC. The user subsequently requested simplifying the two-account requirement: a separate revised plan now uses one real OAuth browser identity, the existing protected operator workflow, and explicitly synthetic cross-user CF contracts. This PR does not yet change the existing v2/two-state runner or bypass its gate. Personal GitHub cookies and long-lived application sessions must not be exported to CI. Independent real assessment provider configuration and a bounded real provider test have now passed (provisioning evidence below). The complete CF manifest and application E2E remain pending; provider success does not permit fabricated sessions or a false manifest.

After-push CF readback completed at 07:06:07–07:06:16 UTC. Production unchanged as below; containers 0, all three staging services return 404/10007, both staging databases have only _cf_KV, and jobs/DLQ/parking queues have no consumers. No staging deployment is claimed. Production must remain on Worker version `3b4b74f8-1f99-4fcc-b590-19035711eed8` / release `aa8c683`, existing D1 and legacy Feed. New CF runtime/adapter are not yet deployed. No production assessment or user-behavior write was performed. No additional recurring compute was provisioned by this code change; real provider cost remains an acceptance prerequisite.

## Rollback and handoff
Do not deploy this candidate until accurate-SHA CI plus real CF staging acceptance pass. Merge this PR by **rebase**, then retest the resulting exact main SHA; do not squash or change repository merge settings.

Before production activation, withdraw this draft or create a normal `git revert dc64f28703364209bff6d701fd89dfdfa9b085cc` commit and run the complete gates. After activation, an application rollback must use an independently verified provider-compatible image via protected GitHub Actions. The parent client uses the obsolete provider protocol, so it is not automatically a safe operational rollback target. There is no schema reversal or data migration in this PR; source facts stay in the existing authoritative database.

Next owner: primary ghfind integration/release agent. Required handoff: actual-checkout CI receipts, remote CF readback, dedicated provider live Agent/configuration and bounded evaluation, completed OAuth registration, implemented one-browser acceptance contracts and CF-verified browser evidence (per user-requested plan adjustment), real CF E2E evidence, immutable image/Worker manifest, and an accepted compatible rollback image. Keep stage 1 acceptance open until those exist.


## Final CI and configuration evidence (2026-09-09)

- Exact push CI [34322093441](https://github.com/hikariming/ghfind/actions/runs/34322093441): all four required jobs plus Verify release passed. Repository `verify-ci-remote` independently verified exact checkout `dc64f28703364209bff6d701fd89dfdfa9b085cc`, tree `4253df2385e2fa5a86e06d1923478859e9a86585`, run attempt 1, and downloaded archive SHA256. [Release artifact 10092357207](https://github.com/hikariming/ghfind/actions/runs/34322093441/artifacts/10092357207), digest `79e65a3fa735f5c53df975d0aea77638514e8a1354f2266f3c7b9f659bf985f8`.
- PR compatibility CI [34322267647](https://github.com/hikariming/ghfind/actions/runs/34322267647): all required jobs and Verify release passed. Downloaded and digest-verified [artifact 10092454179](https://github.com/hikariming/ghfind/actions/runs/34322267647/artifacts/10092454179), digest `8495dd3a2b3e0fb4d83b0837a4f37c59530c09cfc3450ee8d602200cd7e086e5`. Actual synthetic checkout `9c9a712d6f737592698327b66d63d5ba1eb89570`, same tree; receipt event pull_request and eligible=false, so it is not substituted for push/main release eligibility.
- CF API and dashboard provider audit (production and dev) found existing LLM_* model/fallback secrets, used by /api/roast and /api/vs-verdict. Neither Worker has MOSOO_* runtime bindings; both CF Builds UI entries show an unconnected repository. LLM_* cannot be substituted as a Mosoo Thread API credential. Current secret values were not read/reused, and no real assessment was started. This audit does not prove whether an older deployed build contains historical fallback configuration.
- Draft remains open until truthful real CF/provider acceptance and the separately revised browser gate are implemented and pass. No merge or production rollout was performed for this PR.

## Dedicated Mosoo provider provisioned (2026-09-09)

User-supplied StepFun credentials were configured in a new independent Mosoo Project `ghfind-feed-staging` (`01M22PHX9Y11B7HTXQ2MTHYYA9`). [Task Agent](https://cloud.mosoo.ai/agent/01M22PWZR0A7ZYCDKWTEA0YEHQ) `01M22PWZR0A7ZYCDKWTEA0YEHQ` is published at v1 using OpenCode and `step-3.7-flash`. The complete 11-file project-evaluator Skill was imported from immutable `58e7410`; its contents match this PR. Package SHA256: `a7a2840506d251a05cd684821f090576bd1abb533da18da1424977f0fe91935b`.

- Provider connection test passed after correcting an OCR ambiguity in the user-supplied screenshot. No production model credential was reused.
- A real source-only preview evaluated `octocat/Hello-World` at `7fd1a60b01f91b314f59955a4e4d4e80d8edf11d` (analysis `staging-provider-20260909-01`, session `01M22PZ8X71AQZHC14K7FP96A4`). It used actual StepFun/tool execution, emitted all three artifacts, and ran the attached Python validator successfully (exit 0). Artifacts downloaded via authenticated console file links passed the repository validator independently. This was one provider evaluation, not authenticated ghfind/CF E2E or application finalization.
- Published Public Thread API passed project-key authorization, empty Thread creation, identical-key idempotent replay, retrieval, and deletion. No additional model run was invoked. Before publishing, the endpoint returned 409 `agent_not_published`; after publishing, GET threads returned 200. Preview console file IDs returned 404 on the Public Thread file path; the actual console file endpoint returned all three files successfully. These separate surfaces are not conflated.
- Analysis SHA256 `00b7ab7802c567ac0e5b538e6cc41b19f17e1f1aef69e5050ddd7d34df354fb4`; report `fb31421c5d3346859bdc05732ff8fd4aaa9460fc9f84863d79056ab67837ba16`; evidence `4229599d12ab16ebfdf3c040125200ee75f71603e23d953e43c7fa7ba76533fe`.
- `MOSOO_API_TOKEN` installed into protected GitHub environment `Feed staging` at 09:12:29 UTC. Agent ID/API URL/user ID variables saved and read back. The local ignored `.env.local` has the requested configuration with mode 0600. No secret values are in this PR or handoff. Live Mosoo now issues Project API keys; its console explicitly retires the old account token model.
- Current workflow still consumes Agent ID and API URL from `FEED_STAGING_MANIFEST.web.sourceProvider`; the saved variables are not claimed to satisfy that manifest. Full manifest integration and revised browser gate remain open. The remaining real CF/application E2E will verify published model execution and assessment finalization together.
- Cloudflare readback at 09:16 UTC confirms production remains `aa8c683`, Worker `3b4b74f8-1f99-4fcc-b590-19035711eed8`, 100%; staging Web still 404/10007. This configuration work did not push source, deploy ghfind, merge this PR, or alter production data.

Sanitized raw receipts, downloaded artifacts, hashes and next-step instructions are retained in local handoff `20260909-mosoo-project-provisioned`. Full CF deployment/CI artifact evidence is still required before merge. Model monthly cost and enforced network isolation have not been accepted; the live console has inconsistent network-enforcement descriptions, so a saved restricted configuration is not treated as proof.
