### PR TITLE
fix(release): validate ready Cloudflare application summaries with live instances

### DIFF
--- a/scripts/feed-platform-production-readback.mjs
+++ b/scripts/feed-platform-production-readback.mjs
@@ -431,13 +431,18 @@ export async function verifyDeployment(
           (a) => a.name === `${m.runtimeWorker}-${suffix}`,
         ),
         app = matches[0];
+      // Wrangler 4.129.1 containers/list.ts derives this summary from
+      // health.instances: no failed/starting/scheduling/active count => ready.
+      // It is independent of app.instances and is not proof of running instances;
+      // the named instance/version checks below and authenticated readiness remain
+      // mandatory. Never accept degraded/provisioning/unknown summaries.
       requireThat(
         matches.length === 1 &&
           uuid.test(app.id) &&
           app.image === image &&
-          app.state === "active" &&
+          ["active", "ready"].includes(app.state) &&
           scalarVersion(app.version),
-        "immutable application not active",
+        "immutable application identity or health summary differs",
       );
       const configuration = await wrangler([
         "containers",

--- a/scripts/feed-platform-production.test.mjs
+++ b/scripts/feed-platform-production.test.mjs
@@ -182,6 +182,7 @@ function fixture(mode = "off", options = {}) {
     name: `${m.runtimeWorker}-${suffix}`,
     image,
     state: "active",
+    instances: i === 0 ? 2 : 1,
     version: 7,
     env: { SECRET: "must-not-upload" },
   }));
