### PR TITLE
fix(release): wait for verified Container placements and retain failure evidence

### DIFF
--- a/scripts/feed-platform-production-readback.mjs
+++ b/scripts/feed-platform-production-readback.mjs
@@ -17,8 +17,13 @@ import {
 
 export const limits = Object.freeze({
   durationMs: 180000,
-  readinessRequests: 75,
-  metadataReads: 23,
+  // 72 heartbeat slots + 16 per-attempt checks + initial/final checks <= 95.
+  readinessRequests: 95,
+  // Original 23 + 14 additional instance reads + final application identity read.
+  metadataReads: 38,
+  instanceAttempts: 8,
+  instanceIntervalMs: 2500,
+  instanceConvergenceMs: 60000,
   intervalMs: 2500,
   requestMs: 10000,
   metadataMs: 30000,
@@ -31,6 +36,70 @@ function scalarVersion(v) {
     (Number.isSafeInteger(v) && v >= 0) ||
     (typeof v === "string" && /^[A-Za-z0-9_.:-]{1,100}$/.test(v))
   );
+}
+// CLI placement states from pinned Wrangler 4.129.1 containers/instances.ts.
+const instanceStates = new Set([
+  "running",
+  "inactive",
+  "provisioning",
+  "stopping",
+  "stopped",
+  "failed",
+  "unhealthy",
+  "unknown",
+]);
+function inspectInstances(result, names, expectedVersion) {
+  if (
+    !result ||
+    !Array.isArray(result.instances) ||
+    !result.result_info ||
+    typeof result.result_info !== "object" ||
+    Array.isArray(result.result_info) ||
+    result.result_info.next_page_token ||
+    result.instances.length !== names.length
+  )
+    return { status: "rejected", reason: "unexpected_instance_population" };
+  const ids = new Set();
+  let pending = false;
+  for (const name of names) {
+    const rows = result.instances.filter((i) => i?.name === name);
+    if (rows.length !== 1 || !shortIdentity(rows[0].id) || ids.has(rows[0].id))
+      return { status: "rejected", reason: "instance_identity_invalid" };
+    const row = rows[0];
+    ids.add(row.id);
+    if (
+      !instanceStates.has(row.state) ||
+      (row.state === "inactive"
+        ? row.version !== null
+        : !scalarVersion(row.version))
+    )
+      return {
+        status: "rejected",
+        reason: "instance_state_or_version_invalid",
+      };
+    if (["failed", "unhealthy", "unknown"].includes(row.state))
+      return { status: "rejected", reason: "instance_unhealthy" };
+    if (
+      row.state !== "running" ||
+      String(row.version) !== String(expectedVersion)
+    )
+      pending = true;
+  }
+  return {
+    status: pending ? "pending" : "converged",
+    reason: pending ? "instance_state_or_version_pending" : null,
+  };
+}
+function observedInstances(result, names) {
+  // Never copy arbitrary rows, names, environment, placement detail or bodies.
+  return (Array.isArray(result?.instances) ? result.instances : [])
+    .slice(0, names.length)
+    .map((row) => ({
+      id: shortIdentity(row?.id) ? row.id : null,
+      name: names.includes(row?.name) ? row.name : null,
+      state: instanceStates.has(row?.state) ? row.state : "invalid",
+      version: scalarVersion(row?.version) ? row.version : null,
+    }));
 }
 export function activeVersion(active) {
   const d = active?.deployments?.[0];
@@ -312,7 +381,11 @@ export async function verifyDeployment(
     readinessRequests = 0,
     lastReadiness,
     loop,
-    heartbeatFailure;
+    heartbeatFailure,
+    lastReadinessAt = null,
+    stage = "initial_readiness",
+    failureReceipt;
+  const instanceObservations = [];
   function signal(timeout, extra = run.signal) {
     return AbortSignal.any([run.signal, extra, AbortSignal.timeout(timeout)]);
   }
@@ -340,9 +413,12 @@ export async function verifyDeployment(
     run.signal.throwIfAborted();
     return data.result;
   }
-  async function wrangler(args) {
+  async function wrangler(args, extra = run.signal) {
     countMetadata();
-    const result = await metadata(args, { signal: signal(bounds.metadataMs) });
+    const result = await metadata(args, {
+      signal: signal(bounds.metadataMs, extra),
+    });
+    extra.throwIfAborted();
     run.signal.throwIfAborted();
     return result;
   }
@@ -368,6 +444,49 @@ export async function verifyDeployment(
       workerVersionId,
     );
     run.signal.throwIfAborted();
+    lastReadinessAt = new Date().toISOString();
+  }
+  // Deploy returns before every instance is replaced; metadata may still be
+  // transitional. https://developers.cloudflare.com/containers/guides/deploy/
+  async function convergeInstances(app, names, runtimeId) {
+    const convergence = AbortSignal.any([
+      run.signal,
+      AbortSignal.timeout(bounds.instanceConvergenceMs),
+    ]);
+    for (let attempt = 1; attempt <= bounds.instanceAttempts; attempt++) {
+      convergence.throwIfAborted();
+      // A stale placement snapshot is retryable; a stale actual Go process is not.
+      await ready(runtimeId, convergence);
+      convergence.throwIfAborted();
+      const result = await wrangler(
+        ["containers", "instances", app.id, "--per-page", "10", "--json"],
+        convergence,
+      );
+      const verdict = inspectInstances(result, names, app.version);
+      instanceObservations.push({
+        observedAt: new Date().toISOString(),
+        applicationId: app.id,
+        applicationName: app.name,
+        applicationVersion: app.version,
+        applicationSummary: app.state,
+        attempt,
+        readinessObservedAt: lastReadinessAt,
+        ...verdict,
+        instances: observedInstances(result, names),
+      });
+      requireThat(
+        verdict.status !== "rejected",
+        `instance version/state differs or unexpected instance population: ${verdict.reason}`,
+      );
+      if (verdict.status === "converged") return result;
+      requireThat(
+        attempt < bounds.instanceAttempts,
+        `instance version/state differs: convergence attempts exhausted for ${names.join(",")}`,
+      );
+      await sleep(bounds.instanceIntervalMs, undefined, {
+        signal: convergence,
+      });
+    }
   }
   try {
     // Obtain the expected Worker ID before waking Containers; once awake, keep
@@ -396,6 +515,7 @@ export async function verifyDeployment(
         }
       }
     })();
+    stage = "platform_identity";
     const runtime = verifyVersion(
       m,
       sha,
@@ -472,30 +592,8 @@ export async function verifyDeployment(
           configuration.durable_objects?.namespace_id === namespaceId,
         "application is not linked to runtime namespace",
       );
-      const result = await wrangler([
-        "containers",
-        "instances",
-        app.id,
-        "--per-page",
-        "10",
-        "--json",
-      ]);
-      requireThat(
-        !result.result_info?.next_page_token &&
-          result.instances?.length === names.length,
-        "unexpected instance population",
-      );
-      for (const name of names) {
-        const rows = result.instances.filter((i) => i.name === name);
-        requireThat(
-          rows.length === 1 &&
-            shortIdentity(rows[0].id) &&
-            rows[0].state === "running" &&
-            scalarVersion(rows[0].version) &&
-            String(rows[0].version) === String(app.version),
-          `instance version/state differs: ${name}`,
-        );
-      }
+      stage = "instance_convergence";
+      const result = await convergeInstances(app, names, runtimeId);
       applications.push({
         applicationId: app.id,
         name: app.name,
@@ -512,6 +610,7 @@ export async function verifyDeployment(
         })),
       });
     }
