### PR TITLE
fix(release): verify direct Container application identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           npm --prefix platform/runtime run typecheck
           npm --prefix platform/runtime test
-          node --test scripts/feed-platform-manifest.test.mjs scripts/feed-platform-production.test.mjs
+          node --test scripts/feed-platform-manifest.test.mjs scripts/feed-platform-production.test.mjs scripts/feed-production-application-snapshot.test.mjs
           node --test scripts/feed-platform-provision.test.mjs
           node --test scripts/feed-platform-web.test.mjs scripts/feed-platform-staging-evidence.test.mjs scripts/feed-platform-verify-deployment.test.mjs
           node --test scripts/feed-operator.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
           BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
         run: |
           if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "0000000000000000000000000000000000000000" ]; then
+            # Rebase pushes may remove event.before from every advertised ref.
+            # Fetch that exact comparison commit; never skip its version check.
+            git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null || git fetch --no-tags origin "$BASE_REF"
             pnpm versions:check --base-ref "$BASE_REF"
           else
             pnpm versions:check

--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/feed-platform-production.mjs render ops/feed-production-manifest.json "$RELEASE_SHA" "${{ steps.image.outputs.reference }}" off
-          platform/runtime/node_modules/.bin/wrangler containers list --config platform/runtime/wrangler.jsonc --json > "$RUNNER_TEMP/feed-production-evidence/applications-before-off.json"
+          node scripts/feed-platform-production.mjs snapshot ops/feed-production-manifest.json "$RUNNER_TEMP/feed-production-evidence/applications-before-off.json"
           platform/runtime/node_modules/.bin/wrangler deploy --config platform/runtime/wrangler.adapter.production.generated.json --secrets-file "$RUNNER_TEMP/feed-adapter-secrets.json" --tag "production-$RELEASE_SHA"
           platform/runtime/node_modules/.bin/wrangler deploy --config platform/runtime/wrangler.production.generated.json --containers-rollout=immediate --secrets-file "$RUNNER_TEMP/feed-runtime-secrets.json" --tag "production-$RELEASE_SHA"
           sleep 130
@@ -167,7 +167,7 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/feed-platform-production.mjs render ops/feed-production-manifest.json "$RELEASE_SHA" "${{ steps.image.outputs.reference }}" baseline "$RUNNER_TEMP/feed-production-evidence/runtime-off.json"
-          platform/runtime/node_modules/.bin/wrangler containers list --config platform/runtime/wrangler.jsonc --json > "$RUNNER_TEMP/feed-production-evidence/applications-before-baseline.json"
+          node scripts/feed-platform-production.mjs snapshot ops/feed-production-manifest.json "$RUNNER_TEMP/feed-production-evidence/applications-before-baseline.json"
           platform/runtime/node_modules/.bin/wrangler deploy --config platform/runtime/wrangler.production.generated.json --containers-rollout=immediate --secrets-file "$RUNNER_TEMP/feed-runtime-secrets.json" --tag "production-$RELEASE_SHA"
           # Same image can still carry old env until the Container is idle.
           # Do not probe and keep old off-mode instances alive during this wait.

--- a/docs/feed-production-direct-release.md
+++ b/docs/feed-production-direct-release.md
@@ -34,7 +34,11 @@ receipts and actual repository protection. The workflow then:
    both actual Worker versions, bindings, each actual application image, basic
    sizes, instance limits (API 2 / executor 1) and all three Go readiness identities.
    Before each off/baseline runtime deployment, records the two application
-   identities. During bounded convergence only that exact preceding identity may
+   identities from direct Application details (`containers info`), not the
+   dashboard list's potentially delayed version/image. List responses discover
+   unique IDs only; direct details govern subsequent and final identity checks.
+   The predeployment capture reads at most three metadata responses within 60s
+   and stores only name, UUID, version and digest. During bounded convergence only that exact preceding identity may
    remain pending; acceptance always requires the expected new image. Once the
    new image appears its version is pinned, and identity drift or regression stops
    the release. Snapshots never authorize serving traffic from an old image.

