### PR TITLE
fix(release): initialize queue state and verify canonical origin

### DIFF
--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -189,6 +189,7 @@ jobs:
         id: smoke
         env:
           SMOKE_BASE_URL: https://ghfind.beiming1201.workers.dev
+          SMOKE_EXPECTED_ORIGIN: https://ghfind.com
           SMOKE_CANARY_HANDLE: octocat
           SMOKE_FACET_TYPE: language
           SMOKE_FACET_VALUE: TypeScript

--- a/docs/feed-production-direct-release.md
+++ b/docs/feed-production-direct-release.md
@@ -23,6 +23,10 @@ receipts and actual repository protection. The workflow then:
 2. Reads the pinned production D1 databases; creates only the separately named
    production archive bucket and three bounded queues if absent. No production
    database is created, copied, promoted or deleted.
+   Preflights all queue identities, retention and delivery settings. If the
+   optional delivery pause field is absent, initializes explicit `false` and
+   requires a fresh exact readback; an explicit operator pause or settings drift
+   stops the release. Existing queues and messages are preserved.
 3. Applies only the file/hash approvals in `ops/feed-production-schema-release.json`.
    The dev/legacy application migration allowlist remains unchanged.
 4. Detaches only the owned queue consumers, preserving queues and messages.

--- a/docs/feed-production-direct-release.md
+++ b/docs/feed-production-direct-release.md
@@ -48,7 +48,8 @@ receipts and actual repository protection. The workflow then:
    authenticated service-contract smoke with nonempty eligible candidates.
 7. Publishes the same Web build in `all` mode and reads back its runtime binding,
    source SHA, production D1, outbox flag, secrets inventory and all routing vars.
-   Public smoke runs at the WAF-free production workers.dev origin. The custom
+   Public smoke requests the production workers.dev origin and explicitly checks
+   canonical links against `https://ghfind.com` via `SMOKE_EXPECTED_ORIGIN`. The custom
    domain and actual OAuth Feed journey are also checked in the holder browser.
 
 Independent staging workflows stay isolated and cannot accept production IDs.

--- a/scripts/check-cf-release-workflow.mts
+++ b/scripts/check-cf-release-workflow.mts
@@ -36,6 +36,10 @@ for (let i=1;i<order.length;i++) if(deployJob.indexOf(order[i])<=deployJob.index
 // platform rollout step, but retain all actual readiness/instance gates.
 const runtimeDeploys = deployJob.split('\n').filter(line => line.includes('wrangler deploy --config platform/runtime/wrangler.production.generated.json'));
 if (runtimeDeploys.length !== 2 || runtimeDeploys.some(line => !line.includes('--containers-rollout=immediate'))) throw new Error('Paused production runtime requires explicit immediate Container rollout');
+const publicSmoke = /      - name: Bounded public production smoke\n([\s\S]*?)(?=      - name:)/.exec(deployJob)?.[1] ?? '';
+for (const fragment of ['SMOKE_BASE_URL: https://ghfind.beiming1201.workers.dev', 'SMOKE_EXPECTED_ORIGIN: https://ghfind.com', 'run: pnpm smoke:deployment']) {
+  if (!publicSmoke.includes(fragment)) throw new Error(`Production smoke must preserve its transport and canonical origin: ${fragment}`);
+}
 if (/^  (push|workflow_dispatch):/m.test(workflow) || workflow.includes('secrets: inherit') || deployJob.includes('previous_version') || /continue-on-error:\s*true/.test(deployJob)) throw new Error('Unsafe bypass, inherited secrets, legacy rollback or optional production gate');
 
 const ciPath = resolve(process.cwd(), ".github/workflows/ci.yml");

--- a/scripts/check-cf-release-workflow.test.mjs
+++ b/scripts/check-cf-release-workflow.test.mjs
@@ -51,3 +51,13 @@ test('private runtime rollout stays immediate after the existing Go gateway paus
   }
   assert.throws(() => check({ 'deploy-cf-production.yml': production.replace('Pause an already active Go gateway', 'Missing pre-update pause') }));
 });
+
+test('public production smoke checks the canonical custom domain even through workers.dev', () => {
+  const production = originals['deploy-cf-production.yml'];
+  for (const replacement of ['', '          SMOKE_EXPECTED_ORIGIN: https://ghfind.beiming1201.workers.dev\n']) {
+    assert.throws(() => check({ 'deploy-cf-production.yml': production.replace('          SMOKE_EXPECTED_ORIGIN: https://ghfind.com\n', replacement) }));
+  }
+  const misplaced = production.replace('          SMOKE_EXPECTED_ORIGIN: https://ghfind.com\n', '')
+    .replace('    env:\n', '    env:\n      SMOKE_EXPECTED_ORIGIN: https://ghfind.com\n');
+  assert.throws(() => check({ 'deploy-cf-production.yml': misplaced }));
+});