+    stage = "async_triggers";
     const asyncTriggers = await verifyAsyncTriggers(m, mode, api);
     for (const prior of [runtime, adapter]) {
       const after = activeVersion(
@@ -523,9 +622,28 @@ export async function verifyDeployment(
         "deployment changed during readback",
       );
     }
+    stage = "final_application_identity";
+    const finalApps = await wrangler(["containers", "list", "--json"]);
+    requireThat(
+      Array.isArray(finalApps),
+      "invalid final application inventory",
+    );
+    for (const prior of applications) {
+      const matches = finalApps.filter((app) => app?.name === prior.name);
+      requireThat(
+        matches.length === 1 &&
+          matches[0].id === prior.applicationId &&
+          matches[0].image === prior.image &&
+          String(matches[0].version) === String(prior.version) &&
+          scalarVersion(matches[0].version) &&
+          ["active", "ready"].includes(matches[0].state),
+        "application changed during readback",
+      );
+    }
     heartbeat.abort();
     await loop;
     if (heartbeatFailure) throw heartbeatFailure;
+    stage = "final_readiness";
     await ready(runtimeId);
     return {
       format: "ghfind-feed-production-readiness-v1",
@@ -539,6 +657,7 @@ export async function verifyDeployment(
       runtime,
       adapter,
       applications,
+      instanceObservations,
       readiness: lastReadiness,
       bindingsVerified: true,
       asyncTriggers,
@@ -561,11 +680,38 @@ export async function verifyDeployment(
       note: "Read-only exact release readiness. Bootstrap off is not an application rollback; baseline must be separately deployed and read back.",
     };
   } catch (error) {
-    throw heartbeatFailure ?? (run.signal.aborted ? run.signal.reason : error);
+    const failure =
+      heartbeatFailure ?? (run.signal.aborted ? run.signal.reason : error);
+    failureReceipt = {
+      format: "ghfind-feed-production-readback-failure-v1",
+      status: "failed",
+      failureCode: "production_readback_failed",
+      stage,
+      accountId: ACCOUNT,
+      environment: "production",
+      ...identity,
+      observedAt: new Date().toISOString(),
+      readinessObservedAt: lastReadinessAt,
+      instanceObservations,
+      // Only validateReadiness's approved projection; never an unchecked response.
+      lastValidatedReadiness: lastReadiness ?? null,
+      keepWarm: {
+        completed: false,
+        stopped: false,
+        durationMs: Math.round(performance.now() - started),
+        readinessRequests,
+        metadataReads,
+        limits: bounds,
+      },
+      note: "Failed diagnostic only. Does not authorize baseline or traffic admission.",
+    };
+    failure.readbackFailure = failureReceipt;
+    throw failure;
   } finally {
     heartbeat.abort();
     run.abort();
     clearTimeout(timer);
     await loop;
+    if (failureReceipt) failureReceipt.keepWarm.stopped = true;
   }
 }

--- a/scripts/feed-platform-production.mjs
+++ b/scripts/feed-platform-production.mjs
@@ -247,6 +247,41 @@ export function renderAdapter(m, sha) {
   c.r2_buckets = [{ binding: "FEED_ARCHIVE", bucket_name: m.archiveBucket }];
   return c;
 }
+// A failed readback also gets an exclusive, sanitized diagnostic artifact.
+// It has a distinct format/status and can never satisfy validateReceipt.
+export async function verifyProductionToFile(
+  m,
+  sha,
+  image,
+  mode,
+  output,
+  options,
+) {
+  const { verifyDeployment } = await import(
+    "./feed-platform-production-readback.mjs"
+  );
+  let result;
+  try {
+    result = await verifyDeployment(m, sha, image, mode, options);
+  } catch (error) {
+    const failure = error.readbackFailure ?? {
+      format: "ghfind-feed-production-readback-failure-v1",
+      status: "failed",
+      failureCode: "readback_configuration_rejected",
+      observedAt: new Date().toISOString(),
+    };
+    writeFileSync(output, JSON.stringify(failure, null, 2) + "\n", {
+      flag: "wx",
+      mode: 0o600,
+    });
+    throw error;
+  }
+  writeFileSync(output, JSON.stringify(result, null, 2) + "\n", {
+    flag: "wx",
+    mode: 0o600,
+  });
+  return result;
+}
 export function validateReceipt(r, m, sha, image, mode, now = Date.now()) {
   const expected = releaseIdentity(m, sha, image, mode);
   requireThat(
@@ -638,15 +673,9 @@ async function main(args) {
     );
   }
   if (command === "verify" && args.length === 6) {
-    const { verifyDeployment } = await import(
-      "./feed-platform-production-readback.mjs"
-    );
-    const result = await verifyDeployment(m, sha, image, mode, {
+    await verifyProductionToFile(m, sha, image, mode, receiptOrOutput, {
       secret: process.env.FEED_RUNTIME_ADMIN_SECRET,
       token: process.env.CLOUDFLARE_API_TOKEN,
-    });
-    writeFileSync(receiptOrOutput, JSON.stringify(result, null, 2) + "\n", {
-      flag: "wx",
     });
     return console.log(
       "Production immutable deployment and authenticated readiness verified; no OAuth, load or cost acceptance claimed",

--- a/scripts/feed-platform-production.test.mjs
+++ b/scripts/feed-platform-production.test.mjs
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { setTimeout as sleep } from "node:timers/promises";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   template,
   validateManifest,
@@ -10,6 +13,7 @@ import {
   expectedBindings,
   validateReadiness,
   disableConsumers,
+  verifyProductionToFile,
 } from "./feed-platform-production.mjs";
 import {
   validateManifest as stagingValidate,
@@ -37,7 +41,9 @@ const admin = "r".repeat(32),
 function fixture(mode = "off", options = {}) {
   let total = 0,
     readyCalls = 0,
-    metadataCalls = 0;
+    metadataCalls = 0,
+    listCalls = 0;
+  const instanceCalls = new Map();
   const workerId = id(1),
     adapterId = id(2),
     deployments = {};
@@ -81,7 +87,7 @@ function fixture(mode = "off", options = {}) {
       assert.equal(init.headers.authorization, `Bearer ${admin}`);
       return Response.json(
         options.ready
-          ? options.ready(structuredClone(ready), readyCalls)
+          ? options.ready(structuredClone(ready), readyCalls, { metadataCalls })
           : ready,
       );
     }
@@ -191,10 +197,12 @@ function fixture(mode = "off", options = {}) {
     assert.ok(signal instanceof AbortSignal);
     if (options.delay && metadataCalls === 1)
       await sleep(options.delay, undefined, { signal });
-    if (args[1] === "list")
+    if (args[1] === "list") {
+      listCalls++;
       return options.applications
-        ? options.applications(structuredClone(applications))
+        ? options.applications(structuredClone(applications), listCalls)
         : applications;
+    }
     if (args[1] === "info") {
       const a = applications.find((a) => a.id === args[2]);
       const result = {
@@ -226,7 +234,11 @@ function fixture(mode = "off", options = {}) {
       })),
       result_info: {},
     };
-    return options.instances ? options.instances(result) : result;
+    const attempt = (instanceCalls.get(args[2]) ?? 0) + 1;
+    instanceCalls.set(args[2], attempt);
+    return options.instances
+      ? options.instances(result, { appId: args[2], attempt, signal })
+      : result;
   };
   return {
     fetcher,
@@ -238,7 +250,12 @@ function fixture(mode = "off", options = {}) {
       metadata,
       ...(options.bounds ? { limits: options.bounds } : {}),
     },
-    count: () => ({ total, readyCalls, metadataCalls }),
+    count: () => ({
+      total,
+      readyCalls,
+      metadataCalls,
+      instanceCalls: [...instanceCalls.values()].reduce((a, b) => a + b, 0),
+    }),
     ready,
   };
 }
@@ -311,7 +328,7 @@ test("bootstrap off has no asynchronous entrypoints; production resources and ca
 test("actual readback whitelists all published identity fields and gates baseline", async () => {
   const f = fixture();
   const r = await verifyDeployment(m, sha, image, "off", f.options);
-  assert.equal(r.keepWarm.metadataReads, 23);
+  assert.equal(r.keepWarm.metadataReads, 24);
   assert.equal(r.keepWarm.stopped, true);
   assert.equal(r.status, "passed");
   assert.equal(JSON.stringify(r).includes("must-not-upload"), false);
@@ -376,7 +393,7 @@ test("Wrangler ready application summary still requires all named running instan
     });
     const r = await verifyDeployment(m, sha, image, "off", f.options);
     assert.equal(r.status, "passed");
-    assert.equal(r.keepWarm.metadataReads, 23);
+    assert.equal(r.keepWarm.metadataReads, 24);
     assert.deepEqual(
       r.applications.map((a) =>
         a.instances.map((i) => [i.name, i.state, i.version]),
@@ -479,6 +496,7 @@ test("ready application summary cannot replace running instance, version or popu
     const f = fixture("off", {
       applications: (apps) => apps.map((app) => ({ ...app, state: "ready" })),
       instances,
+      bounds: { instanceAttempts: 2, instanceIntervalMs: 1 },
     });
     await assert.rejects(
       verifyDeployment(m, sha, image, "off", f.options),
@@ -489,8 +507,8 @@ test("ready application summary cannot replace running instance, version or popu
 test("ready summary and matching instances cannot hide a final process readiness change", async () => {
   const f = fixture("baseline", {
     applications: (apps) => apps.map((app) => ({ ...app, state: "ready" })),
-    ready: (r, call) => {
-      if (call > 1) r.containers[2].mode = "off";
+    ready: (r, _call, { metadataCalls }) => {
+      if (metadataCalls === 6) r.containers[2].mode = "off";
       return r;
     },
   });
@@ -498,7 +516,255 @@ test("ready summary and matching instances cannot hide a final process readiness
     verifyDeployment(m, sha, image, "baseline", f.options),
     /container readiness differs/,
   );
-  assert.equal(f.count().metadataCalls, 5);
+  assert.equal(f.count().metadataCalls, 6);
+});
+test("bounded placement convergence preserves each actual snapshot and requires fresh process readiness", async () => {
+  const f = fixture("off", {
+    bounds: { instanceIntervalMs: 1 },
+    instances: (result, { appId, attempt }) => {
+      if (appId === id(3) && attempt < 4) {
+        const patch = [
+          { state: "inactive", version: null },
+          { state: "stopped", version: 6 },
+          { state: "running", version: 6 },
+        ][attempt - 1];
+        Object.assign(result.instances[1], patch);
+      }
+      return result;
+    },
+  });
+  const r = await verifyDeployment(m, sha, image, "off", f.options);
+  assert.equal(r.status, "passed");
+  assert.equal(r.keepWarm.metadataReads, 27);
+  assert.equal(f.count().instanceCalls, 5);
+  assert.ok(f.count().readyCalls >= 7);
+  assert.deepEqual(
+    r.instanceObservations.map((o) => o.status),
+    ["pending", "pending", "pending", "converged", "converged"],
+  );
+  assert.deepEqual(
+    r.instanceObservations
+      .slice(0, 4)
+      .map((o) => [o.instances[1].state, o.instances[1].version]),
+    [
+      ["inactive", null],
+      ["stopped", 6],
+      ["running", 6],
+      ["running", 7],
+    ],
+  );
+  for (const o of r.instanceObservations) {
+    assert.equal(o.applicationVersion, 7);
+    assert.ok(Date.parse(o.readinessObservedAt) <= Date.parse(o.observedAt));
+    assert.deepEqual(Object.keys(o.instances[0]), [
+      "id",
+      "name",
+      "state",
+      "version",
+    ]);
+  }
+  assert.equal(JSON.stringify(r).includes("must-not-upload"), false);
+  assert.equal(JSON.stringify(r).includes("arbitraryBody"), false);
+});
+test("permanent placement lag exhausts attempts, persists safe diagnostics and cannot authorize baseline", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "ghfind-readback-"));
+  const output = join(directory, "failed.json");
+  try {
+    const f = fixture("off", {
+      bounds: { instanceAttempts: 3, instanceIntervalMs: 1 },
+      instances: (result) => ({
+        ...result,
+        instances: result.instances.map((i) => ({
+          ...i,
+          state: "inactive",
+          version: null,
+        })),
+      }),
+    });
+    await assert.rejects(
+      verifyProductionToFile(m, sha, image, "off", output, f.options),
+      /convergence attempts exhausted/,
+    );
+    assert.equal(f.count().instanceCalls, 3);
+    const report = JSON.parse(readFileSync(output, "utf8"));
+    assert.equal(report.status, "failed");
+    assert.equal(report.keepWarm.completed, false);
+    assert.equal(report.keepWarm.stopped, true);
+    assert.equal(report.stage, "instance_convergence");
+    assert.equal(report.instanceObservations.length, 3);
+    assert.equal(report.lastValidatedReadiness.length, 3);
+    assert.equal(JSON.stringify(report).includes("must-not-upload"), false);
+    assert.equal(JSON.stringify(report).includes("arbitraryBody"), false);
+    assert.equal(statSync(output).mode & 0o777, 0o600);
+    assert.throws(
+      () => validateReceipt(report, m, sha, image, "off"),
+      /matching/,
+    );
+    assert.throws(
+      () => renderRuntime(m, image, sha, "baseline", report),
+      /matching/,
+    );
+    const saved = readFileSync(output, "utf8");
+    await assert.rejects(
+      verifyProductionToFile(m, sha, image, "off", output, {
+        secret: "invalid",
+        token,
+      }),
+      /EEXIST/,
+    );
+    assert.equal(readFileSync(output, "utf8"), saved);
+    const before = f.count().total;
+    await sleep(20);
+    assert.equal(f.count().total, before);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+test("invalid instance shape or unhealthy placement fails without any retry", async () => {
+  for (const instances of [
+    () => null,
+    (r) => ({ ...r, result_info: undefined }),
+    (r) => ({ ...r, instances: [null, null] }),
+    (r) => ({
+      ...r,
+      instances: r.instances.map((i) => ({ ...i, id: "same-id" })),
+    }),
+    (r) => ({
+      ...r,
+      instances: r.instances.map((i) => ({ ...i, version: null })),
+    }),
+    ...["failed", "unhealthy", "unknown", "active"].map((state) => (r) => ({
+      ...r,
+      instances: r.instances.map((i) => ({ ...i, state })),
+    })),
+  ]) {
+    const f = fixture("off", { instances });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      (error) => {
+        assert.equal(error.readbackFailure.instanceObservations.length, 1);
+        assert.equal(
+          error.readbackFailure.instanceObservations[0].status,
+          "rejected",
+        );
+        return true;
+      },
+    );
+    assert.equal(f.count().instanceCalls, 1);
+  }
+});
+test("instance retry cannot mask wrong actual mode on the next authenticated readiness", async () => {
+  const f = fixture("baseline", {
+    bounds: { instanceIntervalMs: 1 },
+    ready: (r, call) => {
+      if (call >= 3) r.containers[1].mode = "off";
+      return r;
+    },
+    instances: (r) => ({
+      ...r,
+      instances: r.instances.map((i) => ({
+        ...i,
+        state: "stopped",
+        version: 6,
+      })),
+    }),
+  });
+  await assert.rejects(
+    verifyDeployment(m, sha, image, "baseline", f.options),
+    /container readiness differs/,
+  );
+  assert.equal(f.count().instanceCalls, 1);
+});
+test("per-app deadline cancels waiting or metadata and never accepts a late snapshot", async () => {
+  for (const blocked of ["wait", "metadata"]) {
+    const f = fixture("off", {
+      bounds: { instanceConvergenceMs: 30, instanceIntervalMs: 100 },
+      instances: async (r, { signal }) => {
+        if (blocked === "metadata") await sleep(1000, undefined, { signal });
+        return {
+          ...r,
+          instances: r.instances.map((i) => ({
+            ...i,
+            state: "inactive",
+            version: null,
+          })),
+        };
+      },
+    });
+    const start = performance.now();
+    await assert.rejects(verifyDeployment(m, sha, image, "off", f.options));
+    assert.ok(performance.now() - start < 500);
+    assert.equal(f.count().instanceCalls, 1);
+    const before = f.count().total;
+    await sleep(20);
+    assert.equal(f.count().total, before);
+  }
+});
+test("heartbeat failure aborts in-flight convergence metadata without another attempt", async () => {
+  const f = fixture("off", {
+    bounds: { intervalMs: 5 },
+    ready: (r, call) => {
+      if (call >= 3) r.containers[0].storageWriterVersion = 1;
+      return r;
+    },
+    instances: async (r, { signal }) => {
+      await sleep(1000, undefined, { signal });
+      return r;
+    },
+  });
+  await assert.rejects(
+    verifyDeployment(m, sha, image, "off", f.options),
+    /container readiness differs/,
+  );
+  assert.equal(f.count().instanceCalls, 1);
+  const before = f.count().total;
+  await sleep(20);
+  assert.equal(f.count().total, before);
+});
+test("final application snapshot must retain exact application, image and version", async () => {
+  for (const patch of [
+    { version: 8 },
+    { image: "mutable:latest" },
+    { id: id(900) },
+    { state: "degraded" },
+  ]) {
+    const f = fixture("off", {
+      applications: (apps, call) =>
+        call === 2 ? [{ ...apps[0], ...patch }, apps[1]] : apps,
+    });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      /application changed during readback/,
+    );
+    assert.equal(f.count().instanceCalls, 2);
+  }
+});
+test("fixed readback quotas cover both maximum attempt series without widening time or transport bounds", async () => {
+  assert.equal(limits.durationMs, 180000);
+  assert.equal(limits.metadataReads, 23 + 14 + 1);
+  assert.equal(limits.readinessRequests, 95);
+  assert.equal(limits.instanceAttempts, 8);
+  assert.equal(limits.instanceConvergenceMs, 60000);
+  assert.equal(limits.metadataMs, 30000);
+  assert.equal(limits.requestMs, 10000);
+  const f = fixture("off", {
+    bounds: { instanceIntervalMs: 1 },
+    instances: (r, { attempt }) =>
+      attempt < 8
+        ? {
+            ...r,
+            instances: r.instances.map((i) => ({
+              ...i,
+              state: "provisioning",
+              version: 7,
+            })),
+          }
+        : r,
+  });
+  const r = await verifyDeployment(m, sha, image, "off", f.options);
+  assert.equal(r.instanceObservations.length, 16);
+  assert.equal(r.keepWarm.metadataReads, limits.metadataReads);
+  assert.equal(r.keepWarm.readinessRequests, 18);
 });
 test("both runtime and adapter active deployments must stay fixed through readback", async () => {
   for (const changedWorker of [m.runtimeWorker, m.adapterWorker]) {
@@ -646,7 +912,7 @@ test("actual async wiring is checked for off and baseline and retains only polic
   for (const mode of ["off", "baseline"]) {
     const f = fixture(mode),
       r = await verifyDeployment(m, sha, image, mode, f.options);
-    assert.equal(r.keepWarm.metadataReads, 23);
+    assert.equal(r.keepWarm.metadataReads, 24);
     assert.equal(r.asyncTriggers.verified, true);
     assert.equal(r.asyncTriggers.mode, mode);
     assert.deepEqual(


### PR DESCRIPTION
## Problem and resulting behavior

After #277 fixed the application summary interpretation, [production attempt 34345222007](https://github.com/hikariming/ghfind/actions/runs/34345222007) passed initial actual Go readiness but failed the one-shot `api-1` placement check. Later independent metadata showed both API instances running at the expected application version 2. The failed instantaneous value was not saved, so this PR does not assert which state/version was transient.

Cloudflare [documents that deployment does not wait for every instance replacement](https://developers.cloudflare.com/containers/guides/deploy/). The reader now waits for strictly valid placement metadata to converge within bounded attempts, while checking fresh authenticated Go readiness each round. Final acceptance still requires three precisely named running instances, exact application version/digest/namespace/capacity and final unchanged Worker and application identities. Failed, unhealthy, unknown or malformed metadata fails immediately. Wrong actual Go readiness is never retried into a pass.

## Scope and compatibility

Only the production readback CLI and tests change. Public HTTP contract 1, storage writer 2, runtime schema 7, physical schema 12 and the sole Feed D1 are unchanged. No migrations, business writes, provider requests or additional persistent resources are added by the reader. Production remains legacy until the existing verified Actions pipeline reaches the real assessment, projection and service checks.

Total readback remains 180 seconds. Each application permits at most eight instance reads over at most 60 seconds, at 2.5-second intervals. Metadata budget is 38 (previous 23 + at most 14 extra placement reads + one final application read); readiness budget is 95 for bounded heartbeat plus per-attempt and final checks. Success and failure preserve only bounded nonsecret observations. A failed diagnostic has a distinct format/status and cannot authorize baseline or traffic.

## Commits and validation

Base main `e60f2110e93279d264d5c6e810ad03a4bed4d33f`. Exact commit, source tree, local dual-profile E2E and regression results are filled below before push. Rebase merge through PR, never squash. Accurate branch push CI, PR compatibility CI and actual merged-main CI are separate evidence.

## Release, cost, rollback and remaining acceptance

The current failed release left Web `3b4b74f8-1f99-4fcc-b590-19035711eed8` on source `aa8c683` at 100%; off runtime `fe3bc40f-8770-4e08-ae48-f0714a343d03`; adapter `5625651b-28a6-4845-a60f-2ce502f4e1e9`. Image: `registry.cloudflare.com/8f19bebe359e4ec1a24c68c5f49c1584/ghfind-feed@sha256:b1a3ab93ff4ed866283a46182d97ae9107415c73823fa702e124720ea88e607a`. No paused Web, writer-fence activation or real assessment occurred in that failed attempt.

After independently successful main CI, protected GitHub Actions publishes a new immutable exact-source image, reads actual services/schema/instances, installs a Go-only paused Web, fences legacy writers, starts one journaled real Mosoo assessment, verifies queue projection and bounded service smoke, then opens all routing. No local deploy. CF state is read after each push/merge/deploy; source push alone is not cutover.

After Go writes, never restore old Next writers or reverse schema. Use the captured exact-source paused Go Web with the protected `Feed production pause` workflow and then verify actual state. This returns Feed 503 for containment, not proven availability recovery. No resource cost increase; bounded extra metadata reads are diagnostic overhead, not load testing. The $79.69848/$100 monthly scenario remains unmeasured. Capacity, full fault/recovery/migration/semantics and historical/legacy operations remain separate incomplete original-plan acceptance. Main agent owns integration and serialized release; subagent supplied the isolated reader fix.

## Verified before this source push

Commit `d679af4756dcd45e2e9ba248c28156d1a29e231d` (`fix(release): bound instance convergence and persist diagnostics`), tree `5f00ccd5d2b716c58253694cfdc4bd052ca0d123`, clean checkout.

- `node --test scripts/feed-platform-production.test.mjs`: 33/33 passed, zero skips. Covers maximum 16 total placement attempts/38 metadata reads, convergence deadline including metadata reads, actual readiness failure, permanent failures, safe failure receipt with no overwrite, and final application drift.
- `python3 scripts/run-feed-e2e.py --release-sha d679af4756dcd45e2e9ba248c28156d1a29e231d --directory /tmp/ghfind-go-production-e2e-instance-readback-20260909 --execute`: both real local profiles passed all eight journey milestones and cleanup. `realOAuth=false`, `externalProviders=local-fixture-transports` remain explicit. Evidence: `run.json` plus `cf_d1_r2/journey.json` and `postgres/journey.json`.
- Additional release/recovery/assessment/pause Node tests passed. An overbroad `node --test scripts/feed-production-*.test.mjs` invocation failed on two mixed-runner suites; its log is retained. Correct repository commands then passed: `node --import tsx --test scripts/feed-production-compatibility.test.mjs` (14/14 actual workerd tests), `pnpm exec vitest run scripts/feed-production-smoke.test.mjs` (12/12). No source change, skipped test or weakened assertion was used to resolve this invocation error. Logs: `/tmp/ghfind-go-production-20260909/instance-readback-*`.

Remote exact-source push CI, PR compatibility and merged-main validation are pending at creation and will be appended. New production digest and observed active states must come from the subsequent Actions evidence.

## Remote gates before merge

- [Exact push CI 34346506798](https://github.com/hikariming/ghfind/actions/runs/34346506798): all five jobs passed for `d679af4756dcd45e2e9ba248c28156d1a29e231d`. Artifact digest, actual checkout/tree and both E2E profiles were verified with the production evidence checker; receipt `instance-readback-exact-branch-ci.json`.
- [PR compatibility CI 34346523646](https://github.com/hikariming/ghfind/actions/runs/34346523646): all five jobs passed. Synthetic checkout is separately classified.
- CF readback after push at 2026-09-09T11:37:03Z retained old Web `3b4b74f8...`, new source e60f211 runtime `fe3bc40f...` in off, and adapter `5625651b...`. Evidence: `after-instance-readback-push.json`.
- Actual rebase main SHA, its independent CI and the resulting production manifest will be appended; no source push/merge is represented as traffic activation.

## Actual merged main validation

PR rebase merged at 2026-09-09T11:41:36Z as `fd796e34afc80f8091fecec4ab6320f4fd284491`. [Main CI 34346900712](https://github.com/hikariming/ghfind/actions/runs/34346900712) passed all jobs, and the exact actual checkout/E2E artifacts were verified in `instance-readback-exact-main-ci.json`. Post-merge CF readback at 11:41:45Z remained legacy Web plus off Go runtime. [Production 34347218741](https://github.com/hikariming/ghfind/actions/runs/34347218741) has started and passed its authorization gate; final rollout evidence remains pending.

## Retained failed production readbacks

[Production 34347218741 attempt 1](https://github.com/hikariming/ghfind/actions/runs/34347218741/attempts/1) persisted the new diagnostic: eight API placement snapshots showed api-0 running/version3 and api-1 stopped/version3 while all three authenticated Go readiness responses remained current. It correctly stopped without opening Web or starting assessment. No contradictory state was accepted.

A single same-SHA [attempt 2](https://github.com/hikariming/ghfind/actions/runs/34347218741/attempts/2) was run with a bounded independent raw placement sampler. api-1 changed from inactive/null to running/version4 by the second strict read; api-0 was also running/version4. Raw metadata independently confirmed distinct physical deployments mapped to the correct DOs and running status. That run then failed the executor application summary/identity check. Its failed instantaneous application summary was not yet included in diagnostics, so no exact summary value is asserted. Later applications were both active with the expected image/version4.

Artifacts and failed logs are preserved under `production-attempt3/`, `production-attempt3-rerun/`, `production-attempt3-failed.log`, `production-attempt3-rerun-failed.log`, and `attempt3-rerun-api-placements.json`. Main Web was not changed and assessment was not started. Follow-up delivery adds bounded application-summary observations/convergence and requests a single platform rollout step while traffic is legacy/paused. All final instance-running, exact-image/version and authenticated-readiness requirements remain.