@@ -190,7 +191,10 @@ function fixture(mode = "off", options = {}) {
     assert.ok(signal instanceof AbortSignal);
     if (options.delay && metadataCalls === 1)
       await sleep(options.delay, undefined, { signal });
-    if (args[1] === "list") return applications;
+    if (args[1] === "list")
+      return options.applications
+        ? options.applications(structuredClone(applications))
+        : applications;
     if (args[1] === "info") {
       const a = applications.find((a) => a.id === args[2]);
       const result = {
@@ -211,7 +215,7 @@ function fixture(mode = "off", options = {}) {
     assert.deepEqual(args.slice(0, 2), ["containers", "instances"]);
     assert.deepEqual(args.slice(3), ["--per-page", "10", "--json"]);
     const names = args[2] === id(3) ? ["api-0", "api-1"] : ["executor-0"];
-    return {
+    const result = {
       instances: names.map((name) => ({
         id: `instance-${name}`,
         name,
@@ -222,6 +226,7 @@ function fixture(mode = "off", options = {}) {
       })),
       result_info: {},
     };
+    return options.instances ? options.instances(result) : result;
   };
   return {
     fetcher,
@@ -357,6 +362,143 @@ test("actual readback whitelists all published identity fields and gates baselin
     () => renderRuntime(m, image, sha, "baseline", { ...r, applications: [] }),
     /missing/,
   );
+});
+test("Wrangler ready application summary still requires all named running instances and readiness", async () => {
+  // Match the observed first production list: API active/2, executor ready/1.
+  // Also cover ready for both applications: app.instances is an independent count.
+  for (const states of [
+    ["active", "ready"],
+    ["ready", "ready"],
+  ]) {
+    const f = fixture("off", {
+      applications: (apps) =>
+        apps.map((app, i) => ({ ...app, state: states[i] })),
+    });
+    const r = await verifyDeployment(m, sha, image, "off", f.options);
+    assert.equal(r.status, "passed");
+    assert.equal(r.keepWarm.metadataReads, 23);
+    assert.deepEqual(
+      r.applications.map((a) =>
+        a.instances.map((i) => [i.name, i.state, i.version]),
+      ),
+      [
+        [
+          ["api-0", "running", 7],
+          ["api-1", "running", 7],
+        ],
+        [["executor-0", "running", 7]],
+      ],
+    );
+    assert.equal(r.readiness.length, 3);
+    assert.ok(f.count().readyCalls >= 2);
+  }
+});
+test("application summaries other than active or ready fail despite healthy named instances", async () => {
+  for (const state of [
+    "degraded",
+    "provisioning",
+    "unknown",
+    "running",
+    "inactive",
+    null,
+    undefined,
+  ]) {
+    const f = fixture("off", {
+      applications: (apps) => apps.map((app) => ({ ...app, state })),
+    });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      /application identity or health summary/,
+    );
+  }
+});
+test("ready application summary cannot hide immutable application identity drift", async () => {
+  for (const transform of [
+    (apps) => [
+      { ...apps[0], image: image.replace(/b{64}$/, "c".repeat(64)) },
+      apps[1],
+    ],
+    (apps) => [{ ...apps[0], id: "unknown" }, apps[1]],
+    (apps) => [{ ...apps[0], version: null }, apps[1]],
+    (apps) => [{ ...apps[0], name: "foreign-feedapi" }, apps[1]],
+    (apps) => [...apps, apps[0]],
+  ]) {
+    const f = fixture("off", {
+      applications: (apps) =>
+        transform(apps.map((app) => ({ ...app, state: "ready" }))),
+    });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      /application identity or health summary/,
+    );
+  }
+});
+test("ready application summary cannot replace running instance, version or population proof", async () => {
+  const changes = [
+    // Wrangler uses running, not active; inactive/null is a registered DO without a running instance.
+    ...[
+      "active",
+      "inactive",
+      "provisioning",
+      "failed",
+      "stopping",
+      "stopped",
+      "unhealthy",
+      "unknown",
+    ].map((state) => (result) => ({
+      ...result,
+      instances: result.instances.map((i) => ({
+        ...i,
+        state,
+        ...(state === "inactive" ? { version: null } : {}),
+      })),
+    })),
+    (result) => ({
+      ...result,
+      instances: result.instances.map((i) => ({ ...i, version: 6 })),
+    }),
+    (result) => ({
+      ...result,
+      instances: result.instances.map((i) => ({ ...i, name: "foreign" })),
+    }),
+    (result) => ({
+      ...result,
+      instances: result.instances.map((i) => ({ ...i, id: null })),
+    }),
+    (result) => ({ ...result, instances: result.instances.slice(1) }),
+    (result) => ({
+      ...result,
+      instances: result.instances.map(() => result.instances[0]),
+    }),
+    (result) => ({
+      ...result,
+      result_info: { next_page_token: "another-page" },
+    }),
+  ];
+  for (const instances of changes) {
+    const f = fixture("off", {
+      applications: (apps) => apps.map((app) => ({ ...app, state: "ready" })),
+      instances,
+    });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      /instance version\/state differs|unexpected instance population/,
+    );
+  }
+});
+test("ready summary and matching instances cannot hide a final process readiness change", async () => {
+  const f = fixture("baseline", {
+    applications: (apps) => apps.map((app) => ({ ...app, state: "ready" })),
+    ready: (r, call) => {
+      if (call > 1) r.containers[2].mode = "off";
+      return r;
+    },
+  });
+  await assert.rejects(
+    verifyDeployment(m, sha, image, "baseline", f.options),
+    /container readiness differs/,
+  );
+  assert.equal(f.count().metadataCalls, 5);
 });
 test("both runtime and adapter active deployments must stay fixed through readback", async () => {
   for (const changedWorker of [m.runtimeWorker, m.adapterWorker]) {


### PR DESCRIPTION
## Problem and resulting behavior

The first production release from #275 ([34342915828](https://github.com/hikariming/ghfind/actions/runs/34342915828), main `1615c6ec68add420affa835fa30222c0328d6b89`) deployed the immutable Go image and private Workers and passed initial authenticated readiness, then stopped at the application summary guard. Actual Cloudflare metadata reported API `active` with two instances and executor `ready` with one instance. Wrangler 4.129.1 derives this summary independently from aggregate health counters; `ready` does not itself mean an unhealthy container.

This single-purpose commit accepts application summary `active|ready`. It still requires exact digest, application version, namespace and capacity, three named **running** instances at that version, and authenticated readiness before and after readback. Degraded/provisioning/unknown summaries and stopped, missing or stale instances remain failures. No cause for the observed summary difference is assumed.

## Commit, scope and contracts

- `64181a0d03e405ceaf411234b3ef7ee638def299` fix(release): accept healthy ready application summaries
- Base main: `1615c6ec68add420affa835fa30222c0328d6b89`.
- Only release reader and its regression tests change. Public contract 1, storage writer 2, runtime schema 7 and physical schema 12 remain unchanged. No new migration, provider request, resource or routing change in this PR itself.
- Preserve history with PR **rebase**, never squash. Main agent owns integration and serialized Actions release; isolated subagent supplied the fix.

## Validation before push

Exact checkout `64181a0d03e405ceaf411234b3ef7ee638def299`, tree `2f19c89b5bd81abf2766e0d70c0d47202dc5c8eb`, clean.

`node --test scripts/feed-platform-production.test.mjs`: **25/25 passed, zero skips**. Regressions cover the observed mixed application summaries, unhealthy summaries, immutable configuration drift, stopped/missing/old/named-instance drift, pagination mismatch, and final authenticated readiness drift.

`python3 scripts/run-feed-e2e.py --release-sha 64181a0d03e405ceaf411234b3ef7ee638def299 --directory /tmp/ghfind-go-production-e2e-readback-fix-20260909 --execute`: **both profiles passed** with successful cleanup. Actual workerd D1/R2 and Docker PostgreSQL/pgvector/MinIO traverse OAuth callback, assessment finalization, source outbox, executor projection, governance, preferences, events and deletion completed. External OAuth/provider transports are explicitly fixtures; this is not real production-provider evidence.

Local evidence: `/tmp/ghfind-go-production-e2e-readback-fix-20260909/run.json` and each profile journey; `/tmp/ghfind-go-production-20260909/readback-fix-tests.tap`. Exact source push CI must upload reproducible raw receipts; PR compatibility and merged-main CI are separate checks. Remote CI and new production acceptance are pending and will be appended.

## Actual remote state, operations and rollback

The failed attempt left production Web at `3b4b74f8-1f99-4fcc-b590-19035711eed8`, source `aa8c683`, 100% legacy Feed. It never deployed paused Web, enabled the legacy writer fence, started the real assessment or opened Go routing. Private runtime `be38dff5-3ffe-416b-a826-734371164235` is off; adapter `4431638f-4510-440b-aed9-520a1cc9cdc6`. Both are tagged main `1615c6e` and image `registry.cloudflare.com/8f19bebe359e4ec1a24c68c5f49c1584/ghfind-feed@sha256:4c42ba885a4c5f1f6c8507079be372ba7a686dfa2a820ddc52c1b7ba5466c55a`.

The next successful exact-main CI automatically repeats the idempotent protected Actions release, creates a new exact-source image digest, and must pass actual off/baseline readback, one journaled real assessment plus durable projection, bounded service smoke, final all-mode Web and public smoke. Existing D1s remain the only fact source; semantic recall remains off. No local deployment is used. Each push, merge and deployment receives actual CF readback.

Before new Go writes, legacy remains as observed. After Go writes, do not restore old Next writers or reverse schema: use the captured same-source paused Go Web via protected `Feed production pause`, with its exact verified version, and read back the result. This is containment (Feed 503), not a demonstrated availability rollback. Existing docs and #275 give commands and scope.

No additional planned monthly resource cost. The $79.69848 scenario against the $100 budget remains an estimate; measured capacity/cold start, full fault recovery, database migration roundtrip, RPO/RTO, semantics, historical data and Railway disposition remain unaccepted. This fix enables continued Go cutover, not completion of all earlier phases.

## Exact source CI and post-push Cloudflare readback

- [Push CI 34344334459](https://github.com/hikariming/ghfind/actions/runs/34344334459) passed all jobs for `64181a0d03e405ceaf411234b3ef7ee638def299`; the verifier downloaded artifact bytes, checked digest and actual checkout/tree for every job and both E2E profiles. Local verified receipt: `/tmp/ghfind-go-production-20260909/readback-fix-exact-branch-ci.json`.
- CF readback after this push at 2026-09-09T11:13Z confirmed the unchanged Web and off runtime/adapter versions recorded above. Evidence: `/tmp/ghfind-go-production-20260909/after-readback-fix-push.json`.
- PR compatibility CI and independent merged-main CI remain required before the production continuation.

[PR compatibility CI 34344411381](https://github.com/hikariming/ghfind/actions/runs/34344411381) also passed all five jobs before merge. Its synthetic checkout is separate from the source release evidence.

## Rebase merge and new main release

Merged through PR rebase at 2026-09-09T11:18:34Z as `e60f2110e93279d264d5c6e810ad03a4bed4d33f`. [Main CI 34344864501](https://github.com/hikariming/ghfind/actions/runs/34344864501) is independently validating this exact commit. Post-merge CF readback again confirmed Web still legacy and the prior private runtime off; merge is not being reported as traffic cutover.

## Main validation and retained production attempt

[Main CI 34344864501](https://github.com/hikariming/ghfind/actions/runs/34344864501) passed for `e60f2110e93279d264d5c6e810ad03a4bed4d33f`; actual checkout and E2E artifacts were independently verified in `readback-fix-exact-main-ci.json`.

[Production 34345222007 attempt 1](https://github.com/hikariming/ghfind/actions/runs/34345222007) passed authorization, image/resource/schema updates and initial authenticated runtime readiness, then failed `instance version/state differs: api-1` at 11:27:31Z. This is retained as a failed release. Web remained `3b4b74f8-1f99-4fcc-b590-19035711eed8` on legacy source `aa8c683`; paused Web, fence activation and real assessment were not reached.

Actual new off runtime `fe3bc40f-8770-4e08-ae48-f0714a343d03`, adapter `5625651b-28a6-4845-a60f-2ce502f4e1e9`, image `registry.cloudflare.com/8f19bebe359e4ec1a24c68c5f49c1584/ghfind-feed@sha256:b1a3ab93ff4ed866283a46182d97ae9107415c73823fa702e124720ea88e607a`. Later read-only instance metadata showed both APIs running at application version 2. The failing instantaneous value was not persisted, so no specific transient state is asserted. A follow-up will preserve diagnostics and strictly bound metadata convergence, retaining all final running/version/digest/readiness requirements.

Evidence under `/tmp/ghfind-go-production-20260909/`: `production-attempt2-failed.log`, `production-attempt2/`, `attempt2-off-refreshed.json`, `attempt2-container-apps.json`, `attempt2-api-instances.json`, `attempt2-executor-instances.json`. One local readback was 401 from an expired Wrangler OAuth session (`attempt2-off-transition.json`); normal Wrangler refresh restored the read-only verification. This is not classified as missing CF privileges.
