### PR TITLE
feat(profile): expose rescan to all visitors

### DIFF
--- a/src/app/[locale]/u/[username]/page.tsx
+++ b/src/app/[locale]/u/[username]/page.tsx
@@ -280,8 +280,7 @@ export default async function AccountPage({
   const battles = presentation?.battles ?? [];
   const facetRank = presentation?.facetRank ?? null;
   const commonProjects = presentation?.common_projects ?? [];
-  // Inline re-detect is self-service: only the signed-in owner sees it on their
-  // own profile. GitHub handles are case-insensitive, so compare normalized.
+  // GitHub handles are case-insensitive, so compare normalized.
   const isOwner =
     session?.user?.login?.toLowerCase() === d.username.toLowerCase();
   // Badge-landing hook: a visitor arriving from a GitHub README badge (Referer
@@ -697,9 +696,7 @@ export default async function AccountPage({
             <FollowButton username={d.username} className="mt-3" />
           </>
         )}
-        {isOwner && (
-          <RescanButton username={d.username} scannedAt={d.scanned_at} className="mt-3" />
-        )}
+        <RescanButton username={d.username} scannedAt={d.scanned_at} className="mt-3" />
       </div>
 
       {isAdvxCampaign && (

--- a/src/components/__tests__/profileRescan.test.ts
+++ b/src/components/__tests__/profileRescan.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const profileSource = readFileSync(
+  new URL("../../app/[locale]/u/[username]/page.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("profile rescan", () => {
+  it("offers a rescan on every stored profile", () => {
+    expect(profileSource).toContain(
+      '<RescanButton username={d.username} scannedAt={d.scanned_at} className="mt-3" />',
+    );
+    expect(profileSource).not.toMatch(/\{isOwner && \(\s*<RescanButton/);
+  });
+});


### PR DESCRIPTION
GitHub profiles change continuously as developers create repositories, earn stars, merge pull requests, and contribute to open-source projects. However, previously only the profile owner could request a new scan, leaving other visitors with potentially outdated results.
This change exposes the existing rescan action to all visitors so anyone viewing a stale profile can:
- Fetch the latest public GitHub data.
- Recalculate the developer’s score and ranking.
- Regenerate the profile report.
- Persist the updated result for future visitors.