--- a/scripts/feed-production-release.mjs
+++ b/scripts/feed-production-release.mjs
@@ -51,6 +51,19 @@ export async function cf(path, body, method) {
   if(!response.ok || data.success!==true) throw Object.assign(new Error(`Cloudflare request failed (${response.status}; ${(data.errors??[]).map(e=>e.code).join(',')})`),{status:response.status});
   return data.result;
 }
+function queueIdentity(q, name, id) {
+  requireThat(q && q.queue_name===name && typeof q.queue_id==='string' && /^[a-f0-9]{32}$/.test(q.queue_id) && (id===undefined || q.queue_id===id),'queue identity mismatch');
+}
+function queueSettings(q, target, requireExplicit=false) {
+  queueIdentity(q,target.name,target.id);
+  const s=q.settings;
+  requireThat(s && typeof s==='object' && !Array.isArray(s) && s.message_retention_period===target.retention && s.delivery_delay===0,'queue retention/delivery settings differ');
+  const explicit=Object.hasOwn(s,'delivery_paused');
+  // Missing is an initialization candidate, never evidence that delivery is on.
+  // Do not undo an operator pause or coerce malformed API values to false.
+  requireThat(explicit ? s.delivery_paused===false : !requireExplicit,'queue delivery pause must be explicitly false');
+  return explicit;
+}
 export async function ensureResources(m, api=cf) {
   validateManifest(m); authorizeMutation();
   const resources=[];
@@ -66,9 +79,38 @@ export async function ensureResources(m, api=cf) {
   requireThat(bucket.name===m.archiveBucket,'archive identity mismatch');resources.push({kind:'r2',name:bucket.name});
   const queues=[];
   for(let page=1;page<=20;page++) { const rows=await api(`/queues?per_page=100&page=${page}`);requireThat(Array.isArray(rows),'invalid queue list');queues.push(...rows);if(rows.length<100)break;requireThat(page<20,'queue inventory exceeds bound'); }
+  const targets=[];
   for(const name of [m.queue,m.deadLetterQueue,m.terminalParkingQueue]) {
-    const found=queues.filter(q=>q.queue_name===name);requireThat(found.length<=1,'ambiguous queue identity');
-    const q=found[0]??await api('/queues',{queue_name:name,settings:{message_retention_period:name===m.terminalParkingQueue?1209600:345600,delivery_delay:0}});requireThat(q.queue_name===name && /^[a-f0-9]{32}$/.test(q.queue_id),'queue identity mismatch');resources.push({kind:'queue',name,id:q.queue_id});
+    const found=queues.filter(q=>q?.queue_name===name);requireThat(found.length<=1,'ambiguous queue identity');
+    if(found[0])queueIdentity(found[0],name);
+    targets.push({name,id:found[0]?.queue_id,retention:name===m.terminalParkingQueue?1209600:345600});
+  }
+  const existingIds=targets.filter(t=>t.id!==undefined).map(t=>t.id);
+  requireThat(new Set(existingIds).size===existingIds.length,'ambiguous queue identity');
+  // Preflight every existing target before any queue POST/PUT. In particular, a
+  // paused or changed third queue must not partially initialize the first two.
+  for(const target of targets) {
+    if(target.id!==undefined)target.explicit=queueSettings(await api(`/queues/${target.id}`),target);
+  }
+  for(const target of targets) {
+    const settings={message_retention_period:target.retention,delivery_delay:0,delivery_paused:false};
+    if(target.id===undefined) {
+      const created=await api('/queues',{queue_name:target.name,settings});
+      queueIdentity(created,target.name);
+      requireThat(!existingIds.includes(created.queue_id),'ambiguous queue identity');
+      target.id=created.queue_id;existingIds.push(target.id);
+      queueSettings(await api(`/queues/${target.id}`),target,true);
+    } else if(!target.explicit) {
+      // Re-read immediately before a full configuration PUT. Abort if a pause,
+      // retention/delay edit or identity change appeared after the preflight.
+      // https://developers.cloudflare.com/api/resources/queues/methods/update/
+      if(!queueSettings(await api(`/queues/${target.id}`),target)) {
+        const updated=await api(`/queues/${target.id}`,{queue_name:target.name,settings},'PUT');
+        queueIdentity(updated,target.name,target.id);
+        queueSettings(await api(`/queues/${target.id}`),target,true);
+      }
+    }
+    resources.push({kind:'queue',name:target.name,id:target.id});
   }
   return {status:'verified',accountId:ACCOUNT,observedAt:new Date().toISOString(),existingBackend:backend,previousWebVersion:active[0].version_id,resources};
 }

--- a/scripts/feed-production-release.test.mjs
+++ b/scripts/feed-production-release.test.mjs
@@ -1,8 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { authorizeMutation, renderWeb, prepareSecrets, safeBuildEnv, verifyWeb } from './feed-production-release.mjs';
+import { authorizeMutation, renderWeb, prepareSecrets, safeBuildEnv, verifyWeb, ensureResources } from './feed-production-release.mjs';
 import { approvedSchemas } from './feed-platform-schema-release.mjs';
+import { template } from './feed-platform-production.mjs';
 const sha='a'.repeat(40);
 const provider={MOSOO_API_BASE:'https://cloud.mosoo.ai/api/v1',MOSOO_PROJECT_AGENT_ID:'01M22PWZR0A7ZYCDKWTEA0YEHQ',MOSOO_PROJECT_USER_ID:'ghfind-feed-staging'};
 test('production mutations reject local, fork, branch and alternate workflow execution',()=>{
@@ -49,4 +50,120 @@ test('production Feed schema approval covers the complete fixed migrations witho
  const legacy=JSON.parse(readFileSync(new URL('../ops/feed-application-schema-release.json',import.meta.url)));
  assert.equal(legacy.feed.length,2);
  assert.ok(!legacy.core.some(e=>e.name==='0005_feed_source_outbox.sql'));
+});
+
+const productionActions={GITHUB_ACTIONS:'true',GITHUB_REPOSITORY:'hikariming/ghfind',GITHUB_REF:'refs/heads/main',GITHUB_WORKFLOW_REF:'hikariming/ghfind/.github/workflows/deploy-cf-production.yml@refs/heads/main'};
+async function withActions(fn,changes={}) {
+ const saved=Object.fromEntries(Object.keys(productionActions).map(k=>[k,process.env[k]]));
+ Object.assign(process.env,productionActions,changes);
+ try{return await fn();}finally{for(const [k,v] of Object.entries(saved)){if(v===undefined)delete process.env[k];else process.env[k]=v;}}
+}
+function resourcesFixture({missing=[],pause=false,onRead,onWrite}={}) {
+ const m=template();m.billing={confirmed:true,evidence:'https://example.invalid/synthetic-billing',maximumMonthlyUSD:100,projectedMonthlyUSD:50};
+ const names=[m.queue,m.deadLetterQueue,m.terminalParkingQueue];
+ const ids=names.map((_,i)=>String(i+1).repeat(32));
+ const calls=[],reads=new Map();
+ const rows=new Map(names.filter(n=>!missing.includes(n)).map(name=>{
+  const q={queue_name:name,queue_id:ids[names.indexOf(name)],settings:{message_retention_period:name===m.terminalParkingQueue?1209600:345600,delivery_delay:0},consumers:[{consumer_id:'preserved-consumer'}],messages:17};
+  if(pause!=='missing')q.settings.delivery_paused=pause;
+  return [q.queue_id,q];
+ }));
+ const api=async(path,body,method)=>{
+  method??=body?'POST':'GET';calls.push({path,method,...(body?{body:structuredClone(body)}:{})});
+  if(path==='/workers/scripts/ghfind/deployments')return {deployments:[{versions:[{percentage:100,version_id:'11111111-1111-4111-8111-111111111111'}]}]};
+  if(path.startsWith('/workers/scripts/ghfind/versions/'))return {resources:{bindings:[{name:'FEED_BACKEND',text:'go'}]}};
+  for(const d of [m.coreDatabase,m.feedDatabase])if(path===`/d1/database/${d.id}`)return {uuid:d.id,name:d.name};
+  if(path===`/r2/buckets/${m.archiveBucket}`)return {name:m.archiveBucket};
+  if(path==='/queues?per_page=100&page=1')return [...rows.values()].map(q=>({queue_id:q.queue_id,queue_name:q.queue_name}));
+  if(path==='/queues'&&method==='POST') {
+   assert.ok(names.includes(body.queue_name));
+   assert.ok(![...rows.values()].some(q=>q.queue_name===body.queue_name));
+   const q={queue_id:ids[names.indexOf(body.queue_name)],...structuredClone(body),consumers:[],messages:0};
+   rows.set(q.queue_id,q);onWrite?.(q,method);return structuredClone(q);
+  }
+  const match=/^\/queues\/([a-f0-9]{32})$/.exec(path);
+  if(match) {
+   const q=rows.get(match[1]);assert.ok(q,'known queue required');
+   if(method==='GET') {
+    const count=(reads.get(match[1])??0)+1;reads.set(match[1],count);
+    const result=structuredClone(q);onRead?.(result,count,rows);return result;
+   }
+   assert.equal(method,'PUT');assert.deepEqual(Object.keys(body).sort(),['queue_name','settings']);
+   Object.assign(q,structuredClone(body));onWrite?.(q,method);return structuredClone(q);
+  }
+  throw new Error(`unexpected synthetic API call ${method} ${path}`);
+ };
+ return {m,names,ids,api,calls,rows,reads,mutations:()=>calls.filter(c=>c.method!=='GET')};
+}
+test('resource initialization is Actions-only before even reading the API',async()=>{
+ for(const changed of [{GITHUB_ACTIONS:'false'},{GITHUB_REPOSITORY:'fork/ghfind'},{GITHUB_REF:'refs/heads/feature'},{GITHUB_WORKFLOW_REF:'hikariming/ghfind/.github/workflows/ci.yml@refs/heads/main'}]) {
+  const f=resourcesFixture();await withActions(()=>assert.rejects(ensureResources(f.m,f.api),/only the production Actions/),changed);assert.deepEqual(f.calls,[]);
+ }
+});
+test('missing delivery flag initializes once only after all three exact queue preflights and fresh explicit readback',async()=>{
+ const f=resourcesFixture({pause:'missing'});
+ const before=[...f.rows.values()].map(q=>({id:q.queue_id,consumers:q.consumers,messages:q.messages}));
+ const result=await withActions(()=>ensureResources(f.m,f.api));
+ assert.equal(result.status,'verified');assert.equal(result.resources.filter(r=>r.kind==='queue').length,3);
+ assert.equal(f.mutations().length,3);
+ const firstMutation=f.calls.findIndex(c=>c.method!=='GET');
+ for(const id of f.ids)assert.ok(f.calls.slice(0,firstMutation).some(c=>c.path===`/queues/${id}`&&c.method==='GET'));
+ for(const c of f.mutations()) {
+  assert.equal(c.method,'PUT');
+  assert.deepEqual(c.body,{queue_name:f.names[f.ids.indexOf(c.path.split('/').at(-1))],settings:{message_retention_period:c.body.queue_name===f.m.terminalParkingQueue?1209600:345600,delivery_delay:0,delivery_paused:false}});
+ }
+ for(const old of before) {
+  const current=f.rows.get(old.id);assert.deepEqual(current.consumers,old.consumers);assert.equal(current.messages,old.messages);assert.equal(f.reads.get(old.id),3);
+ }
+ await withActions(()=>ensureResources(f.m,f.api));assert.equal(f.mutations().length,3,'successful re-entry never repeats PUT');
+});
+test('new queue creation pins explicit delivery false and independently reads its exact identity and settings',async()=>{
+ const names=resourcesFixture().names;
+ const f=resourcesFixture({missing:names});
+ await withActions(()=>ensureResources(f.m,f.api));
+ assert.equal(f.mutations().length,3);assert.ok(f.mutations().every(c=>c.path==='/queues'&&c.method==='POST'&&c.body.settings.delivery_paused===false));
+ for(const id of f.ids)assert.equal(f.reads.get(id),1);
+ await withActions(()=>ensureResources(f.m,f.api));assert.equal(f.mutations().length,3);
+});
+test('explicit false is idempotent while a third paused or malformed queue prevents every queue mutation',async()=>{
+ const ready=resourcesFixture();await withActions(()=>ensureResources(ready.m,ready.api));assert.deepEqual(ready.mutations(),[]);
+ for(const pause of [true,null,0,'false',undefined]) {
+  const f=resourcesFixture({pause:'missing'});f.rows.get(f.ids[2]).settings.delivery_paused=pause;
+  await withActions(()=>assert.rejects(ensureResources(f.m,f.api),/pause must be explicitly false/));assert.deepEqual(f.mutations(),[]);
+ }
+ for(const key of ['message_retention_period','delivery_delay']) {
+  const f=resourcesFixture({pause:'missing'});f.rows.get(f.ids[2]).settings[key]++;
+  await withActions(()=>assert.rejects(ensureResources(f.m,f.api),/retention\/delivery settings differ/));assert.deepEqual(f.mutations(),[]);
+ }
+ const f=resourcesFixture({missing:[ready.names[0]],pause:'missing'});f.rows.get(f.ids[2]).settings.delivery_paused=true;
+ await withActions(()=>assert.rejects(ensureResources(f.m,f.api)));assert.deepEqual(f.mutations(),[],'new queue cannot be created before existing third target preflight');
+});
+test('identity drift during preflight or immediate pre-PUT read fails without changing a queue',async()=>{
+ for(const countToChange of [1,2])for(const field of ['queue_id','queue_name']) {
+  const f=resourcesFixture({pause:'missing',onRead(q,count){if(count===countToChange)q[field]=field==='queue_id'?'f'.repeat(32):'other-owner-queue';}});
+  await withActions(()=>assert.rejects(ensureResources(f.m,f.api),/queue identity mismatch/));assert.deepEqual(f.mutations(),[]);
+ }
+ const paused=resourcesFixture({pause:'missing',onRead(q,count){if(count===2)q.settings.delivery_paused=true;}});
+ await withActions(()=>assert.rejects(ensureResources(paused.m,paused.api),/pause must be explicitly false/));assert.deepEqual(paused.mutations(),[]);
+ const initialized=resourcesFixture({pause:'missing',onRead(q,count){if(count===2)q.settings.delivery_paused=false;}});
+ await withActions(()=>ensureResources(initialized.m,initialized.api));assert.deepEqual(initialized.mutations(),[],'another initializer completed between reads');
+});
+test('PUT and create cannot pass without explicit fresh readback or with changed returned identity/settings',async()=>{
+ for(const existing of [true,false])for(const change of ['missing','paused','malformed','identity','retention','delay','get-error']) {
+  const f=resourcesFixture({missing:existing?[]:resourcesFixture().names,pause:'missing',onRead(q,count){
+   if(count!==(existing?3:1))return;
+   if(change==='missing')delete q.settings.delivery_paused;
+   if(change==='paused')q.settings.delivery_paused=true;
+   if(change==='malformed')q.settings.delivery_paused='false';
+   if(change==='identity')q.queue_id='f'.repeat(32);
+   if(change==='retention')q.settings.message_retention_period++;
+   if(change==='delay')q.settings.delivery_delay++;
+   if(change==='get-error')throw new Error('synthetic readback unavailable');
+  }});
+  await withActions(()=>assert.rejects(ensureResources(f.m,f.api)));assert.equal(f.mutations().length,1,'uncertain operation is never blindly retried and later targets stay untouched');
+ }
+ for(const existing of [true,false]) {
+  const f=resourcesFixture({missing:existing?[]:resourcesFixture().names,pause:'missing',onWrite(q){q.queue_name='other-owner-queue';}});
+  await withActions(()=>assert.rejects(ensureResources(f.m,f.api),/queue identity mismatch/));assert.equal(f.mutations().length,1);
+ }
 });


### PR DESCRIPTION
## Problem and resulting behavior

The final candidate also corrects the public release smoke: requests still use workers.dev, while canonical links must match the configured production domain `https://ghfind.com`. The previous implicit transport-origin expectation would falsely fail after a healthy cutover. The smoke assertion itself is preserved; its expected origin is now explicit and step-scoped.

[Production34352849551](https://github.com/hikariming/ghfind/actions/runs/34352849551), exact source `09ffe57c7652208a999174255e6b000ca6f8e4ca`, passed initial authenticated readiness and observed api-0, api-1 and executor-0 running at applicationversion5 with the pinned digest. It then stopped at strict asynchronous-trigger validation: all three dedicated queues had correct retention/delivery-delay but no `settings.delivery_paused` field. No paused Web, writer-fence activation, assessment or gateway cutover was reached. The failed receipt remains diagnostic, not an off-mode acceptance receipt.

Cloudflare's [Queue API](https://developers.cloudflare.com/api/resources/queues/methods/update/) exposes the pause setting as optional. The preceding resource creator did not explicitly configure it, while readback required actualfalse. This PR initializes that value through the existing production Actions resource operation and keeps strict readback. It does not infer missingfalse as acceptance or weaken the release gate.

## Actual platform reproduction

At2026-09-09T12:51:42Z, GETs for the jobs/DLQ/parking queues confirmed delivery_delay0 and retention345600/345600/1209600, zero consumers, and no pause field. `/tmp/ghfind-go-production-20260909/attempt4-queue-settings.json`. The runtime schedules response is the expected `{schedules:[]}` (`attempt4-schedules.json`).

A bounded isolated-staging probe on `ghfind-feed-staging-jobs` (`c128f5a45ac14ddaa48dbd26ece73b4b`) checked zero consumers and zero backlog, then PUT the same name, retention and delay plus explicitdelivery_pausedfalse. Both the update response and a freshGET returnedfalse, with identical queue identity and zero consumers. `/tmp/ghfind-go-production-20260909/queue-delivery-field-staging-probe.json`,12:54:08Z. No production queue was modified locally; no message was produced, consumed or purged.

## Implementation, commits and compatibility

Base main09ffe57. The Actions-only resource step preflights all queue identities and existing retention/delay/pause settings before queue initialization. Explicittrue, malformed settings, identity drift or retention/delay drift fails; it never overrides an operator pause. New queues explicitly configurefalse. An existing absent field is initialized through the pinned queue's PUT operation and verified by a freshGET with the same identity and settings. Already explicitfalse is idempotent. The strict off/baseline reader still requires actualfalse.

Ordered commits, final source/tree, independent review and exact local/CI evidence will be appended before merge. Public HTTP1, writer2, controlschema7 and Feedmigration12 are unchanged. No business rule, fact source, Container size/count, consumer ownership, semantic activation or provider configuration changes.

## Release state and bounded impact

Production remains legacyWeb `3b4b74f8-1f99-4fcc-b590-19035711eed8`, sourceaa8c683,100%. Latest off runtime `fd94bd96-e698-430e-8d08-7b9475918df5`; adapter `d44fd61f-d69b-4264-9dfc-e6cf99ad8b13`; image `registry.cloudflare.com/8f19bebe359e4ec1a24c68c5f49c1584/ghfind-feed@sha256:2cb536ba27c321be2b3d0bd82dd3dbeb231f0ffb4bafd46125e129b7c3c02d40`. All are intermediate-source evidence, not future-release evidence.

Existing authoritative coreD1 `60d45096-bfe7-4de1-8b85-c1b66a466b0d`, FeedD1 `9c4ac13a-4c90-40a8-9d56-d7141f864bbf` and R2 `ghfind-feed-production-archive` remain. QueueIDs: jobs `9f63d7dd07b7435e82376ab7d05bfa2e`, DLQ `1eb1d03e40d9430889af427958fbc5fa`, parking `da1be5c5e55245e4a29621cd243be077`. Only three dedicated queue configurations are eligible; no queues/messages are removed and no new persistent resource cost is introduced. APImax2basic/executormax1 remains; $79.69848 scenario is still a planning estimate, not measured acceptance.

## Validation, rollback and handoff

Mandatory complete local E2E for both workerdD1/R2 and PostgreSQL/pgvector/MinIO runs on the final clean source before push, with no skipped profile. External OAuth/provider fixtures remain explicitly fixtures. Exact pushCI, PR compatibilityCI, rebase-mainCI and every postpush/merge CFreadback are recorded separately. Root handles serial production Actions; independent subagent implements/tests the resource operation.

After exact main CI, the formal workflow deploys an immutable image and off runtime, verifies all bindings/instances/queues, captures Go-only paused Web and writer fence, completes one journaled real assessment and durable projection, verifies Go service contracts, and opens Weball with publicsmoke. The new release must supply its own exact SHA/digest/Worker/instance/schema/queue/assessment/smoke evidence.

Preserve existing queue data and explicit delivery configuration when rolling back compatible code. After Go writes, do not reopen legacy Next writers or disable the DBfence. Use the captured exact-source Go-only paused Web through protected Actions for containment; it yields Feed503 and is not a demonstrated availability recovery. Original-plan capacity/fault, migration/recovery/RPO/RTO, semantic quality/cost, historical and Railway items remain separately unaccepted. Final cutover will be claimed only after actual Weball and production checks.

## Exact candidate evidence

Ordered commits: `64218fad802ff19795e4cded67c39ddb32a9da2d` (release documentation), `b7a009a84a0e02579ec3488d0529295862b93f08` (explicit queue state initialization). Final source `b7a009a84a0e02579ec3488d0529295862b93f08`; Git tree `15d8fc78267b9a37b0ce2082cee789b45ef7ef6e`.

Root ran `node --test scripts/feed-production-release.test.mjs scripts/feed-platform-production.test.mjs scripts/check-cf-release-workflow.test.mjs`: 55 passed, zero failed/skipped (`queue-settings-tests.tap`). Independent read-only review found no blocking issue and separately passed the 11 resource and 39 platform tests. Review verified all existing queue preflights precede writes, operator pauses and malformed values fail closed, immediate prewrite reread, strict postwrite readback, and idempotent explicit false.

Complete local E2E command: `python3 scripts/run-feed-e2e.py --release-sha b7a009a84a0e02579ec3488d0529295862b93f08 --directory /tmp/ghfind-go-production-e2e-queue-settings-20260909 --execute`. Exact-source run passed 2026-09-09T13:04:28.396801Z–13:04:51.757836Z; both profiles passed all eight journey milestones and cleanup succeeded. Receipt `/tmp/ghfind-go-production-e2e-queue-settings-20260909/run.json`. These are fixture OAuth/provider transports, not a claim of real production OAuth/provider acceptance.

Remote CI, postpush CF readback, rebase-main and production results are pending and will be appended with actual evidence. Next owner: root release operator; next gate: exact candidate push CI and PR compatibility CI, then rebase-main verification and the existing Actions-only release.

Push completed after exact-source E2E. [Exact push CI34354923177](https://github.com/hikariming/ghfind/actions/runs/34354923177) and [PR compatibility CI34354950431](https://github.com/hikariming/ghfind/actions/runs/34354950431) are running. CF readback at2026-09-09T13:05:48.840662Z (`queue-settings-after-push.json`) confirmed Web legacy aa8c683 UUID3b4b74f8 at100%, runtime09ffe57 off UUIDfd94bd96, adapter09ffe57 UUIDd44fd61f, and unchanged pinned D1/R2 bindings. Branch push did not deploy a runtime or change production traffic; direct-production exception means staging is not asserted as deployed.

## Final candidate and superseded evidence

Both earlier b7a009a push CI34354923177 and PR CI34354950431 passed all five jobs. They remain evidence only for that superseded source, not qualification for the final commit.

The final third commit is `2011be5a9700855c594e0130f666e5c510e7ae36` (`fix(release): verify production canonical origin in smoke`), final tree `a90b6aae6731a7703a702286c444d1e115ac93ce`. Independent review of this commit passed with no blocking issue and six workflow contract tests. It preserves the workers.dev transport, exact ghfind.com canonical check and existing containment gates. Regression checks cover absent/wrong/misplaced canonical configuration.

Root's same three test files passed56/56, zero skips (`queue-settings-final-tests.tap`). Final clean-source complete local E2E passed2026-09-09T13:09:33.885324Z–13:10:00.991530Z, both profiles all eight milestones and cleanup. Command: `python3 scripts/run-feed-e2e.py --release-sha 2011be5a9700855c594e0130f666e5c510e7ae36 --directory /tmp/ghfind-go-production-e2e-queue-settings-final-20260909 --execute`; receipt at that directory's `run.json`. Fixture identities/providers remain explicitly local test evidence. This rerun precedes the final source push.

## Merge entry evidence

[Final exact push CI34355450050](https://github.com/hikariming/ghfind/actions/runs/34355450050) and [final PR compatibility CI34355456222](https://github.com/hikariming/ghfind/actions/runs/34355456222) passed all five jobs. `node scripts/feed-ci-evidence.mjs verify-ci-remote 2011be5a9700855c594e0130f666e5c510e7ae36 /tmp/ghfind-go-production-20260909/queue-settings-final-exact-branch-ci.json` independently verified the actual checkout/tree and complete dual-profile E2E from CI artifacts; no older green source was substituted.

CF readback following the final push at2026-09-09T13:10:57.829886Z (`queue-settings-final-after-push.json`) verified the same legacy Web3b4b74f8/aa8c683 and private off runtimefd94bd96/09ffe57, adapterd44fd61f/09ffe57, all at100% of their own Worker deployments. Production Feed traffic remains legacy. Rebase merge is authorized and selected; main exact SHA CI and Actions release remain independent subsequent gates.

## Rebase merge and actual main

Rebase merged2026-09-09T13:16:12Z; actual main `b07c765ab45bc3d89e2bdf750d4e5f73d9949017`, same final tree `a90b6aae6731a7703a702286c444d1e115ac93ce`. Ordered rebased commits: `9ca4bf6d57752b19d4566b1c62d8a6a50f1d7926`, `b055dc2f9da259b6c74f2be01dc5131fcf5be424`, `b07c765ab45bc3d89e2bdf750d4e5f73d9949017`; no squash. [Main CI34356016761](https://github.com/hikariming/ghfind/actions/runs/34356016761) is running for this actual SHA.

Postmerge CF readback2026-09-09T13:16:30.334067Z (`queue-settings-final-after-merge.json`) verified production still legacy Web3b4b74f8/aa8c683, private off runtimefd94bd96/09ffe57 and adapterd44fd61f/09ffe57, with no unverified resource. Source merge itself did not claim deployment or cutover.

## Actual main qualification and automatic release

[Exact main CI34356016761](https://github.com/hikariming/ghfind/actions/runs/34356016761) passed all five jobs for `b07c765ab45bc3d89e2bdf750d4e5f73d9949017`. Independent `verify-ci-remote` passed against this checkout (`queue-settings-final-exact-main-ci.json`), including all exact-SHA job artifacts and complete dual-profile E2E. An additional root local E2E of actual main passed13:17:35.484011Z (`/tmp/ghfind-go-production-e2e-queue-settings-main-20260909/run.json`).

[Automatic production34356442335](https://github.com/hikariming/ghfind/actions/runs/34356442335) is running and has passed its independent exact-main authorization job. Release outcome, actual CF mode, assessment/projection and final smoke are not yet asserted.

## Preserved production attempt1 failure and bounded retry

[Production34356442335 attempt1](https://github.com/hikariming/ghfind/actions/runs/34356442335/attempts/1) passed queue resource initialization/readback, approved migrations and consumer detachment. New off runtime UUID `e1b6a429-6976-4091-8d49-2fd74e78efe0` and adapter `b359155e-2a24-4a78-889c-9bddd86352d4` used exact main b07c765; image `registry.cloudflare.com/8f19bebe359e4ec1a24c68c5f49c1584/ghfind-feed@sha256:a11252630badfc03e5de38eb289675811bb18aedb5311fa39e3c2d0f9f99ad26`.

At13:25:31Z the first aggregate readiness request returned HTTP503. Its failed diagnostic reports stageinitial_readiness, one request, one metadata read, no accepted app/instance/readiness evidence (`production-attempt5/runtime-off.json`). Do not treat this as off acceptance. No paused Web, fence activation, assessment or public Go cutover was reached. Later actual app metadata showed APIversion6 provisioning with the expected image and executorversion6 ready; placement readback showed api1running6 but api0unassigned. That is a startup-state observation, not proof of the precise HTTP503 cause. The local readiness read received network403 and supplies no service acceptance.

One bounded rerun of the same exact-source Actions release was started; all strict gates remain unchanged. No new assessment was previously initiated. Attempt1 failure and nonsecret CFreadbacks remain retained. Attempt2 outcome is pending.

## Attempt2 outcome and follow-up boundary

Same-SHA [attempt2](https://github.com/hikariming/ghfind/actions/runs/34356442335/attempts/2) passed initial readiness for all three Go processes, then failed `application_convergence`: API appversion7 had the expected digest8d777b1d..., while executor summary still reported its preceding version6/digesta1125263.... Both Container update commands had reported success. Subsequent fresh CLI readback showed both applications atversion7/digest8d777b1d; this later observation does not retroactively validate the failed release. The second attempt built a different image digest for the same source; every attempt was checked against its own captured digest.

No paused Web, fence activation, assessment or Go public cutover was reached. CF readback at13:39:24.873542Z (`after-attempt5-rerun-failure-refreshed.json`) confirms legacy Web3b4b74f8/aa8c683, runtimeac69cf19/off/b07c765 and adapterb27ff8d8/b07c765. The preceding13:37:34Z local read was OAuth401 and remains explicitly UNVERIFIED; normal Wrangler credential refresh restored access. Independent queue GETs13:47:00.532786Z confirmed all three `delivery_paused=false`, delay0, retention345600/345600/1209600 and consumers0 (`queue-settings-current-verified.json`).

A separate follow-up `codex/feed-production-startup-convergence` is being prepared locally with predeployment application snapshots and bounded convergence; it has not yet been pushed or merged. PR281's queue/canonical fixes are merged and locally/CI validated, but the overall production cutover remains incomplete.