--- a/scripts/check-cf-release-workflow.mts
+++ b/scripts/check-cf-release-workflow.mts
@@ -38,7 +38,7 @@ const runtimeDeploys = deployJob.split('\n').filter(line => line.includes('wrang
 if (runtimeDeploys.length !== 2 || runtimeDeploys.some(line => !line.includes('--containers-rollout=immediate'))) throw new Error('Paused production runtime requires explicit immediate Container rollout');
 for (const [mode, title] of [['off', 'Deploy private adapter and off-mode candidate by immutable digest'], ['baseline', 'Activate executor and verify actual baseline instances before gateway traffic']]) {
   const step = new RegExp(`      - name: ${title}\\n([\\s\\S]*?)(?=      - name:)`).exec(deployJob)?.[1] ?? '';
-  const capture = `platform/runtime/node_modules/.bin/wrangler containers list --config platform/runtime/wrangler.jsonc --json > "$RUNNER_TEMP/feed-production-evidence/applications-before-${mode}.json"`;
+  const capture = `node scripts/feed-platform-production.mjs snapshot ops/feed-production-manifest.json "$RUNNER_TEMP/feed-production-evidence/applications-before-${mode}.json"`;
   const verify = ` ${mode} "$RUNNER_TEMP/feed-production-evidence/runtime-${mode}.json" "$RUNNER_TEMP/feed-production-evidence/applications-before-${mode}.json"`;
   const deployAt = step.indexOf('wrangler deploy --config platform/runtime/wrangler.production.generated.json');
   if (!step.includes(capture) || !step.includes(verify) || step.indexOf(capture) >= deployAt || step.indexOf(verify) <= deployAt) throw new Error(`Production ${mode} requires its own predeployment application snapshot`);

--- a/scripts/check-cf-release-workflow.test.mjs
+++ b/scripts/check-cf-release-workflow.test.mjs
@@ -65,7 +65,7 @@ test('public production smoke checks the canonical custom domain even through wo
 test('each runtime deployment captures and verifies its own preceding application identities', () => {
   const production = originals['deploy-cf-production.yml'];
   for (const mode of ['off', 'baseline']) {
-    const capture = `          platform/runtime/node_modules/.bin/wrangler containers list --config platform/runtime/wrangler.jsonc --json > "$RUNNER_TEMP/feed-production-evidence/applications-before-${mode}.json"\n`;
+    const capture = `          node scripts/feed-platform-production.mjs snapshot ops/feed-production-manifest.json "$RUNNER_TEMP/feed-production-evidence/applications-before-${mode}.json"\n`;
     assert.throws(() => check({ 'deploy-cf-production.yml': production.replace(capture, '') }));
     assert.throws(() => check({ 'deploy-cf-production.yml': production.replace(capture, '').replace('          sleep 130\n', `          sleep 130\n${capture}`) }));
     const verify = ` ${mode} "$RUNNER_TEMP/feed-production-evidence/runtime-${mode}.json" "$RUNNER_TEMP/feed-production-evidence/applications-before-${mode}.json"`;

--- a/scripts/feed-platform-production-readback.mjs
+++ b/scripts/feed-platform-production-readback.mjs
@@ -22,9 +22,10 @@ export const limits = Object.freeze({
   initialReadinessAttempts: 8,
   initialReadinessIntervalMs: 2500,
   initialReadinessConvergenceMs: 60000,
-  // Original 23 + 14 instance retries + 14 application retries + final identity read.
+  // 19 fixed reads + 7 paired detail rounds (14) + 16 instance reads +
+  // 2 final details = 51, below the unchanged hard quota of 52.
   metadataReads: 52,
-  applicationAttempts: 8,
+  applicationAttempts: 8, // Includes the reserved final detail read for each app.
   applicationIntervalMs: 2500,
   applicationConvergenceMs: 60000,
   instanceAttempts: 8,
@@ -95,6 +96,61 @@ export function validatePreviousApplications(apps, m) {
   }
   return previous;
 }
+const requiredHealthCounters = [
+  "active",
+  "healthy",
+  "failed",
+  "starting",
+  "scheduling",
+];
+const optionalHealthCounters = ["assigned", "stopped"];
+const healthCounters = [...requiredHealthCounters, ...optionalHealthCounters];
+function directApplication(raw) {
+  const h = raw?.health,
+    counts = h?.instances;
+  const countValid = (k) => Number.isSafeInteger(counts[k]) && counts[k] >= 0;
+  const valid =
+    h &&
+    typeof h === "object" &&
+    !Array.isArray(h) &&
+    (h.errors === undefined || Array.isArray(h.errors)) &&
+    counts &&
+    typeof counts === "object" &&
+    !Array.isArray(counts) &&
+    requiredHealthCounters.every(countValid) &&
+    optionalHealthCounters.every(
+      (k) => !Object.hasOwn(counts, k) || countValid(k),
+    );
+  // Pinned Wrangler 4.129.1 derives these states from the same direct health
+  // counters. Errors are additionally fail-closed; raw error/config text is never
+  // emitted. Zero active instances is legitimate idle, not evidence of startup.
+  const state = !valid
+    ? "unknown"
+    : h.errors?.length || counts.failed > 0
+      ? "degraded"
+      : counts.starting > 0 || counts.scheduling > 0
+        ? "provisioning"
+        : counts.active > 0
+          ? "active"
+          : "ready";
+  return {
+    id: raw?.id,
+    name: raw?.name,
+    version: raw?.version,
+    image: raw?.configuration?.image,
+    state,
+    health: {
+      errorCount: Array.isArray(h?.errors) ? h.errors.length : null,
+      instances: valid
+        ? Object.fromEntries(
+            healthCounters
+              .filter((k) => Object.hasOwn(counts, k))
+              .map((k) => [k, counts[k]]),
+          )
+        : null,
+    },
+  };
+}
 function inspectApplication(apps, name, image, prior, previous) {
   const matches = Array.isArray(apps)
     ? apps.filter((a) => a?.name === name)
@@ -154,6 +210,7 @@ function observedApplications(matches, name) {
     name: app?.name === name ? app.name : null,
     state: applicationStates.has(app?.state) ? app.state : "invalid",
     version: scalarVersion(app?.version) ? app.version : null,
+    health: app?.health ?? null,
     imageDigest:
       typeof app?.image === "string"
         ? (/^registry\.cloudflare\.com\/[a-f0-9]{32}\/ghfind-feed@sha256:([a-f0-9]{64})$/.exec(
@@ -519,11 +576,10 @@ export async function verifyDeployment(
     applicationObservations = [],
     readinessObservations = [];
   const expectedApplicationPins = new Map();
-  const applicationAttempts = new Map(),
-    applicationSequences = new Map();
-  let latestApplications,
-    latestApplicationsAt,
-    applicationSequence = 0;
+  const applicationDetails = new Map();
+  let applicationRound = 0,
+    applicationAnchors,
+    runtimeNamespaces;
   function signal(timeout, extra = run.signal) {
     return AbortSignal.any([run.signal, extra, AbortSignal.timeout(timeout)]);
   }
@@ -558,45 +614,6 @@ export async function verifyDeployment(
     });
     extra.throwIfAborted();
     run.signal.throwIfAborted();
-    if (args[0] === "containers" && args[1] === "list") applicationSequence++;
-    if (
-      previousApplications !== undefined &&
-      args[0] === "containers" &&
-      args[1] === "list"
-    ) {
-      latestApplications = result;
-      latestApplicationsAt = new Date().toISOString();
-      // Every actual list read witnesses both registered apps. Once either
-      // reaches the target digest, another app's retry must not hide rollback.
-      for (const suffix of ["feedapi", "feedexecutor"]) {
-        const name = `${m.runtimeWorker}-${suffix}`;
-        const verdict = inspectApplication(
-          result,
-          name,
-          image,
-          expectedApplicationPins.get(name),
-          previous.get(name),
-        );
-        if (verdict.status === "rejected") {
-          observeApplication(
-            result,
-            name,
-            expectedApplicationPins.get(name),
-            latestApplicationsAt,
-            "snapshot",
-            null,
-          );
-          throw new Error(
-            `immutable application identity or health summary differs: ${verdict.reason}`,
-          );
-        }
-        if (verdict.app.image === image)
-          expectedApplicationPins.set(name, {
-            id: verdict.app.id,
-            version: verdict.app.version,
-          });
-      }
-    }
     return result;
   }
   async function ready(
@@ -725,6 +742,7 @@ export async function verifyDeployment(
     );
     applicationObservations.push({
       observedAt,
+      metadataSource: "containers_info",
       phase,
       attempt,
       applicationName: name,
@@ -735,71 +753,162 @@ export async function verifyDeployment(
     });
     return verdict;
   }
-  async function convergeApplication(
-    initialApps,
-    initialObservedAt,
-    name,
-    convergence,
-    identityOnly = false,
-    initialSequence = applicationSequence,
-  ) {
-    let apps = initialApps,
-      observedAt = initialObservedAt,
-      prior,
-      sequence = initialSequence;
-    for (;;) {
-      convergence.throwIfAborted();
-      let attempt = applicationAttempts.get(name) ?? 0,
-        verdict;
-      if (applicationSequences.get(name) !== sequence) {
-        requireThat(
-          attempt < bounds.applicationAttempts,
-          `application summary convergence attempts exhausted: ${name}`,
-        );
-        applicationAttempts.set(name, ++attempt);
-        applicationSequences.set(name, sequence);
-        verdict = observeApplication(
-          apps,
-          name,
-          prior,
-          observedAt,
-          identityOnly ? "identity" : "convergence",
-          attempt,
-        );
-      } else {
-        // The same cached identity snapshot can be rechecked after ready. It
-        // neither resets attempts nor counts as another actual metadata read.
-        verdict = inspectApplication(
-          apps,
-          name,
-          image,
-          expectedApplicationPins.get(name) ?? prior,
-          previous.get(name),
+  async function discoverApplications(convergence) {
+    const listed = await wrangler(
+      ["containers", "list", "--json"],
+      convergence,
+    );
+    const ids = new Set();
+    return ["feedapi", "feedexecutor"].map((suffix) => {
+      const name = `${m.runtimeWorker}-${suffix}`;
+      const rows = Array.isArray(listed)
+        ? listed.filter((a) => a?.name === name)
+        : [];
+      const app = rows[0];
+      let reason = null;
+      if (!Array.isArray(listed) || rows.length !== 1)
+        reason = "application_population_invalid";
+      else if (!uuid.test(app?.id) || ids.has(app.id))
+        reason = "application_identity_invalid";
+      else if (previous.has(name) && previous.get(name).id !== app.id)
+        reason = "application_identity_changed";
+      if (reason) {
+        applicationObservations.push({
+          observedAt: new Date().toISOString(),
+          phase: "discovery",
+          attempt: null,
+          applicationName: name,
+          status: "rejected",
+          reason,
+          matchCount: rows.length,
+          applications: rows
+            .slice(0, 2)
+            .map((a) => ({
+              id: uuid.test(a?.id) ? a.id : null,
+              name: a?.name === name ? name : null,
+            })),
+        });
+        throw new Error(
+          `immutable application identity or health summary differs: ${reason}`,
         );
       }
+      ids.add(app.id);
+      // /dash/applications can lag direct /applications/{id}. Only name and UUID
+      // are discovery facts; never authorize or reject from its version/state/image.
+      return { id: app.id, name };
+    });
+  }
+  function configurationError(configuration, anchor) {
+    const apiRole = anchor.name.endsWith("-feedapi");
+    const basic =
+      configuration?.configuration?.instance_type === "basic" ||
+      (configuration?.configuration?.vcpu === 0.25 &&
+        configuration.configuration.memory_mib === 1024 &&
+        configuration.configuration.disk?.size_mb === 4000);
+    if (configuration?.max_instances !== (apiRole ? 2 : 1) || !basic)
+      return "actual application capacity/image differs";
+    const namespaceId = runtimeNamespaces.find(
+      (d) => d.className === (apiRole ? "FeedAPI" : "FeedExecutor"),
+    )?.namespaceId;
+    if (
+      !namespaceId ||
+      configuration?.durable_objects?.namespace_id !== namespaceId
+    )
+      return "application is not linked to runtime namespace";
+    return null;
+  }
+  async function readApplications(phase, extra, final = false) {
+    if (!final) {
       requireThat(
-        verdict.status !== "rejected",
-        `immutable application identity or health summary differs: ${verdict.reason}`,
+        applicationRound < bounds.applicationAttempts - 1,
+        "application summary convergence attempts exhausted (final details reserved)",
       );
-      // The first target-image identity is pinned even while provisioning. A new
-      // version/UUID/digest never resets the bounded convergence window.
+      applicationRound++;
+    }
+    // Both independent details settle before either is trusted. Checking both on
+    // every round prevents one application's retry from hiding the other's drift.
+    const reads = await Promise.allSettled(
+      applicationAnchors.map((a) =>
+        wrangler(["containers", "info", a.id, "--json"], extra),
+      ),
+    );
+    let readFailure;
+    const verdicts = [];
+    for (let i = 0; i < reads.length; i++) {
+      const read = reads[i],
+        anchor = applicationAnchors[i];
+      if (read.status === "rejected") {
+        readFailure ??= read.reason;
+        continue;
+      }
+      const raw = read.value;
+      const app = directApplication(raw);
+      // Match direct identity to the UUID discovered once, regardless of any
+      // different UUID/name returned by the endpoint addressed with that UUID.
+      const apps =
+        app?.id === anchor.id && app?.name === anchor.name ? [app] : [];
+      const verdict = observeApplication(
+        apps,
+        anchor.name,
+        null,
+        new Date().toISOString(),
+        phase,
+        final ? applicationRound + 1 : applicationRound,
+      );
+      verdicts.push(verdict);
+      if (verdict.status !== "rejected") {
+        const invalidConfiguration = configurationError(raw, anchor);
+        if (invalidConfiguration) {
+          Object.assign(verdict, {
+            status: "rejected",
+            reason: "application_configuration_changed",
+          });
+          Object.assign(applicationObservations.at(-1), {
+            status: verdict.status,
+            reason: verdict.reason,
+          });
+          readFailure ??= new Error(invalidConfiguration);
+        }
+      }
+      if (verdict.status === "rejected") {
+        readFailure ??= new Error(
+          `immutable application identity or health summary differs: ${verdict.reason}`,
+        );
+        continue;
+      }
+      applicationDetails.set(anchor.name, raw);
       if (verdict.app.image === image)
-        prior ??= { id: verdict.app.id, version: verdict.app.version };
+        expectedApplicationPins.set(anchor.name, {
+          id: verdict.app.id,
+          version: verdict.app.version,
+        });
+    }
+    if (readFailure) throw readFailure;
+    return verdicts;
+  }
+  async function convergeApplications(convergence, identityOnly, initial) {
+    let verdicts = initial;
+    for (;;) {
+      convergence.throwIfAborted();
+      if (!verdicts)
+        verdicts = await readApplications(
+          identityOnly ? "identity" : "convergence",
+          convergence,
+        );
       if (
-        verdict.status === "converged" ||
-        (identityOnly && verdict.app.image === image)
+        verdicts.every((v) =>
+          identityOnly ? v.app.image === image : v.status === "converged",
+        )
       )
-        return verdict.app;
+        return verdicts;
       requireThat(
-        attempt < bounds.applicationAttempts,
-        `application summary convergence attempts exhausted: ${name}`,
+        applicationRound < bounds.applicationAttempts - 1,
+        "application summary convergence attempts exhausted (final details reserved)",
       );
       await sleep(bounds.applicationIntervalMs, undefined, {
         signal: convergence,
       });
-      apps = await wrangler(["containers", "list", "--json"], convergence);
-      observedAt = new Date().toISOString();
-      sequence = applicationSequence;
+      verdicts = null;
     }
   }
   // Deploy returns before every instance is replaced; metadata may still be
@@ -876,40 +985,17 @@ export async function verifyDeployment(
       await api(`/workers/scripts/${m.adapterWorker}/versions/${adapterId}`),
       await api(`/workers/scripts/${m.adapterWorker}/subdomain`),
     );
-    let applicationConvergence,
-      apps,
-      appsObservedAt,
-      initialApplicationSequence;
-    const identitySnapshots = new Map();
-    if (previousApplications !== undefined) {
-      stage = "application_identity_convergence";
-      applicationConvergence = AbortSignal.any([
-        run.signal,
-        AbortSignal.timeout(bounds.applicationConvergenceMs),
-      ]);
-      apps = await wrangler(
-        ["containers", "list", "--json"],
-        applicationConvergence,
-      );
-      appsObservedAt = latestApplicationsAt;
-      initialApplicationSequence = applicationSequence;
-      for (const suffix of ["feedapi", "feedexecutor"]) {
-        const app = await convergeApplication(
-          latestApplications,
-          latestApplicationsAt,
-          `${m.runtimeWorker}-${suffix}`,
-          applicationConvergence,
-          true,
-          applicationSequence,
-        );
-        if (["active", "ready"].includes(app.state))
-          identitySnapshots.set(app.name, {
-            apps: latestApplications,
-            observedAt: latestApplicationsAt,
-            sequence: applicationSequence,
-          });
-      }
-    }
+    runtimeNamespaces = runtime.durableNamespaces;
+    stage = "application_identity_convergence";
+    const applicationConvergence = AbortSignal.any([
+      run.signal,
+      AbortSignal.timeout(bounds.applicationConvergenceMs),
+    ]);
+    applicationAnchors = await discoverApplications(applicationConvergence);
+    const identityVerdicts = await convergeApplications(
+      applicationConvergence,
+      true,
+    );
     // Verify both fixed Worker configurations before trusting the protected
     // dependency-only code. An old process/unknown 503 never grants a retry.
     stage = "initial_readiness";
@@ -934,51 +1020,22 @@ export async function verifyDeployment(
       }
     })();
     stage = "application_convergence";
-    // Start before the first shared metadata request. Both summaries settle
-    // within this same 60s window, before inspecting any instance; the overall
-    // 180s timer still governs all later work. No cached first read is uncounted.
-    if (!applicationConvergence) {
-      applicationConvergence = AbortSignal.any([
-        run.signal,
-        AbortSignal.timeout(bounds.applicationConvergenceMs),
-      ]);
-      apps = await wrangler(
-        ["containers", "list", "--json"],
-        applicationConvergence,
-      );
-      appsObservedAt = new Date().toISOString();
-      initialApplicationSequence = applicationSequence;
-    }
-    const settledApplications = [];
-    for (const [suffix, names] of [
-      ["feedapi", ["api-0", "api-1"]],
-      ["feedexecutor", ["executor-0"]],
-    ]) {
-      // Wrangler 4.129.1 derives the summary from health counters. Provisioning
-      // may be observed during rollout, but is never accepted as successful.
-      const name = `${m.runtimeWorker}-${suffix}`;
-      const knownHealthy = identitySnapshots.get(name);
-      const app = await convergeApplication(
-        knownHealthy?.apps ?? latestApplications ?? apps,
-        knownHealthy?.observedAt ?? latestApplicationsAt ?? appsObservedAt,
-        name,
-        applicationConvergence,
-        false,
-        knownHealthy?.sequence ??
-          (latestApplications
-            ? applicationSequence
-            : initialApplicationSequence),
-      );
-      settledApplications.push({ app, suffix, names });
-    }
+    // Identity and health share seven paired direct reads and the same 60s
+    // deadline, including discovery/startup. Cold idle is not an instance proof.
+    const settled = await convergeApplications(
+      applicationConvergence,
+      false,
+      identityVerdicts,
+    );
+    const settledApplications = settled.map(({ app }, i) => ({
+      app,
+      suffix: i === 0 ? "feedapi" : "feedexecutor",
+      names: i === 0 ? ["api-0", "api-1"] : ["executor-0"],
+    }));
     const applications = [];
     for (const { app, suffix, names } of settledApplications) {
-      const configuration = await wrangler([
-        "containers",
-        "info",
-        app.id,
-        "--json",
-      ]);
+      // Reuse the validated direct detail; do not spend another metadata call.
+      const configuration = applicationDetails.get(app.name);
       const basic =
         configuration.configuration?.instance_type === "basic" ||
         (configuration.configuration?.vcpu === 0.25 &&
@@ -1032,22 +1089,11 @@ export async function verifyDeployment(
       );
     }
     stage = "final_application_identity";
-    const finalApps = await wrangler(["containers", "list", "--json"]);
-    const finalAppsObservedAt = new Date().toISOString();
-    for (const prior of applications) {
-      const verdict = observeApplication(
-        finalApps,
-        prior.name,
-        { id: prior.applicationId, version: prior.version },
-        finalAppsObservedAt,
-        "final",
-        null,
-      );
-      requireThat(
-        verdict.status === "converged",
-        "application changed during readback",
-      );
-    }
+    const finalVerdicts = await readApplications("final", run.signal, true);
+    requireThat(
+      finalVerdicts.every((v) => v.status === "converged"),
+      "application changed during readback",
+    );
     heartbeat.abort();
     await loop;
     if (heartbeatFailure) throw heartbeatFailure;

--- a/scripts/feed-platform-production.mjs
+++ b/scripts/feed-platform-production.mjs
@@ -625,11 +625,54 @@ export function readPreviousApplicationSnapshot(path) {
   );
   return JSON.parse(bytes.toString("utf8"));
 }
+// Dashboard list responses can lag the application detail after a completed
+// rollout. Use them only to discover IDs; record prior identities from GET /id.
+export async function captureProductionApplications(m, { metadata } = {}) {
+  validateManifest(m);
+  const { wranglerMetadata, validatePreviousApplications } = await import(
+    "./feed-platform-production-readback.mjs"
+  );
+  const read = metadata ?? wranglerMetadata;
+  const signal = AbortSignal.timeout(60000);
+  const listing = await read(["containers", "list", "--json"], { signal });
+  signal.throwIfAborted();
+  requireThat(Array.isArray(listing), "invalid application discovery response");
+  const selected = [], ids = new Set();
+  for (const suffix of ["feedapi", "feedexecutor"]) {
+    const name = `${m.runtimeWorker}-${suffix}`;
+    const rows = listing.filter((a) => a?.name === name);
+    requireThat(rows.length <= 1, "duplicate application discovery");
+    if (!rows.length) continue; // First install supplies no prior-image allowance.
+    const { id } = rows[0];
+    requireThat(
+      typeof id === "string" && /^[a-f0-9]{8}-(?:[a-f0-9]{4}-){3}[a-f0-9]{12}$/.test(id) && !ids.has(id),
+      "invalid discovered application identity",
+    );
+    ids.add(id);
+    selected.push({ id, name });
+  }
+  const snapshot = [];
+  for (const prior of selected) {
+    const detail = await read(["containers", "info", prior.id, "--json"], { signal });
+    signal.throwIfAborted();
+    requireThat(detail?.id === prior.id && detail?.name === prior.name,
+      "discovered application identity changed");
+    snapshot.push({ id: detail.id, name: detail.name, version: detail.version,
+      image: detail.configuration?.image });
+  }
+  validatePreviousApplications(snapshot, m);
+  return snapshot;
+}
 async function main(args) {
   const [command, path, sha, image, mode, receiptOrOutput, previousPath] = args;
   if (command === "template" && args.length === 1)
     return console.log(JSON.stringify(template(), null, 2));
   const m = validateManifest(JSON.parse(readFileSync(path, "utf8")));
+  if (command === "snapshot" && args.length === 3) {
+    const snapshot = await captureProductionApplications(m);
+    writeFileSync(args[2], JSON.stringify(snapshot, null, 2) + "\n", { flag: "wx", mode: 0o600 });
+    return console.log("Recorded direct application identities before deployment");
+  }
   if (command === "disable-consumers" && args.length === 3) {
     const output = args[2];
     writeFileSync(
@@ -700,7 +743,7 @@ async function main(args) {
     );
   }
   throw new Error(
-    "usage: feed-platform-production.mjs template | validate MANIFEST | disable-consumers MANIFEST RECEIPT | render MANIFEST SHA IMAGE off | render MANIFEST SHA IMAGE baseline OFF_RECEIPT | verify MANIFEST SHA IMAGE off|baseline OUTPUT [PREVIOUS_APPLICATIONS]",
+    "usage: feed-platform-production.mjs template | validate MANIFEST | snapshot MANIFEST OUTPUT | disable-consumers MANIFEST RECEIPT | render MANIFEST SHA IMAGE off | render MANIFEST SHA IMAGE baseline OFF_RECEIPT | verify MANIFEST SHA IMAGE off|baseline OUTPUT [PREVIOUS_APPLICATIONS]",
   );
 }
 if (

--- a/scripts/feed-platform-production.test.mjs
+++ b/scripts/feed-platform-production.test.mjs
@@ -50,7 +50,10 @@ function fixture(mode = "off", options = {}) {
   let total = 0,
     readyCalls = 0,
     metadataCalls = 0,
-    listCalls = 0;
+    listCalls = 0,
+    infoRound = 0,
+    roundApplications,
+    delayUsed = false;
   const instanceCalls = new Map();
   const workerId = id(1),
     adapterId = id(2),
@@ -207,30 +210,67 @@ function fixture(mode = "off", options = {}) {
   const metadata = async (args, { signal }) => {
     metadataCalls++;
     assert.ok(signal instanceof AbortSignal);
-    if (options.delay && metadataCalls === 1)
+    const delayAt = options.delayOn ?? "list";
+    if (
+      options.delay &&
+      !delayUsed &&
+      (args[1] === delayAt ||
+        (delayAt === "info-after-first" &&
+          args[1] === "info" &&
+          args[2] === id(3) &&
+          infoRound === 1))
+    ) {
+      delayUsed = true;
       await sleep(options.delay, undefined, { signal });
+    }
+    // Discovery deliberately does not share the direct detail overrides. The
+    // applications callback below models /applications/{id}, not /dash/apps.
     if (args[1] === "list") {
       listCalls++;
-      return options.applications
-        ? options.applications(structuredClone(applications), listCalls)
+      return options.discovery
+        ? options.discovery(structuredClone(applications), listCalls)
         : applications;
     }
     if (args[1] === "info") {
-      const a = applications.find((a) => a.id === args[2]);
+      const index = args[2] === id(3) ? 0 : 1;
+      if (index === 0) {
+        infoRound++;
+        roundApplications = options.applications
+          ? options.applications(structuredClone(applications), infoRound)
+          : structuredClone(applications);
+      }
+      const a = roundApplications?.[index];
       const result = {
-        id: a.id,
-        name: a.name,
-        max_instances: a.name.endsWith("feedapi") ? 2 : 1,
-        durable_objects: {
-          namespace_id: id(a.name.endsWith("feedapi") ? 31 : 32),
-        },
+        id: a?.id,
+        name: a?.name,
+        version: a?.version,
+        max_instances: index === 0 ? 2 : 1,
+        durable_objects: { namespace_id: id(index === 0 ? 31 : 32) },
         configuration: {
-          image,
+          image: a?.image,
           instance_type: "basic",
           env: { SECRET: "must-not-upload" },
         },
+        health: ["active", "ready", "provisioning", "degraded"].includes(
+          a?.state,
+        )
+          ? {
+              errors: [],
+              instances: {
+                active: a.state === "active" ? 1 : 0,
+                assigned: 0,
+                healthy: 0,
+                stopped: 0,
+                failed: a.state === "degraded" ? 1 : 0,
+                scheduling: 0,
+                starting: a.state === "provisioning" ? 1 : 0,
+              },
+            }
+          : null,
       };
-      return options.appInfo ? options.appInfo(result) : result;
+      return options.appInfo
+        ? options.appInfo(result, { round: infoRound, index, signal })
+        : result;
     }
     assert.deepEqual(args.slice(0, 2), ["containers", "instances"]);
     assert.deepEqual(args.slice(3), ["--per-page", "10", "--json"]);
@@ -269,6 +309,8 @@ function fixture(mode = "off", options = {}) {
       total,
       readyCalls,
       metadataCalls,
+      listCalls,
+      infoRound,
       instanceCalls: [...instanceCalls.values()].reduce((a, b) => a + b, 0),
     }),
     ready,
@@ -285,6 +327,166 @@ function previousApps(previousImage = image.replace(/b{64}$/, "c".repeat(64))) {
     arbitrarySecret: "never-upload-snapshot",
   }));
 }
+test("stale dashboard versions and health cannot override current authoritative application details", async () => {
+  for (const previousApplications of [undefined, previousApps()]) {
+    const f = fixture("off", {
+      ...(previousApplications ? { previousApplications } : {}),
+      discovery: (apps) =>
+        apps.map((a, i) => ({
+          ...a,
+          image: previousApps()[i].image,
+          version: 6,
+          state: i ? "unknown" : "degraded",
+        })),
+    });
+    const r = await verifyDeployment(m, sha, image, "off", f.options);
+    assert.equal(r.status, "passed");
+    assert.equal(f.count().listCalls, 1);
+    assert.equal(
+      f.count().infoRound,
+      2,
+      "one paired direct read, then one paired final read",
+    );
+    assert.equal(r.keepWarm.metadataReads, 25);
+    assert.ok(
+      r.applications.every((a) => a.version === 7 && a.image === image),
+    );
+    assert.ok(
+      r.applicationObservations.every(
+        (o) =>
+          o.metadataSource === "containers_info" && o.status === "converged",
+      ),
+    );
+  }
+});
+test("discovery authorizes only distinct registered names and UUIDs, never an identity redirect", async () => {
+  for (const discovery of [
+    (apps) => [apps[0], { ...apps[1], id: apps[0].id }],
+    (apps) => [{ ...apps[0], id: id(999) }, apps[1]],
+    (apps) => [...apps, apps[1]],
+  ]) {
+    const f = fixture("off", {
+      previousApplications: previousApps(),
+      discovery,
+    });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      /immutable application/,
+    );
+    assert.equal(f.count().listCalls, 1);
+    assert.equal(f.count().infoRound, 0);
+    assert.equal(f.count().readyCalls, 0);
+  }
+});
+test("direct health accepts documented optional absence and actual cold idle but rejects errors or malformed counters", async () => {
+  for (const appInfo of [
+    (r) => {
+      delete r.health.errors;
+      delete r.health.instances.assigned;
+      delete r.health.instances.stopped;
+      return r;
+    },
+    (r) => {
+      // Actual cold-idle fixture: healthy counts are prepared placements, not
+      // proof of a currently running Go process. Instance checks still follow.
+      Object.assign(r.health.instances, {
+        active: 0,
+        healthy: r.max_instances,
+      });
+      delete r.configuration.instance_type;
+      Object.assign(r.configuration, {
+        vcpu: 0.25,
+        memory_mib: 1024,
+        disk: { size_mb: 4000 },
+      });
+      return r;
+    },
+  ]) {
+    const f = fixture("off", { appInfo });
+    const r = await verifyDeployment(m, sha, image, "off", f.options);
+    assert.equal(r.status, "passed");
+    assert.equal(f.count().instanceCalls, 2);
+    assert.equal(r.readiness.length, 3);
+  }
+  for (const appInfo of [
+    (r) => ({ ...r, health: undefined }),
+    (r) => ({ ...r, health: {} }),
+    ...[null, {}, "private-error", ["private-error"]].map((errors) => (r) => ({
+      ...r,
+      health: { ...r.health, errors },
+    })),
+    ...[undefined, null, -1, 1.5, "0", Number.MAX_SAFE_INTEGER + 1].map(
+      (active) => (r) => ({
+        ...r,
+        health: { ...r.health, instances: { ...r.health.instances, active } },
+      }),
+    ),
+    (r) => ({
+      ...r,
+      health: {
+        ...r.health,
+        instances: { ...r.health.instances, assigned: null },
+      },
+    }),
+    (r) => ({
+      ...r,
+      health: {
+        ...r.health,
+        instances: { ...r.health.instances, stopped: -1 },
+      },
+    }),
+    (r) => ({
+      ...r,
+      health: { ...r.health, instances: { ...r.health.instances, failed: 1 } },
+    }),
+  ]) {
+    const f = fixture("off", { appInfo });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      (e) => {
+        assert.match(e.message, /application_health_rejected/);
+        assert.equal(
+          JSON.stringify(e.readbackFailure).includes("private-error"),
+          false,
+        );
+        assert.equal(e.readbackFailure.applicationObservations.length, 2);
+        return true;
+      },
+    );
+    assert.equal(f.count().infoRound, 1);
+    assert.equal(f.count().readyCalls, 0);
+  }
+});
+test("final direct details also recheck capacity, namespace and health without trusting cached configuration", async () => {
+  for (const patch of [
+    (r) => ({ ...r, max_instances: 99 }),
+    (r) => ({ ...r, durable_objects: { namespace_id: id(999) } }),
+    (r) => ({ ...r, health: { ...r.health, errors: ["private-final-error"] } }),
+    (r) => ({
+      ...r,
+      image,
+      configuration: { ...r.configuration, image: undefined },
+    }),
+  ]) {
+    const f = fixture("off", {
+      appInfo: (r, { round }) => (round === 2 ? patch(r) : r),
+    });
+    await assert.rejects(
+      verifyDeployment(m, sha, image, "off", f.options),
+      (e) => {
+        assert.equal(e.readbackFailure.stage, "final_application_identity");
+        assert.equal(e.readbackFailure.status, "failed");
+        assert.equal(
+          JSON.stringify(e.readbackFailure).includes("private-final-error"),
+          false,
+        );
+        return true;
+      },
+    );
+    assert.equal(f.count().infoRound, 2);
+    assert.equal(f.count().instanceCalls, 2);
+  }
+});
 test("predeployment snapshot permits only the exact prior digest/version until the expected app converges", async () => {
   const previous = previousApps();
   let appsRead = 0;
@@ -311,7 +513,7 @@ test("predeployment snapshot permits only the exact prior digest/version until t
     r.applicationObservations.filter(
       (o) => o.reason === "prior_application_pending",
     ).length,
-    2,
+    3,
   );
   assert.ok(
     r.applications.every(
@@ -336,7 +538,7 @@ test("predeployment snapshot permits only the exact prior digest/version until t
     verifyDeployment(m, sha, image, "off", strict.options),
     /application_image_changed/,
   );
-  assert.equal(strict.count().metadataCalls, 1);
+  assert.equal(strict.count().metadataCalls, 3);
 });
 test("target-image provisioning may reach initial process readiness before application health converges", async () => {
   let readyObserved = false;
@@ -462,7 +664,7 @@ test("snapshot never permits a third digest, wrong UUID/version, unhealthy prior
       verifyDeployment(m, sha, image, "off", f.options),
       /immutable application/,
     );
-    assert.equal(f.count().metadataCalls, 1);
+    assert.equal(f.count().metadataCalls, 3);
     assert.equal(f.count().instanceCalls, 0);
   }
 });
@@ -487,7 +689,7 @@ test("expected-image entry pins version across both application retry streams an
     );
     assert.equal(
       f.count().metadataCalls,
-      2,
+      5,
       "a second app cannot regress unseen while the first app waits",
     );
   }
@@ -566,7 +768,7 @@ test("same-image versions cannot regress and only equal or ordered numeric versi
         /application_version_regressed_or_unordered/,
       );
       assert.equal(f.count().readyCalls, 0);
-      assert.equal(f.count().metadataCalls, 1);
+      assert.equal(f.count().metadataCalls, 3);
     }
   }
   for (const previousVersion of [6, "6", 7, "7", "07"]) {
@@ -622,15 +824,13 @@ test("same-image versions cannot regress and only equal or ordered numeric versi
     /application_identity_changed/,
   );
 });
-test("prior-image and instance maximum attempts still fit 52 metadata reads without resetting application budgets", async () => {
+test("prior-image and instance maximum attempts fit 51 metadata reads without resetting application budgets", async () => {
   const previous = previousApps();
   const f = fixture("off", {
     previousApplications: previous,
     bounds: { applicationIntervalMs: 1, instanceIntervalMs: 1 },
     applications: (apps, call) =>
-      apps.map((app, i) =>
-        call < (i === 0 ? 8 : 15) ? { ...app, ...previous[i] } : app,
-      ),
+      apps.map((app, i) => (call < 7 ? { ...app, ...previous[i] } : app)),
     instances: (r, { attempt }) =>
       attempt < 8
         ? {
@@ -643,8 +843,16 @@ test("prior-image and instance maximum attempts still fit 52 metadata reads with
         : r,
   });
   const r = await verifyDeployment(m, sha, image, "off", f.options);
-  assert.equal(r.keepWarm.metadataReads, 52);
-  assert.equal(r.applicationObservations.length, 18);
+  assert.equal(r.keepWarm.metadataReads, 51);
+  assert.equal(f.count().listCalls, 1);
+  assert.equal(f.count().infoRound, 8);
+  assert.deepEqual(
+    r.applicationObservations
+      .filter((o) => o.phase === "final")
+      .map((o) => o.attempt),
+    [8, 8],
+  );
+  assert.equal(r.applicationObservations.length, 16);
   assert.equal(r.instanceObservations.length, 16);
   assert.equal(r.keepWarm.readinessRequests, 18);
   assert.ok(
@@ -751,7 +959,7 @@ test("nondependency HTTP failures and malformed error responses preserve safe di
       },
     );
     assert.equal(f.count().readyCalls, 1);
-    assert.equal(f.count().metadataCalls, 0);
+    assert.equal(f.count().metadataCalls, 3);
   }
 });
 test("initial dependency retry exhaustion, request body deadline and global quotas all remain finite", async () => {
@@ -777,7 +985,7 @@ test("initial dependency retry exhaustion, request body deadline and global quot
     await assert.rejects(verifyDeployment(m, sha, image, "off", f.options));
     assert.ok(performance.now() - at < 500);
     assert.ok(f.count().readyCalls <= 3);
-    assert.equal(f.count().metadataCalls, 0);
+    assert.equal(f.count().metadataCalls, 3);
   }
   const slow = fixture("off", {
     bounds: { requestMs: 20 },
@@ -799,6 +1007,8 @@ test("initial dependency retry exhaustion, request body deadline and global quot
 test("dependency code after initial success cannot hide a heartbeat failure", async () => {
   const f = fixture("off", {
     delay: 1000,
+    delayOn: "info-after-first",
+    applications: (apps) => apps.map((a) => ({ ...a, state: "provisioning" })),
     bounds: { intervalMs: 5 },
     readyResponse: (call) =>
       call > 1
@@ -895,7 +1105,7 @@ test("bootstrap off has no asynchronous entrypoints; production resources and ca
 test("actual readback whitelists all published identity fields and gates baseline", async () => {
   const f = fixture();
   const r = await verifyDeployment(m, sha, image, "off", f.options);
-  assert.equal(r.keepWarm.metadataReads, 24);
+  assert.equal(r.keepWarm.metadataReads, 25);
   assert.equal(r.keepWarm.stopped, true);
   assert.equal(r.status, "passed");
   assert.equal(JSON.stringify(r).includes("must-not-upload"), false);
@@ -960,7 +1170,7 @@ test("Wrangler ready application summary still requires all named running instan
     });
     const r = await verifyDeployment(m, sha, image, "off", f.options);
     assert.equal(r.status, "passed");
-    assert.equal(r.keepWarm.metadataReads, 24);
+    assert.equal(r.keepWarm.metadataReads, 25);
     assert.deepEqual(
       r.applications.map((a) =>
         a.instances.map((i) => [i.name, i.state, i.version]),
@@ -1006,22 +1216,26 @@ test("only correctly identified provisioning applications can converge before st
   });
   const r = await verifyDeployment(m, sha, image, "off", f.options);
   assert.equal(r.status, "passed");
-  assert.equal(r.keepWarm.metadataReads, 27);
+  assert.equal(r.keepWarm.metadataReads, 31);
   assert.deepEqual(
     r.applicationObservations.map((o) => o.status),
     [
       "pending",
       "pending",
+      "pending",
+      "pending",
       "converged",
       "pending",
       "converged",
       "converged",
       "converged",
+      "converged",
     ],
   );
-  assert.equal(
-    r.applicationObservations[0].observedAt,
-    r.applicationObservations[3].observedAt,
+  assert.ok(
+    r.applicationObservations.every(
+      (o) => o.metadataSource === "containers_info",
+    ),
   );
   assert.equal(
     r.applicationObservations[0].applications[0].imageDigest,
@@ -1051,7 +1265,7 @@ test("permanent provisioning persists bounded application observations without a
       const r = error.readbackFailure;
       assert.equal(r.status, "failed");
       assert.equal(r.stage, "application_convergence");
-      assert.equal(r.applicationObservations.length, 3);
+      assert.equal(r.applicationObservations.length, 4);
       assert.ok(
         r.applicationObservations.every(
           (o) => o.reason === "application_provisioning",
@@ -1065,7 +1279,7 @@ test("permanent provisioning persists bounded application observations without a
       return true;
     },
   );
-  assert.equal(f.count().metadataCalls, 3);
+  assert.equal(f.count().metadataCalls, 5);
   assert.equal(f.count().instanceCalls, 0);
 });
 test("provisioning cannot conceal changed identity, digest or version and malformed health never retries", async () => {
@@ -1094,15 +1308,15 @@ test("provisioning cannot conceal changed identity, digest or version and malfor
           error.message,
           /application identity or health summary differs/,
         );
-        assert.equal(error.readbackFailure.applicationObservations.length, 2);
+        assert.equal(error.readbackFailure.applicationObservations.length, 4);
         assert.equal(
-          error.readbackFailure.applicationObservations[1].status,
+          error.readbackFailure.applicationObservations[2].status,
           "rejected",
         );
         return true;
       },
     );
-    assert.equal(f.count().metadataCalls, 2);
+    assert.equal(f.count().metadataCalls, 5);
     assert.equal(f.count().instanceCalls, 0);
   }
   for (const applications of [
@@ -1111,7 +1325,7 @@ test("provisioning cannot conceal changed identity, digest or version and malfor
     () => [],
     (apps) => [...apps, apps[0]],
   ]) {
-    const f = fixture("off", { applications });
+    const f = fixture("off", { discovery: applications });
     await assert.rejects(
       verifyDeployment(m, sha, image, "off", f.options),
       (error) => {
@@ -1144,7 +1358,7 @@ test("application convergence deadline and heartbeat failure stop all summary re
     const start = performance.now();
     await assert.rejects(verifyDeployment(m, sha, image, "off", f.options));
     assert.ok(performance.now() - start < 500);
-    assert.equal(f.count().metadataCalls, 1);
+    assert.equal(f.count().metadataCalls, 3);
     const before = f.count().total;
     await sleep(20);
     assert.equal(f.count().total, before);
@@ -1167,7 +1381,7 @@ test("maximal application and instance convergence stays within fixed 180s and 5
     applications: (apps, call) =>
       apps.map((app, i) => ({
         ...app,
-        state: call < (i === 0 ? 8 : 15) ? "provisioning" : "ready",
+        state: call < 7 ? "provisioning" : "ready",
       })),
     instances: (r, { attempt }) =>
       attempt < 8
@@ -1185,9 +1399,9 @@ test("maximal application and instance convergence stays within fixed 180s and 5
   assert.equal(limits.readinessRequests, 95);
   assert.equal(limits.applicationAttempts, 8);
   assert.equal(limits.applicationConvergenceMs, 60000);
-  assert.equal(r.applicationObservations.length, 18);
+  assert.equal(r.applicationObservations.length, 16);
   assert.equal(r.instanceObservations.length, 16);
-  assert.equal(r.keepWarm.metadataReads, 52);
+  assert.equal(r.keepWarm.metadataReads, 51);
   assert.equal(r.keepWarm.readinessRequests, 18);
 });
 test("ready application summary cannot hide immutable application identity drift", async () => {
@@ -1199,7 +1413,6 @@ test("ready application summary cannot hide immutable application identity drift
     (apps) => [{ ...apps[0], id: "unknown" }, apps[1]],
     (apps) => [{ ...apps[0], version: null }, apps[1]],
     (apps) => [{ ...apps[0], name: "foreign-feedapi" }, apps[1]],
-    (apps) => [...apps, apps[0]],
   ]) {
     const f = fixture("off", {
       applications: (apps) =>
@@ -1269,7 +1482,7 @@ test("ready summary and matching instances cannot hide a final process readiness
   const f = fixture("baseline", {
     applications: (apps) => apps.map((app) => ({ ...app, state: "ready" })),
     ready: (r, _call, { metadataCalls }) => {
-      if (metadataCalls === 6) r.containers[2].mode = "off";
+      if (metadataCalls === 7) r.containers[2].mode = "off";
       return r;
     },
   });
@@ -1277,7 +1490,7 @@ test("ready summary and matching instances cannot hide a final process readiness
     verifyDeployment(m, sha, image, "baseline", f.options),
     /container readiness differs/,
   );
-  assert.equal(f.count().metadataCalls, 6);
+  assert.equal(f.count().metadataCalls, 7);
 });
 test("bounded placement convergence preserves each actual snapshot and requires fresh process readiness", async () => {
   const f = fixture("off", {
@@ -1296,7 +1509,7 @@ test("bounded placement convergence preserves each actual snapshot and requires 
   });
   const r = await verifyDeployment(m, sha, image, "off", f.options);
   assert.equal(r.status, "passed");
-  assert.equal(r.keepWarm.metadataReads, 27);
+  assert.equal(r.keepWarm.metadataReads, 28);
   assert.equal(f.count().instanceCalls, 5);
   assert.ok(f.count().readyCalls >= 7);
   assert.deepEqual(
@@ -1495,14 +1708,14 @@ test("final application snapshot must retain exact application, image and versio
     });
     await assert.rejects(
       verifyDeployment(m, sha, image, "off", f.options),
-      /application changed during readback/,
+      /immutable application/,
     );
     assert.equal(f.count().instanceCalls, 2);
   }
 });
 test("fixed readback quotas cover both maximum attempt series without widening time or transport bounds", async () => {
   assert.equal(limits.durationMs, 180000);
-  assert.equal(limits.metadataReads, 23 + 14 + 14 + 1);
+  assert.equal(limits.metadataReads, 52);
   assert.equal(limits.readinessRequests, 95);
   assert.equal(limits.instanceAttempts, 8);
   assert.equal(limits.instanceConvergenceMs, 60000);
@@ -1524,7 +1737,7 @@ test("fixed readback quotas cover both maximum attempt series without widening t
   });
   const r = await verifyDeployment(m, sha, image, "off", f.options);
   assert.equal(r.instanceObservations.length, 16);
-  assert.equal(r.keepWarm.metadataReads, 38);
+  assert.equal(r.keepWarm.metadataReads, 39);
   assert.equal(r.keepWarm.readinessRequests, 18);
 });
 test("both runtime and adapter active deployments must stay fixed through readback", async () => {
@@ -1554,7 +1767,7 @@ test("same digest old off process and incompatible writer/epoch/profile are reje
       verifyDeployment(m, sha, image, "baseline", f.options),
       /container readiness differs/,
     );
-    assert.equal(f.count().metadataCalls, 0);
+    assert.equal(f.count().metadataCalls, 3);
   }
   const f = fixture();
   assert.throws(
@@ -1609,7 +1822,7 @@ test(
   "metadata longer than 10-second executor idle window receives bounded readiness and finally stops",
   { timeout: 15000 },
   async () => {
-    const f = fixture("off", { delay: 11000 });
+    const f = fixture("off", { delay: 11000, delayOn: "instances" });
     const r = await verifyDeployment(m, sha, image, "off", f.options);
     assert.ok(r.keepWarm.durationMs >= 11000);
     assert.ok(r.keepWarm.readinessRequests >= 6);
@@ -1654,7 +1867,7 @@ test("remote application size or image drift cannot be hidden by healthy fixed i
     const f = fixture("off", { appInfo });
     await assert.rejects(
       verifyDeployment(m, sha, image, "off", f.options),
-      /capacity\/image differs/,
+      /capacity\/image differs|application_image_changed/,
     );
   }
 });
@@ -1673,7 +1886,7 @@ test("actual async wiring is checked for off and baseline and retains only polic
   for (const mode of ["off", "baseline"]) {
     const f = fixture(mode),
       r = await verifyDeployment(m, sha, image, mode, f.options);
-    assert.equal(r.keepWarm.metadataReads, 24);
+    assert.equal(r.keepWarm.metadataReads, 25);
     assert.equal(r.asyncTriggers.verified, true);
     assert.equal(r.asyncTriggers.mode, mode);
     assert.deepEqual(

--- a/scripts/feed-production-application-snapshot.test.mjs
+++ b/scripts/feed-production-application-snapshot.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { captureProductionApplications } from './feed-platform-production.mjs';
+
+const manifest = JSON.parse(readFileSync(new URL('../ops/feed-production-manifest.json', import.meta.url)));
+const image = `registry.cloudflare.com/${manifest.accountId}/ghfind-feed@sha256:${'a'.repeat(64)}`;
+const names = ['feedapi', 'feedexecutor'].map(suffix => `${manifest.runtimeWorker}-${suffix}`);
+const ids = ['a03bde57-2e65-4185-a0ac-d95e13941703', 'a03818ef-42c6-48e4-8dd9-70225e7f6702'];
+function setup(change = {}) {
+  const listing = names.map((name, i) => ({ id: ids[i], name, version: 7, image: 'stale-dashboard-image', state: 'degraded' }));
+  const details = names.map((name, i) => ({ id: ids[i], name, version: 8, configuration: { image, env: { MUST_NOT_COPY: 'fixture-private-value' } }, health: { instances: { active: 0 } } }));
+  const calls = [];
+  const metadata = async (args, { signal }) => {
+    assert.ok(signal instanceof AbortSignal);
+    calls.push(args);
+    if (args[1] === 'list') return Object.hasOwn(change, 'listing') ? change.listing : listing;
+    assert.equal(args[1], 'info');
+    const i = ids.indexOf(args[2]);
+    assert.ok(i >= 0);
+    return change.detail ? change.detail(structuredClone(details[i]), i) : details[i];
+  };
+  return { metadata, calls, listing, details };
+}
+
+test('predeployment snapshot uses direct identities despite stale dashboard versions and health', async () => {
+  const f = setup();
+  const result = await captureProductionApplications(manifest, f);
+  assert.deepEqual(result, names.map((name, i) => ({ id: ids[i], name, version: 8, image })));
+  assert.equal(f.calls.length, 3);
+  assert.doesNotMatch(JSON.stringify(result), /MUST_NOT_COPY|fixture-private|health|stale/);
+});
+
+test('first install has no old-image permission and reads no nonexistent application', async () => {
+  const f = setup({ listing: [{ id: 'unrelated', name: 'another-project' }] });
+  assert.deepEqual(await captureProductionApplications(manifest, f), []);
+  assert.equal(f.calls.length, 1);
+});
+
+test('ambiguous or invalid discovery fails before detail requests', async () => {
+  const initial = setup();
+  for (const listing of [null, {}, [...initial.listing, initial.listing[0]], [{ name: names[0], id: '../bad' }], initial.listing.map(a => ({ ...a, id: ids[0] }))]) {
+    const f = setup({ listing });
+    await assert.rejects(captureProductionApplications(manifest, f));
+    assert.equal(f.calls.length, 1);
+  }
+});
+
+test('changed direct identity, invalid version or unpinned image cannot become a prior anchor', async () => {
+  for (const detail of [a => ({ ...a, id: ids[1] }), a => ({ ...a, name: 'unowned' }), a => ({ ...a, version: null }), a => ({ ...a, configuration: { image: 'some-registry/image:latest' } })]) {
+    await assert.rejects(captureProductionApplications(manifest, setup({ detail })));
+  }
+});
+
+test('a direct-read failure is terminal and never falls back to dashboard identity', async () => {
+  const f = setup();
+  const metadata = async (args, options) => {
+    if (args[1] === 'info') throw new Error('fixture metadata unavailable');
+    return f.metadata(args, options);
+  };
+  await assert.rejects(captureProductionApplications(manifest, { metadata }), /metadata unavailable/);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   // Worker packages own workerd-backed configs and must not run in Node's
   // default pool. CI invokes each package's required contract suite explicitly.
   test: {
-    exclude: ["**/node_modules/**", "**/.git/**", "platform/**", "scripts/feed-platform-*.test.mjs", "scripts/feed-operator.test.mjs", "scripts/feed-governance.test.mjs", "scripts/feed-snapshot*.test.mjs", "scripts/feed-ci-evidence.test.mjs", "scripts/check-cf-release-workflow.test.mjs", "scripts/feed-github-protection.test.mjs", "scripts/feed-e2e-remote.test.mjs", "scripts/feed-e2e/ack-loss.test.mjs", "scripts/feed-production-release.test.mjs", "scripts/feed-production-compatibility.test.mjs", "scripts/feed-production-pause.test.mjs", "scripts/feed-production-assessment.test.mjs", "scripts/feed-production-assessment-recovery.test.mjs"],
+    exclude: ["**/node_modules/**", "**/.git/**", "platform/**", "scripts/feed-platform-*.test.mjs", "scripts/feed-operator.test.mjs", "scripts/feed-governance.test.mjs", "scripts/feed-snapshot*.test.mjs", "scripts/feed-ci-evidence.test.mjs", "scripts/check-cf-release-workflow.test.mjs", "scripts/feed-github-protection.test.mjs", "scripts/feed-e2e-remote.test.mjs", "scripts/feed-e2e/ack-loss.test.mjs", "scripts/feed-production-release.test.mjs", "scripts/feed-production-compatibility.test.mjs", "scripts/feed-production-pause.test.mjs", "scripts/feed-production-assessment.test.mjs", "scripts/feed-production-assessment-recovery.test.mjs", "scripts/feed-production-application-snapshot.test.mjs"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem and resulting behavior

[Production 34362140952 attempt 1](https://github.com/hikariming/ghfind/actions/runs/34362140952/attempts/1), exact main `1d943588f3e1ec52018e752e2c697ec2b2dcadb8`, failed before its first Go readiness request. The off verifier used dashboard application summaries as its image/version source. At 14:18:31–14:18:58Z the API summary identified the target version 8 and image, but eight executor observations still identified the exact preceding version 7/image. The bounded prior-identity wait exhausted and correctly failed closed: 29.937 seconds, 14 metadata reads, zero readiness calls, no accepted instance evidence.

Root and the independent CF reviewer traced the blocker to the metadata source. Direct application GETs collected at 14:21:17Z identify both applications at version 8 with the requested digest. The newest rollout for each application also records target version 8, the same target image and completed rollout status. The executor direct record has updated_at 14:18:52Z, while the later failing dashboard observation still showed version 7. These are separately timed observations; they do not form an atomic snapshot or prove Go health. The direct health summaries report active count 0, and the failed release never reached readiness or instance checks. A completed rollout is not service acceptance.

This change reads application identity from direct `containers info` / application GET-by-ID for the predeployment snapshot, convergence observations and final identity verification. The collection listing is used only to discover the uniquely named application ID. Final acceptance continues to require the requested immutable image, a valid nonregressing application version, three actual running instances, exact Go source/mode/contracts, correct namespaces/capacities, queues/crons and final readiness. A stale, missing, malformed or drifting direct response still fails; dashboard metadata is not a fallback that can override it.

Branch `codex/feed-authoritative-application-readback`, final source `4f3cad5774380312ea817834ca7de75005c33fbc`, tree `0a06e335c84595b3c49319c5c1e354b5b2027719`. Full local dual-profile E2E passed before push; remote CI and release evidence will be appended below.

## Observed evidence and failure boundary

| Evidence | Facts and limitations |
|---|---|
| `production-attempt6/runtime-off.json` | `status=failed`, stage `application_identity_convergence`, exact source/digest, preceding version 7 snapshot, target API summary and eight old executor summaries; 180s/52 metadata/95 readiness limits remain unchanged |
| `startup-final-during-off.json`, 14:18:21Z | Legacy Web `3b4b74f8-1f99-4fcc-b590-19035711eed8` / aa8c683 remains 100%; runtime `2df65bfd-4eba-4d74-b7d9-7396f1669c5b` is off/source1d943588; adapter `97203f8d-9706-4e76-8d21-6e241b24dd86` has the same source |
| `authoritative-applications-observed-summary.json` | Nonsecret field-selected derivative with the source file hashes, the failure observations, both direct application identities and only each application's latest rollout; no historical rollout list or response-body dump |
| `startup-final-rollouts-after-failure.json` | Original local diagnostic remains the source for the derivative. It is not automatically placed in the durable archive allowlist |
| `production-attempt6-failed.log` | Original failure log remains local. Its existence is retained; raw logs are not copied into the archive without a separate content review |

All paths above are relative to `/tmp/ghfind-go-production-20260909/`. The root owns raw Actions evidence and eventual durable nonsecret artifact links. This run did not install the paused gateway, activate the legacy writer fence, start the real assessment, enable baseline consumers, run Go service smoke or cut over public Feed traffic. Existing D1 schema installation does not imply fence activation.

## Scope, ordered commits and compatibility

Base main after preserving concurrent article PR283: `bdd763f58eb6a78821d6ec3b7cdf38369417564d`. The change was initially based on `1d943588`; a clean rebase onto latest main passed a fresh complete dual-profile E2E before its updated push. Ordered commits:

1. `070a3728f64c8fe50850afde0b08f1dde14e7ea7` — capture direct application identities, wire each deployment snapshot, enforce its Node test in CI and exclude it from Vitest.
2. `fe42972d94f2df6483990036f930ec36135d11d1` — use direct application details for all convergence/final identity checks, preserve strict readiness/instance validation and the original request limits.
3. `4f3cad5774380312ea817834ca7de75005c33fbc` — fetch an unadvertised exact event.before commit after rebase before enforcing the existing release-version comparison.

Independent CF reviewer passed both scopes; an initially missing Vitest exclusion was caught and fixed before push. Root independently reviewed the final readback implementation. Merge through PR rebase or merge commit, never squash.

The intended scope is application metadata retrieval, the existing snapshot/CLI integration and their focused regression tests. Root serializes shared workflow integration, E2E, pushing, PR merge and all resource/release operations. Public Feed HTTP 1, storage writer 2, runtime control schema 7, installed Feed migration 12, D1 ownership and business behavior remain unchanged. No change to provider configuration, OAuth credentials, semantic activation, Container instance limits or task business rules is proposed.

Total readback limits remain 180 seconds, 52 metadata reads and 95 readiness requests. Direct lookups must count against the same metadata/deadline budget, including discovery, loop observations and final rereads; the separate predeployment snapshot is bounded to three metadata reads within 60 seconds; the change must not create an uncounted request path. Same-image version regression/unknown ordering, different-image prior snapshot validation and post-pin immutability remain enforced. Unknown/auth/identity readiness errors and heartbeat failures remain immediate failures.

## Acceptance before pushing this branch

| Required check | Evidence to append |
|---|---|
| Exact metadata-source regression | Dashboard summary stays at version 7 while the directly addressed application identifies target version 8. Discovery may find the ID, but snapshot/loop/final identity must use direct GET; wrong direct digest or version must reject regardless of the list summary |
| Discovery and identity boundaries | Duplicate/missing/wrong application IDs, name drift, malformed direct objects, unbounded pagination or a failed direct GET fail closed; a first deployment has no invented previous application |
| Version and final-state boundaries | Preserve the independent review counterexample: same-image snapshot8→current7 or string7 rejects; equal/valid forward versions behave correctly; once target is pinned, regression, image/namespace/capacity drift or final direct mismatch rejects |
| End-to-end gate remains strict | Direct target metadata alone does not pass. Explicit dependency-only initial retry, all three actual running instances and exact Go identities plus bindings/queues/crons/final readiness remain necessary |
| Request and diagnostic budgets | 180s/52 metadata/95 readiness bounds hold, including every direct GET; failures retain only allowlisted status/identity/code fields, never body/secrets |
| Exact final local validation | 80/80 focused Node tests passed, zero skips. Independent review passed. Clean-source full workerd D1/R2 and PostgreSQL/pgvector/MinIO E2E passed for source4f3cad5/tree0a06e33 at14:38:04–14:38:28Z, all eight milestones per profile and cleanup passed |

Local OAuth/provider transports must remain explicitly classified as fixtures. A previous source's E2E or successful direct metadata probe does not authorize this new source. Push only after the final exact-source full E2E; source changes or rebase/conflict fixes require a new applicable validation record.

Local commands/evidence:

```sh
node --test scripts/feed-platform-production.test.mjs scripts/feed-production-release.test.mjs scripts/feed-production-application-snapshot.test.mjs scripts/check-cf-release-workflow.test.mjs
python3 scripts/run-feed-e2e.py --release-sha 4f3cad5774380312ea817834ca7de75005c33fbc --directory /tmp/ghfind-go-production-e2e-authoritative-final-20260909 --execute
```

Local receipts: `/tmp/ghfind-go-production-20260909/authoritative-combined-tests.tap`, `/tmp/ghfind-go-production-e2e-authoritative-final-20260909/run.json`. A read-only CF execution of the new snapshot command also read both applications at version8/targetdigest; this proves metadata behavior, not Go runtime readiness. No public HTTP, storage, schema or runtime code contract changed.

## Remote delivery and handoff

Exact source push CI and artifact/checkout verifier: **[pending]**. Separate PR compatibility CI: **[pending]**. Postpush CF readback: **[pending]**. Rebase/merge actual main source/tree/ordered commits: **[pending]**. Independent exact-main CI/E2E and receipt: **[pending]**. All prior failures and the PR282 cleanup timeout/retry remain preserved.

The formal Actions pipeline publishes the new immutable digest, applies only approved compatible resource/schema operations, verifies off, captures the Go-only paused gateway and fences old writers, completes the one journaled real assessment and durable queue projection, passes bounded Go contracts, then opens Web/all and runs public smoke. This fix must produce its own successful off/baseline receipts, instance identities, queue settings, assessment/projection records and final Web/readback evidence; none are currently claimed. Local deployment is not the release path.

## Actual resources, cost and rollback

Requested image in the failed run:

`registry.cloudflare.com/8f19bebe359e4ec1a24c68c5f49c1584/ghfind-feed@sha256:5da2ace8260cc6aacddf7f8e0e9635a5c9967c54cca290ac68d84a7653dda2f1`

It belongs to the failed 1d943588 run, not this upcoming change. API app `a03bde57-2e65-4185-a0ac-d95e13941703`; executor app `a03818ef-42c6-48e4-8dd9-70225e7f6702`. Account `8f19bebe359e4ec1a24c68c5f49c1584`; core D1 `60d45096-bfe7-4de1-8b85-c1b66a466b0d`; Feed D1 `9c4ac13a-4c90-40a8-9d56-d7141f864bbf`; archive `ghfind-feed-production-archive`. Dedicated jobs/DLQ/parking queue identities remain in the pinned production manifest. Queue explicit false, retention and zero consumers were independently read at 13:47Z; the new run must reread actual settings.

API maximum two basic instances and executor maximum one are unchanged. No new persistent resource cost or extra provider request is proposed; metadata stays within existing budgets. The $79.69848 monthly planning scenario is still an estimate, not measured capacity/cost acceptance.

After Go writes, keep the database fence and use only the captured compatible Go-only paused Web through protected Actions, followed by actual readback. This returns Feed 503 for containment; it is not demonstrated availability recovery. Do not reopen legacy Next writers, reverse migrations, switch database environment variables or purge queues. An exact paused anchor has not yet been captured in these failed attempts.

Next owner: root release operator. Final handoff must separate successful Go traffic activation from the still-unaccepted original-plan performance/cold-start/cost, fault recovery, database migration/restore/RPO/RTO, full holder-OAuth Feed behavior, semantics and historical/Railway disposition. A successful metadata fix alone completes none of those stages.


### Concurrent main update preserved

Article PR283 merged independently at14:21:27Z as main `bdd763f58eb6a78821d6ec3b7cdf38369417564d`. Its automatic [production34363491794](https://github.com/hikariming/ghfind/actions/runs/34363491794) also failed under the old summary-based checker before readiness, assessment or cutover: preceding dashboard snapshot was stale and the observed intermediate image was rejected. This PR preserves all article content and fixes both the preceding snapshot and subsequent identity sources. Latest postpush CF readback remains Web legacy, runtime off/sourcebdd763f and adapter same source. The original branch E2E/CI is retained as superseded evidence; only final source4f3cad5 can qualify this PR.


### Rebase CI failure preserved and fixed

Push CI34364469156 failed its release-version comparison because the old `event.before=21e0f8c` was no longer on any advertised remote branch and checkout did not fetch it. Commit4f3cad5 fetches that exact base only if missing, then runs the unchanged comparison. An independent empty repository successfully fetched21e0f8c by SHA and verified its release manifest. The workflow contract tests passed again. Final exact-source full local E2E passed before the follow-up push; earlier intermediate E2Es/CI remain superseded evidence. No test assertion was removed.


### Final branch acceptance

Final source `4f3cad5774380312ea817834ca7de75005c33fbc`: [push CI34364975473](https://github.com/hikariming/ghfind/actions/runs/34364975473) and separate [PR CI34364982288](https://github.com/hikariming/ghfind/actions/runs/34364982288) each passed all five jobs. All application, dual storage, runtime build and complete local E2E gates passed. Postpush CF readback at14:42:39Z confirms Web remains legacy while runtime/adapter remain off/bdd763f; this branch has not been deployed yet. Earlier401 readbacks are retained as unverified; official Wrangler OAuth login restored only the Beiming account and a fresh read succeeded. No production resource was changed by local CLI.
